### PR TITLE
feat(pipeline): visibility gating + Obsidian Shell Commands integration

### DIFF
--- a/.github/workflows/generate-html.yml
+++ b/.github/workflows/generate-html.yml
@@ -37,7 +37,7 @@ jobs:
         run: python utilities/campaign_frame/generate_campaign_frame.py --out docs/campaign-frame.html
 
       - name: Generate world HTML + index
-        run: python utilities/legendkeeper-pipeline/generate_all_world_html.py
+        run: python utilities/legendkeeper-pipeline/generate_all_world_html.py --public
 
       - name: Commit generated files
         run: |

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
-  command   = "python utilities/dashboard/generate_dashboard.py && python utilities/campaign_frame/generate_campaign_frame.py && python utilities/legendkeeper-pipeline/generate_all_world_html.py"
+  command   = "python utilities/dashboard/generate_dashboard.py && python utilities/campaign_frame/generate_campaign_frame.py && python utilities/legendkeeper-pipeline/generate_all_world_html.py --public"
   publish   = "docs"

--- a/utilities/legendkeeper-pipeline/SOURCE_FORMAT.md
+++ b/utilities/legendkeeper-pipeline/SOURCE_FORMAT.md
@@ -5,7 +5,7 @@ type: operational
 visibility: public
 status: active
 created: 2026-03-16
-last_updated: 2026-03-16
+last_updated: 2026-03-17
 ---
 
 # LegendKeeper Pipeline — Source Format Specification
@@ -40,12 +40,14 @@ title: Document Title
 project: TTRPG_Tarim_Shaiel
 type: myth              # myth | lore | timeline
 tags: [myth]            # LK tag(s), list or string
-visibility: public      # public | gm_secrets
+visibility: public      # public | gm_secrets  (REQUIRED — omitting defaults to gm_secrets)
 status: draft           # draft | review | canon | deprecated
 created: YYYY-MM-DD
 last_updated: YYYY-MM-DD
 ---
 ```
+
+> **Visibility is fails-closed.** The pipeline only publishes documents that are **explicitly** tagged `visibility: public`. Any other value — `gm_secrets`, a typo, or a missing field — causes the document to be treated as GM-only and excluded from Netlify/CI deploys. Local runs (without `--public`) generate everything.
 
 ### Myth/Lore — Additional Optional Fields
 
@@ -233,10 +235,66 @@ Each `## Section` (except `Calendar Eras`) becomes a **lane** in the LK timeline
 
 ## Secret Content Handling
 
-| Content | LK Markdown | LK JSON | HTML |
-|---------|-------------|---------|------|
-| `%%...%%` blocks | Converted to LK Secret section | SECRET lane (timeline); stripped (myth, Phase 2) | Stripped entirely |
-| `visibility: gm_secrets` | No effect on content | No effect on content | File generated anyway; label added |
+### Document-level gating (`visibility:` frontmatter)
+
+| Value | Local run (no flag) | Netlify / CI (`--public` flag) |
+|-------|---------------------|-------------------------------|
+| `visibility: public` | ✅ Generated, **no GM badge** | ✅ Generated and deployed |
+| `visibility: gm_secrets` | ✅ Generated, **GM badge** shown | ❌ Skipped entirely — no HTML, not in index |
+| *(field missing)* | ✅ Generated, **GM badge** (fails-closed default) | ❌ Skipped entirely |
+| *(any other value)* | ✅ Generated, **GM badge** | ❌ Skipped entirely |
+
+**The allowlist is narrow by design.** Only an explicit `public` value passes. Everything else stays off the public deploy.
+
+---
+
+### Inline sub-document secrets — two patterns
+
+#### Pattern A: `%%...%%` blocks (standard)
+
+Use for small secrets tightly coupled to their context. Stripped from all HTML output.
+
+```markdown
+%%
+**GM note:** This event is secretly caused by the Wizard.
+%%
+```
+
+For timelines, secret events are wrapped in a `%% ## Secret ... %%` block:
+
+```markdown
+%%
+## Secret
+
+- "The Wizard Ascends" | date: 1448 | color: "#DC2626" | icon: hat-wizard
+%%
+```
+
+**Rules:**
+- `%%...%%` content is stripped from ALL generated HTML (public and local)
+- Use **bold text** (`**Label**`) for structural labels inside `%%...%%`, not `##` headings (headings inside `%%...%%` may appear in the Obsidian outline panel)
+- Block IDs inside `%%...%%` blocks may not be reliably reachable via Obsidian transclusion — use Pattern B if cross-document referencing is needed
+
+#### Pattern B: `-gm` companion file (for referenceable GM notes)
+
+Use when GM content needs to be authored separately, referenced across documents, or transcluded into other GM materials.
+
+```
+world/myths/the-roads-a-fable.md         (visibility: public)
+world/myths/the-roads-a-fable-gm.md      (visibility: gm_secrets)
+```
+
+- The public file contains NO inline secrets
+- The `-gm` companion is excluded from Netlify in `--public` mode (via `visibility: gm_secrets`)
+- Within Obsidian: `![[the-roads-a-fable-gm#^block-id]]` transclusion works normally
+- Locally: the companion generates its own HTML page for GM preview
+- **Naming convention:** `<public-stem>-gm.md` — sorts next to the public file
+
+#### LK output handling
+
+| Content | LK Markdown | LK JSON |
+|---------|-------------|---------|
+| `%%...%%` blocks | Converted to LK Secret section | SECRET lane (timeline); stripped (myth, Phase 2) |
 
 ---
 

--- a/utilities/legendkeeper-pipeline/generate_all_world_html.py
+++ b/utilities/legendkeeper-pipeline/generate_all_world_html.py
@@ -12,6 +12,12 @@ Usage:
     python generate_all_world_html.py
     python generate_all_world_html.py --vault /path/to/vault
     python generate_all_world_html.py --dry-run
+    python generate_all_world_html.py --public   # Netlify/CI: only visibility: public docs
+
+Visibility gating (--public, fails closed):
+    Only documents with EXPLICIT 'visibility: public' in frontmatter are generated
+    and listed in the index.  Missing, gm_secrets, or any other value → skipped.
+    Documents without a visibility tag default to 'gm_secrets' in metadata (safe side).
 """
 
 import re
@@ -76,8 +82,13 @@ def _slug(src: Path) -> str:
 
 # ── generation ────────────────────────────────────────────────────────────────
 
-def generate_all(vault: Path, docs: Path, dry_run: bool = False) -> list[dict]:
-    """Generate HTML for every discovered source. Returns list of doc metadata."""
+def generate_all(vault: Path, docs: Path, dry_run: bool = False, public_only: bool = False) -> list[dict]:
+    """Generate HTML for every discovered source. Returns list of doc metadata.
+
+    Args:
+        public_only: When True, only generate docs explicitly tagged
+                     visibility: public (fails closed — missing/other → skipped).
+    """
     sources = discover_sources(vault)
     generated = []
 
@@ -86,6 +97,14 @@ def generate_all(vault: Path, docs: Path, dry_run: bool = False) -> list[dict]:
         fm, body = parse_frontmatter(raw)
         doc_type = fm.get('type', '').lower()
         if doc_type not in PIPELINE_TYPES:
+            continue
+
+        # Visibility gate (fails closed): require explicit visibility: public.
+        # Default is 'gm_secrets' — untagged docs are treated as GM-only.
+        visibility = fm.get('visibility', 'gm_secrets')
+        if public_only and visibility != 'public':
+            rel = src.relative_to(vault)
+            print(f'  SKIP     {rel}  (not visibility: public)')
             continue
 
         slug     = _slug(src)
@@ -105,7 +124,7 @@ def generate_all(vault: Path, docs: Path, dry_run: bool = False) -> list[dict]:
         generated.append({
             'title':       fm.get('title') or slug.replace('-', ' ').title(),
             'type':        doc_type,
-            'visibility':  fm.get('visibility', 'public'),
+            'visibility':  visibility,   # 'gm_secrets' if untagged (safe default)
             'calendar':    fm.get('calendar', ''),
             'description': fm.get('description', ''),
             'filename':    f'{slug}.html',
@@ -320,15 +339,24 @@ def main() -> None:
     )
     parser.add_argument('--vault',   help='Vault root (default: auto-detected from script location)')
     parser.add_argument('--dry-run', action='store_true', help='Print what would run, do not write files')
+    parser.add_argument(
+        '--public', action='store_true',
+        help='Public-only mode: only generate/index docs with explicit visibility: public. '
+             'Use for Netlify/CI deployments. Fails closed — missing or gm_secrets → skipped.',
+    )
     args = parser.parse_args()
 
     vault = Path(args.vault) if args.vault else Path(__file__).parent.parent.parent
     docs  = vault / 'docs'
 
     print(f'Vault: {vault}')
+    if args.public:
+        print('Mode: PUBLIC (visibility: public only — fails closed)')
+    else:
+        print('Mode: LOCAL (all docs including gm_secrets)')
     print('Scanning for pipeline sources...')
 
-    generated = generate_all(vault, docs, dry_run=args.dry_run)
+    generated = generate_all(vault, docs, dry_run=args.dry_run, public_only=args.public)
     print(f'Generated {len(generated)} world document(s).')
 
     if not args.dry_run:

--- a/utilities/legendkeeper-pipeline/generate_world_html.py
+++ b/utilities/legendkeeper-pipeline/generate_world_html.py
@@ -12,6 +12,8 @@ Supports two document types:
 Usage:
     python generate_world_html.py source.md
     python generate_world_html.py source.md --output docs/my-doc.html
+    python generate_world_html.py source.md --public   # skip gm_secrets docs (fails closed)
+    python generate_world_html.py source.md --open     # open in browser after generating
 """
 
 import re
@@ -960,6 +962,9 @@ def _html_wrapper(
 # Entry point
 # ---------------------------------------------------------------------------
 
+PIPELINE_TYPES = {'timeline', 'myth', 'lore'}
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description='Generate Campaign Frame-style HTML from an Obsidian source file.'
@@ -968,6 +973,15 @@ def main() -> None:
     parser.add_argument(
         '--output', '-o',
         help='Output HTML path (default: docs/<source-stem>.html)',
+    )
+    parser.add_argument(
+        '--public', action='store_true',
+        help='Public-only mode: only generate docs explicitly tagged visibility: public. '
+             'Anything else (gm_secrets, untagged, typo) is skipped. Fails closed.',
+    )
+    parser.add_argument(
+        '--open', action='store_true',
+        help='Open generated HTML in the default browser after writing.',
     )
     args = parser.parse_args()
 
@@ -978,6 +992,19 @@ def main() -> None:
     raw = src.read_text(encoding='utf-8')
     fm, body = parse_frontmatter(raw)
     doc_type = fm.get('type', '').lower()
+
+    # Silent skip: not a pipeline source type — exit 0 without noise.
+    # Allows Shell Commands file-save event to fire on any .md without errors.
+    if doc_type not in PIPELINE_TYPES:
+        import sys
+        sys.exit(0)
+
+    # Visibility gate (fails closed): only generate if explicitly visibility: public.
+    # Missing tag, gm_secrets, or any other value → skip in public mode.
+    if args.public and fm.get('visibility') != 'public':
+        print(f'Skipped (not visibility: public): {src}')
+        import sys
+        sys.exit(0)
 
     if doc_type == 'timeline':
         html = render_timeline_html(fm, body)
@@ -996,8 +1023,13 @@ def main() -> None:
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(html, encoding='utf-8')
     print(f'HTML written: {out_path}')
-    print(f'  Type: {doc_type or "page (default)"}')
+    print(f'  Type: {doc_type}')
     print(f'  Title: {fm.get("title", "(no title)")}')
+    print(f'  Visibility: {fm.get("visibility", "(unset — treated as gm_secrets)")}')
+
+    if args.open:
+        import subprocess
+        subprocess.run(['open', str(out_path)])
 
 
 if __name__ == '__main__':

--- a/utilities/shell-commands-config.md
+++ b/utilities/shell-commands-config.md
@@ -1,0 +1,133 @@
+---
+title: Obsidian Shell Commands — Pipeline Setup
+project: TTRPG_Tarim_Shaiel
+type: operational
+visibility: public
+status: active
+created: 2026-03-17
+last_updated: 2026-03-17
+---
+
+# Obsidian Shell Commands — Pipeline Setup
+
+Configures the [Shell Commands](https://github.com/Tero-Laitinen/obsidian-shellcommands) community plugin to trigger the HTML generation pipeline from within Obsidian.
+
+**Install first:** Settings → Community plugins → Browse → search "Shell Commands" → Install → Enable.
+
+---
+
+## Commands to Configure
+
+Open Settings → Shell Commands → click **"+"** to add each command.
+
+---
+
+### Command 1 — Regenerate HTML Preview (file-save trigger)
+
+**Alias:** `Regenerate HTML Preview`
+
+**Command:**
+```bash
+python "{{vault_path}}/utilities/legendkeeper-pipeline/generate_world_html.py" --source "{{file_path:absolute}}" --open
+```
+
+**Behavior:**
+- Runs whenever you save a pipeline source file (`type: myth|lore|timeline`)
+- Generates `docs/<slug>.html` locally (no `--public` flag — full GM preview)
+- Opens the generated HTML in your default browser
+- Non-pipeline files (location notes, faction docs, etc.) **exit silently** — no output, no error
+- GM-only files (`visibility: gm_secrets`) generate locally — you can preview all content
+
+**Configure Events tab:**
+1. Under the command's **Events** tab → enable **"After saving a file"**
+2. Under **Folder restrictions** → restrict to `world` and `narrative` (prevents triggering on unrelated saves)
+
+**Configure Output tab:**
+- stdout → **Status bar** (brief success message)
+- stderr → **Notification** (shows errors prominently)
+
+---
+
+### Command 2 — Full Pipeline (Local)
+
+**Alias:** `Full Pipeline (Local)`
+
+**Command (macOS/Linux):**
+```bash
+cd "{{vault_path}}" && python utilities/dashboard/generate_dashboard.py --out docs/dashboard.html && python utilities/campaign_frame/generate_campaign_frame.py --out docs/campaign-frame.html && python utilities/legendkeeper-pipeline/generate_all_world_html.py && open docs/index.html
+```
+
+**Behavior:**
+- Runs all three generators: dashboard, campaign frame, world HTML + index
+- No `--public` flag — generates everything including GM-only docs for full local review
+- Opens `docs/index.html` in browser when complete
+
+**Configure Hotkey:** Assign `Cmd+Shift+B` (or your preference) via Settings → Hotkeys → search "Full Pipeline".
+
+**Configure Output tab:**
+- stdout → **Notification** ("Pipeline complete" summary)
+- stderr → **Notification**
+
+---
+
+### Command 3 — Open Local Preview (optional convenience)
+
+**Alias:** `Open Local Preview`
+
+**Command:**
+```bash
+open "{{vault_path}}/docs/{{file_name:stem}}.html"
+```
+
+**Behavior:**
+- Opens the already-generated HTML for the current file — does NOT regenerate
+- Use when you've already run Command 1 and just want to re-open the browser tab
+- Works reliably for kebab-case filenames (all existing world docs); may not resolve correctly for files with spaces or special characters
+
+---
+
+## Variable Reference
+
+These are Shell Commands plugin variables used above:
+
+| Variable | Value |
+|----------|-------|
+| `{{vault_path}}` | Absolute path to the Obsidian vault root (no trailing slash) |
+| `{{file_path:absolute}}` | Absolute path to the currently open file |
+| `{{file_name:stem}}` | Filename without extension (e.g. `nianhao-the-divine-arc`) |
+
+---
+
+## Visibility Gating Reminder
+
+Commands 1 and 2 run **without** `--public` — they generate ALL documents including `visibility: gm_secrets` files. This is intentional for local GM preview.
+
+The `--public` flag is only used by:
+- `netlify.toml` (Netlify deploys)
+- `.github/workflows/generate-html.yml` (GitHub Actions commits to `docs/`)
+
+**Never add `--public` to Shell Commands.** Local = full preview. Remote = public only.
+
+---
+
+## Troubleshooting
+
+**Command doesn't trigger on save:**
+- Verify the "After saving a file" event is enabled on the command
+- Check folder restrictions — ensure `world` and `narrative` are included
+- Confirm the file has `type: myth`, `type: lore`, or `type: timeline` in frontmatter
+
+**"HTML not found" when opening preview:**
+- Run Command 1 manually first to generate the file
+- Check `docs/` directory exists in vault root
+
+**Python not found:**
+- Ensure Python 3 is in your PATH: `which python3` in terminal
+- If needed, use full path: `/usr/bin/python3` or `/usr/local/bin/python3`
+- On macOS with Homebrew: `/opt/homebrew/bin/python3`
+
+**pyyaml not installed:**
+```bash
+pip install pyyaml
+```
+Without pyyaml, the generator falls back to a basic frontmatter parser — most cases work, but YAML lists and quoted values may parse differently.


### PR DESCRIPTION
- Add --public flag (fails closed) to generate_world_html.py and generate_all_world_html.py: only documents with explicit visibility: public are generated/indexed; missing tag, gm_secrets, or any other value → skipped. Protects against accidental GM content exposure from authoring mistakes.
- Add --open flag to generate_world_html.py: opens generated HTML in default browser after writing (used by Shell Commands on-save)
- Add silent-skip for non-pipeline files (type not in timeline|myth|lore): exits 0 without output, allowing Shell Commands file-save event to fire on any .md save without noise
- Wire --public into netlify.toml and GitHub Actions generate-html.yml
- Update SOURCE_FORMAT.md: fails-closed note in frontmatter section, full secret content handling table, Pattern A (%%...%%) and Pattern B (-gm companion file) documented with rules and tradeoffs
- Add utilities/shell-commands-config.md: setup reference for three Shell Commands plugin commands (on-save preview, full pipeline hotkey, open preview)