### PR TITLE
chore: remove stale effort line from TODO; rewrite utilities/README w…

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -338,8 +338,6 @@ without breaking existing Netlify, GitHub Actions, or Obsidian Shell Commands in
 - [x] Ancestry visibility gating: `visibility: gm_secrets` in per-ancestry frontmatter excludes from public HTML; GALAPA, RIBBET, FAERIE, NAGA-KIN gated; stub files created
 - [x] `.gitignore` fixed: `images/*` + `!images/people/ancestries/` so ancestry portraits are committable
 
-**Estimated effort:** Stage 4 only remaining — ~half session
-
 ---
 
 ### 4. Publishing Infrastructure Setup ✅ COMPLETE

--- a/utilities/README.md
+++ b/utilities/README.md
@@ -1,98 +1,174 @@
 ---
-title: Tarim-Shaiel Utilities
+title: Tarim-Shaiel Utilities — Publishing Pipeline
 project: TTRPG_Tarim_Shaiel
-type: utilities
+type: operational
+visibility: public
+status: active
 created: 2025-12-07
+last_updated: 2026-04-05
 ---
 
-# Tarim-Shaiel Utilities
+# Tarim-Shaiel Publishing Pipeline
 
-This directory contains utility scripts and tools for the Tarim-Shaiel TTRPG project.
+This directory contains all Python tooling for the Tarim-Shaiel HTML publishing pipeline. The single entry point is `build.py`. Generators read Markdown source from the vault, copy any referenced images to `docs/images/`, and write styled HTML to `docs/`. Content with `visibility: gm_secrets` in frontmatter is excluded from public builds.
 
 ---
 
-## mountain_range_generator.py
+## Pipeline Overview
 
-**Purpose:** Generates KML files with evenly-spaced mountain icons along ridge lines for fantasy mapping.
+```mermaid
+flowchart LR
+    subgraph Vault["Vault (source files)"]
+        direction TB
+        MD["Markdown\nworld/  narrative/\ntemplates/  TODO.md"]
+        ANCREC["world/ancestries/\n{ancestry}.md\n(visibility + image ref)"]
+        IMG["images/people/ancestries/\n*.png  ← committed to git"]
+        WORLDIMG["images/**\n*.png/jpg/webp\n(other world images)"]
+    end
 
-**Use Case:** Create Tolkien-style decorated mountain ranges on maps, where instead of a single point or line, you get a row of mountain icons distributed along the ridge crest.
+    subgraph Shared["utilities/shared/"]
+        direction TB
+        ASSETS["assets.py\nprepare_image()"]
+        SHELL["page_shell.py"]
+        RENDER["html_render.py"]
+        FM["frontmatter.py"]
+    end
 
-### Quick Start
+    BUILD["utilities/build.py\n─────────────────\nlist · all · name\n--public  --source"]
+
+    subgraph Generators
+        direction TB
+        DASH["dashboard"]
+        FRAME["campaign-frame"]
+        LORE["lore"]
+        ANC["ancestry"]
+        WORLD["world (single doc)"]
+        WALL["world-all (batch)"]
+    end
+
+    subgraph Output["docs/  (build artifacts)"]
+        direction TB
+        HTML["*.html\nworld/*.html\nindex.html"]
+        DIMG["images/\ncopied at build time\ngitignored"]
+    end
+
+    MD --> BUILD
+    ANCREC --> BUILD
+    IMG --> ASSETS
+    WORLDIMG --> ASSETS
+    BUILD --> Generators
+    Shared --> Generators
+    ASSETS --> DIMG
+    Generators --> HTML
+```
+
+---
+
+## Where Source Files Go
+
+| Asset type | Vault location | Convention |
+|---|---|---|
+| Ancestry portraits | `images/people/ancestries/` | **Committed to git.** Reference in `world/ancestries/{name}.md` as `![[FILENAME.png\|250]]` (filename only — no path). |
+| World / lore images | Anywhere under `images/` | **Not committed** (gitignored). Reference as `![[FILENAME.ext]]` in doc body. Generator copies to `docs/images/` at build time via `rglob()`. |
+| Per-ancestry metadata | `world/ancestries/{dh_name_lowercase}.md` | YAML frontmatter sets `visibility`. First `![[image.ext]]` in body becomes the floated figure. |
+| World / myth / lore docs | `world/`, `narrative/lore/`, `narrative/myth/`, etc. | Any `.md` with the correct `type:` frontmatter is a valid source. |
+
+`docs/images/` is **gitignored** — it is a build artifact directory recreated on every run.
+
+---
+
+## Running Generators
+
+### From the terminal
 
 ```bash
-cd /Users/mo/Documents/Games/HeroHeaven/utilities
-python3 mountain_range_generator.py
+# See all registered generators
+python utilities/build.py list
+
+# Run the full public pipeline (matches Netlify)
+python utilities/build.py all --public
+
+# Run full pipeline with GM content (local review)
+python utilities/build.py all
+
+# Single generator
+python utilities/build.py ancestry
+python utilities/build.py dashboard
+
+# Generators that need a source file
+python utilities/build.py lore --source "narrative/lore/The Roads.md"
+python utilities/build.py world --source world/cosmology/warrens.md
 ```
 
-This generates `mountain_ranges.kml` in the current directory with the five major ranges (Tian Shan, Kunlun, Pamir, Turkestan, Zarafshan).
+### From Obsidian (Shell Commands plugin)
 
-### Customization
+Three commands are pre-configured — see `utilities/shell-commands-config.md` for full installation and setup instructions.
 
-Edit the `ranges` list in the `if __name__ == "__main__":` section to define your own ranges:
+| Alias | Hotkey | What it does |
+|---|---|---|
+| **Regenerate HTML Preview** | Command palette (manual) | Regenerates HTML for the currently open file only. Includes GM content (no `--public`). |
+| **Full Pipeline (Local)** | `Cmd+Shift+B` | Runs dashboard + campaign-frame + world-all, then opens `docs/index.html` in browser. |
+| **Open Local Preview** | Command palette (manual) | Opens the already-generated HTML for the current file without regenerating. |
 
-```python
-ranges = [
-    {
-        'name': 'Your Range Name',
-        'start_lat': 40.0,          # Starting latitude
-        'start_lon': 70.0,          # Starting longitude
-        'end_lat': 42.0,            # Ending latitude
-        'end_lon': 75.0,            # Ending longitude
-        'spacing_km': 60,           # Distance between icons (km)
-        'style': 'mountain-peak'    # Style ID
-    }
-]
-```
-
-### Available Styles
-
-- `mountain-peak` - Brown/tan mountains (standard)
-- `high-peak` - White mountains (snow-capped, larger)
-- `sacred-peak` - Gold mountains (special/magical)
-
-### Programmatic Use
-
-You can also import the functions:
-
-```python
-from mountain_range_generator import generate_ridge_placemarks, generate_kml
-
-# Generate placemarks for a single range
-placemarks = generate_ridge_placemarks(
-    start_lat=40.0, start_lon=70.0,
-    end_lat=42.0, end_lon=75.0,
-    spacing_km=60,
-    name_prefix="My Mountains",
-    style="mountain-peak"
-)
-
-# Or generate a complete KML file
-ranges = [...]  # Your range definitions
-generate_kml(ranges, output_file="custom_mountains.kml")
-```
-
-### Icon Spacing
-
-The default spacing of 60km is calibrated for Google Earth at the scale of Central Asia. At this scale, mountain icons appear to be ~55-60km wide, so 60km spacing creates a continuous decorated ridge without overlap.
-
-Adjust `spacing_km` if working at different map scales:
-- Larger scale (zoomed in): Use smaller spacing (30-40km)
-- Smaller scale (zoomed out): Use larger spacing (80-100km)
-
-### Output Location
-
-Generated KML files can be imported directly into:
-- Google Earth (File → Import)
-- Google My Maps
-- Most GIS tools
-- Obsidian with Leaflet plugin
+> Local Shell Commands **never** use `--public` — local review shows all content including GM-only docs. `--public` is applied only by Netlify and GitHub Actions.
 
 ---
 
-## Future Utilities
+## Local vs. Online Generation
 
-Additional utilities to be added:
-- Trade route generator
-- City placement validator (minimum distances)
-- Region boundary generator
-- Fantasy name generator
+| | Local (terminal / Obsidian) | GitHub Actions | Netlify |
+|---|---|---|---|
+| **Trigger** | Manual — `build.py` or Shell Commands hotkey | Push to `main` (or manual dispatch from GitHub UI) | Push to `main` (auto-deploy) |
+| **Visibility** | All content (no `--public`) | `--public` only | `--public` only |
+| **Output** | `docs/` in your local vault | Committed back to `docs/` on `main` [skip ci] | Served from `docs/` at the Netlify deploy URL |
+| **Images** | Copied from vault `images/` at runtime | Copied from committed `images/people/ancestries/` | Same as GitHub Actions |
+| **Config** | `utilities/build.py` | `.github/workflows/generate-html.yml` | `netlify.toml` |
+
+**Netlify build command** (from `netlify.toml`):
+```bash
+python utilities/dashboard/generate_dashboard.py && \
+python utilities/campaign_frame/generate_campaign_frame.py && \
+python utilities/lore/generate_lore_html.py --source 'narrative/lore/The Roads.md' && \
+python utilities/ancestries/generate_ancestry_html.py && \
+python utilities/world/generate_all_world_html.py --public
+```
+
+---
+
+## Generator Reference
+
+| Name | Script | Default output | Notes |
+|---|---|---|---|
+| `dashboard` | `dashboard/generate_dashboard.py` | `docs/dashboard.html` | Reads `TODO.md` |
+| `campaign-frame` | `campaign_frame/generate_campaign_frame.py` | `docs/campaign-frame.html` | |
+| `lore` | `lore/generate_lore_html.py` | `docs/lore/` | Defaults to `narrative/lore/The Roads.md` |
+| `ancestry` | `ancestries/generate_ancestry_html.py` | `docs/peoples-of-tarim-shaiel.html` | Per-ancestry files supply visibility + portrait |
+| `world` | `world/generate_world_html.py` | `docs/world/` | Single doc; `--source` required |
+| `world-all` | `world/generate_all_world_html.py` | `docs/world/` + index | Batch all world docs |
+
+The **LegendKeeper pipeline** (`legendkeeper-pipeline/`) is a separate, standalone sub-pipeline. Entry point: `legendkeeper-pipeline/publish.py`.
+
+---
+
+## Shared Modules
+
+| Module | Purpose |
+|---|---|
+| `shared/assets.py` | `prepare_image()`, `prepare_audio_wiki()` — vault rglob → copy to `docs/images/` |
+| `shared/page_shell.py` | HTML page wrapper and navigation shell |
+| `shared/html_render.py` | `render_prose()` — Markdown → HTML including wiki-embed rendering |
+| `shared/frontmatter.py` | YAML frontmatter extraction with regex fallback |
+| `shared/config.py` | Shared path constants |
+| `shared/base_generator.py` | `Generator` Protocol (`name`, `description`, `run()`) |
+
+---
+
+## Visibility Gating
+
+Content gating is applied at the generator level:
+
+- **Ancestry generator**: `visibility: gm_secrets` in a per-ancestry file's YAML frontmatter → that ancestry is excluded from HTML output entirely.
+- **`world-all` generator**: `--public` flag → files with `visibility: gm_secrets` are skipped.
+- **Dashboard, campaign-frame, lore**: not yet gated (all content is public-safe).
+
+`--public` is always passed in Netlify and GitHub Actions builds. Local builds omit it so the GM can review everything.


### PR DESCRIPTION
…ith pipeline diagram

Removes leftover "Estimated effort: Stage 4 only remaining" line from the completed Python Toolset Refactor section of TODO.md.

Replaces the stale utilities/README.md (which only documented mountain_range_generator.py) with a full pipeline reference covering:
- Mermaid flowchart of vault → generators → docs/
- Where source files and images belong (local vs committed)
- How to run generators from terminal and Obsidian Shell Commands
- Local vs GitHub Actions vs Netlify generation (visibility/trigger differences)
- Generator reference table and shared module descriptions
- Visibility gating behaviour

https://claude.ai/code/session_013BQ1P8UnsoD22opNGxRBUF