### PR TITLE
infra: precision navigation pass on lat.md/ — section anchors + noise…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Read the relevant `lat.md/` file before diving into domain content — one read 
 |---|---|---|
 | Cosmological architecture, Warren, R/H/K, Held Breath | [[lat.md/cosmology]] | Any cosmology / Warren / Wizard question |
 | Session 0 design, awakenings, flashbacks, memory events | [[lat.md/session0]] | Session 0 work, pacing, scenario status |
-| Archetypes, tools system, surrendered-layer, identity | [[lat.md/characters]] | Archetype descriptions, tools-as-divine-marks |
+| Archetypes, tools system, surrendered-layer, identity | [[lat.md/characters]] | Archetype description constraints, tools-as-divine-marks, identity mechanics |
 | Locations, regions, factions, geography | [[lat.md/world]] | Any world / location / faction question |
 | Daggerheart integration, current mechanics, Wrongness | [[lat.md/mechanics]] | Rules questions, mechanical identity |
 | All locked decisions + hard constraints (summary) | [[lat.md/decisions]] | Verifying lock status before any design work |

--- a/lat.md/characters.md
+++ b/lat.md/characters.md
@@ -8,6 +8,8 @@ created: 2026-04-11
 last_updated: 2026-04-11
 ---
 
+> _Navigation layer — points to where answers live, not what they are. Follow specific links below. Avoid index files with Dataview queries and `transcripts/` — neither is a canonical source._
+
 # Characters
 
 ## Archetype Description Rule 🔒
@@ -66,7 +68,10 @@ last_updated: 2026-04-11
 
 ## Key Files
 - [[characters/archetypes.md]] — 6 core archetypes with thematic tensions
-- [[.meta/DECISION_LOG.md]] — Decision 10 (Surrendered-Layer), Decision 5 (R/H/K/tools)
+- [[.meta/DECISION_LOG.md]] § Player Pitch & Archetype Development (archetype one-liners + design philosophy) — Decision 10 (Surrendered-Layer), Decision 5 (R/H/K/tools)
 - [[mechanics/character-progression/TOOL_EVOLUTION_FRAMEWORK.md]] — 4-stage tool evolution (crude → legendary)
-- [[characters/Index.md]] — character frameworks index
 - [[world/ancestries/PEOPLES_OF_TARIM_SHAIEL.md]] — all 18 ancestries (player-facing)
+
+## Avoid
+- `characters/Index.md` — Dataview queries only; not Claude-readable
+- `transcripts/` — historical session logs; not canonical; constraints live in DECISION_LOG and archetypes.md

--- a/lat.md/cosmology.md
+++ b/lat.md/cosmology.md
@@ -8,6 +8,8 @@ created: 2026-04-11
 last_updated: 2026-04-11
 ---
 
+> _Navigation layer — points to where answers live, not what they are. Follow specific links below. Avoid index files with Dataview queries and `transcripts/` — neither is a canonical source._
+
 # Cosmology
 
 ## The Mythic Ecosystem 🔒
@@ -61,7 +63,8 @@ last_updated: 2026-04-11
 - Celestial Court nature ❓ — distributed will option most interesting; not yet decided
 
 ## Key Files
-- [[.meta/DECISION_LOG.md]] — Decisions 1–8 in full (sessions 2026-03-08 and 2026-03-17)
+- [[.meta/DECISION_LOG.md]] § Decision 6 (liberation framing), § Decisions 2&3 (Held Breath), § Decision 4 (Wizard) — Decisions 1–8 in full (sessions 2026-03-08 and 2026-03-17)
+- [[narrative/lore/liberation_aftermath.md]] — liberation prose (Warren beacon framing, 1,000-year aftermath)
 - [[world/mythology/]] — Cosmological lore for player-facing content
 - [[narrative/gm_secrets/]] — Held Breath details, Wizard layer, Divine Players
 - [[narrative/gm_secrets/DIVINE_PLAYERS.md]] — Seven divine players, alignment map

--- a/lat.md/decisions.md
+++ b/lat.md/decisions.md
@@ -8,6 +8,8 @@ created: 2026-04-11
 last_updated: 2026-04-11
 ---
 
+> _Navigation layer — points to where answers live, not what they are. Follow specific links below. Avoid index files with Dataview queries and `transcripts/` — neither is a canonical source._
+
 # Decisions
 
 _One-line summaries. Source of truth: [[.meta/DECISION_LOG.md]]_

--- a/lat.md/mechanics.md
+++ b/lat.md/mechanics.md
@@ -8,6 +8,8 @@ created: 2026-04-11
 last_updated: 2026-04-11
 ---
 
+> _Navigation layer — points to where answers live, not what they are. Follow specific links below. Avoid index files with Dataview queries and `transcripts/` — neither is a canonical source._
+
 # Mechanics
 
 ## Base System

--- a/lat.md/session0.md
+++ b/lat.md/session0.md
@@ -8,6 +8,8 @@ created: 2026-04-11
 last_updated: 2026-04-11
 ---
 
+> _Navigation layer — points to where answers live, not what they are. Follow specific links below. Avoid index files with Dataview queries and `transcripts/` — neither is a canonical source._
+
 # Session 0
 
 ## Core Architecture 🔒
@@ -72,8 +74,8 @@ last_updated: 2026-04-11
 - Cut to black before anyone speaks; session ends on realization, not explanation
 
 ## Key Files
-- [[narrative/sessions/00_session0/Sessions_Structure.md]] — full locked structure
+- [[narrative/sessions/00_session0/Sessions_Structure.md]] — full locked structure (§ Shared Memory Events Architecture for event details; § Flashback Triggering System for 4-axis triggers)
 - [[narrative/sessions/00_session0/Session_0_Introduction.md]] — opening framework text
 - [[narrative/sessions/00_session0/gm_secrets/]] — design notes, surrendered-layer framework
-- [[.meta/DECISION_LOG.md]] — Session 0 architecture entries (2026-01-08)
+- [[.meta/DECISION_LOG.md]] § Shared Memory Events Architecture — Session 0 architecture entries (2026-01-08)
 - [[narrative/Shared_Memory_Events.md]] — SME event stubs + CP distribution

--- a/lat.md/world.md
+++ b/lat.md/world.md
@@ -8,6 +8,8 @@ created: 2026-04-11
 last_updated: 2026-04-11
 ---
 
+> _Navigation layer — points to where answers live, not what they are. Follow specific links below. Avoid index files with Dataview queries and `transcripts/` — neither is a canonical source._
+
 # World
 
 ## Setting


### PR DESCRIPTION
… suppressors

- Add navigation callout header to all 6 lat.md/ files (points to answers, flags noise)
- Add section anchors: DECISION_LOG § Decision 6/2&3/4 in cosmology.md; § Shared Memory Events Architecture in session0.md; § Player Pitch & Archetype Development in characters.md
- Add liberation_aftermath.md to cosmology.md Key Files (explicit liberation prose pointer)
- Add Sessions_Structure.md section hints (§ Shared Memory Events, § Flashback Triggering)
- Add Avoid block to characters.md: characters/Index.md (Dataview) and transcripts/ (not canonical)
- Remove characters/Index.md from Key Files (superseded by Avoid block)
- Tighten CLAUDE.md Quick Nav characters entry: "Archetype description constraints, tools-as-divine-marks, identity mechanics"

Follow-up: run second baseline test against same 3 questions to verify cascade reduction.

https://claude.ai/code/session_01KUT6Xx9665utKTXUQmU9JB