### PR TITLE
infra: remove DECISION_LOG from nav chain; hard block in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,13 @@ This is a **design and authoring workspace**, not a software project. Files are 
 
 ---
 
+## Do not read — archives only
+- `.meta/DECISION_LOG.md` — human audit trail; all canonical content is already summarized in `lat.md/` files
+- `mechanics/design-decisions/DECISION_LOG.md` — same
+- `transcripts/` — historical session logs; no canonical content
+
+---
+
 ## Quick Navigation (AI-readable domain index)
 
 Read the relevant `lat.md/` file before diving into domain content — one read replaces 2–3 file searches.

--- a/lat.md/characters.md
+++ b/lat.md/characters.md
@@ -68,7 +68,6 @@ last_updated: 2026-04-11
 
 ## Only if the summary above doesn't answer it
 - [[characters/archetypes.md]] — 6 core archetypes with thematic tensions
-- [[.meta/DECISION_LOG.md]] § Player Pitch & Archetype Development (archetype one-liners + design philosophy)
 
 ## Do not read
 - `characters/Index.md` — Dataview queries only; not Claude-readable

--- a/lat.md/cosmology.md
+++ b/lat.md/cosmology.md
@@ -62,9 +62,6 @@ last_updated: 2026-04-11
 - Cosmic Conscription (Decision 11) ❓ — expulsion as punishment vs. deployment; unresolved, gates Celestial Court + full Wizard motivation
 - Celestial Court nature ❓ — distributed will option most interesting; not yet decided
 
-## Only if the summary above doesn't answer it
-- [[.meta/DECISION_LOG.md]] § Decision 6 (liberation framing), § Decisions 2&3 (Held Breath), § Decision 4 (Wizard)
-
 ## Do not read
 - `narrative/lore/liberation_aftermath.md` — liberation prose; framing is fully covered in the summary above; only read if prose specifically requested
 - `narrative/gm_secrets/MID_CAMPAIGN_CONVERGENCE_ARCHITECTURE.md` — deep CP architecture; only read if convergence point specifics requested

--- a/lat.md/decisions.md
+++ b/lat.md/decisions.md
@@ -12,7 +12,7 @@ last_updated: 2026-04-11
 
 # Decisions
 
-_One-line summaries. Source of truth: [[.meta/DECISION_LOG.md]]_
+_One-line summaries. Source of truth: `.meta/DECISION_LOG.md` (human archive — do not read autonomously)_
 
 ## Locked 🔒
 

--- a/lat.md/mechanics.md
+++ b/lat.md/mechanics.md
@@ -60,4 +60,3 @@ last_updated: 2026-04-11
 
 ## Only if the summary above doesn't answer it
 - [[mechanics/character-progression/TOOL_EVOLUTION_FRAMEWORK.md]] — tool evolution + tether mechanics
-- [[.meta/DECISION_LOG.md]] § Decisions 5, 10, 13 for mechanics context

--- a/lat.md/session0.md
+++ b/lat.md/session0.md
@@ -74,5 +74,4 @@ last_updated: 2026-04-11
 - Cut to black before anyone speaks; session ends on realization, not explanation
 
 ## Only if the summary above doesn't answer it
-- [[.meta/DECISION_LOG.md]] § Shared Memory Events Architecture — Session 0 architecture entries (2026-01-08)
 - [[narrative/Shared_Memory_Events.md]] — SME event stubs + CP distribution


### PR DESCRIPTION
- CLAUDE.md: add "Do not read — archives only" block before Quick Navigation; blocks .meta/DECISION_LOG.md, mechanics/design-decisions/DECISION_LOG.md, transcripts/
- lat.md/cosmology.md: remove "Only if" section entirely (DECISION_LOG was only entry; summary is complete)
- lat.md/session0.md: remove DECISION_LOG from "Only if"; keep Shared_Memory_Events.md
- lat.md/characters.md: remove DECISION_LOG from "Only if"; keep archetypes.md
- lat.md/mechanics.md: remove DECISION_LOG from "Only if"; keep TOOL_EVOLUTION_FRAMEWORK.md
- lat.md/decisions.md: de-wikilink DECISION_LOG source-of-truth reference; plain text only

Locked content is already inlined in lat.md summaries — nothing to backfill.

https://claude.ai/code/session_01KUT6Xx9665utKTXUQmU9JB