### PR TITLE
infra: lat.md/ AI navigation layer — precision passes + DECISION_LOG removal

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -23,6 +23,7 @@ banner-y: 37
 - 🔄 **Active work:** Session 0 scenarios (3/6 core done; expanded 4 have design framework only), STORY_ARC_SYNTHESIS.md needs update to reflect locked decisions, individual entity files to be created from indexes
 - ~~⚠️ **Blockers:** liberation_aftermath.md rewrite (Warren disturbance framing — see DECISION_LOG 2026-03-08)~~ ✅ **Resolved 2026-04-05** — v2.0 complete; Warren disturbance framing + 1,000-year timeline. [#106](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/106)
 - ✅ **Completed (2026-04-11):** `lat.md/` AI navigation layer — 6 dense, path-forward orientation files (`cosmology`, `session0`, `characters`, `world`, `mechanics`, `decisions`) + CLAUDE.md Quick Navigation table. [#121](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/121)
+- 🗒️ **Backlog added (2026-04-11):** CLAUDE.md audit + subagent context block — 5-pass baseline testing revealed subagents bypass CLAUDE.md entirely; need to identify portable behavioral constraints for spawned agents; audit-first before any slimming; risks documented. [#128](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/128)
 - 🗒️ **Backlog added (2026-04-07):** Nianhao D3 timeline phase 2 — content import, GM-tunable influence scores, cross-view interaction, mobile optimization, LK sync docs, click-through to event pages. [#116](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/116)
 - 🗒️ **Backlog added (2026-03-26):** Dashboard completion % from GitHub Issues — explore tying domain/section completion percentages to GitHub issue open/closed state (in addition to TODO.md checkbox counts). Requires GitHub API call during dashboard generation. Low priority; investigate after hook infrastructure ([#40](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/40)) is live.
 - 🗒️ **Backlog added (2026-03-21):** Template frontmatter reconciliation — `templates/world-building/` files use non-canonical fields (`type: concept`, `classification:` instead of `visibility:`, etc.); needs pass to align with CLAUDE.md spec
@@ -41,7 +42,15 @@ _What happened this session. Newest first. Trim to last 3 sessions; older entrie
 - Fixed `visibility: public` → `visibility: internal` on all 6 `lat.md/` files; added `internal` to CLAUDE.md frontmatter spec
 - Added session-init sentence to CLAUDE.md Working Conventions: "Then check the Quick Navigation table above and read any `lat.md/` files relevant to the session's domain before beginning work."
 - Logged `visibility: internal` schema extension in DECISION_LOG.md
-- **Pending (user-run):** Baseline test in fresh session — 3 domain questions with tool-use artifact tracking; evaluate routing efficiency before CLAUDE.md slimming pass. Test questions and artifact spec documented in session transcript.
+- Ran 5-pass baseline test (user-run parallel Explore agents, 3 domain questions each pass):
+  - Pass 1 (pre-lat.md/): Q1 1,480 lines / Q2 1,206 lines / Q3 1,423 lines
+  - Pass 2 (section anchors + noise suppressors): Q3 improved to 630 lines; Q2 regressed (liberation_aftermath.md added to Key Files)
+  - Pass 3 (Key Files renamed → "Only if"; list culled): Q3 regressed; identified listing = read invitation
+  - Pass 4 (stronger suppressors; Do not read blocks): Q3 515 lines (win); Q2 1,898 lines (worst pass — blocks not working)
+  - Pass 5 (DECISION_LOG removed from nav chain; CLAUDE.md hard block): Q3 515 lines (stable win); Q1/Q2 still noisy
+- Root cause identified: subagents bypass CLAUDE.md entirely; no instruction reaches them at spawn time
+- Decided: lat.md/ nav layer works when followed; problem is portability of constraints to spawned agents
+- Filed [#128](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/128): CLAUDE.md audit + subagent context block
 
 ### 2026-04-11
 - Explored lat.md (Agent Lattice) as an AI navigation pattern for the vault — `[[wikilinks]]` convention matches directly; identified key gap: vault has content graph but no curated AI-readable orientation layer


### PR DESCRIPTION
## Summary

Follow-on work from #121 (`lat.md/` navigation layer). Five-pass baseline test revealed what was working, what wasn't, and why — leading to a series of targeted improvements and one fundamental architectural finding.

## What changed

**Precision navigation pass (section anchors + noise suppressors)**
- Added section anchors on highest-traffic DECISION_LOG links (`§ Decision 6`, `§ Decisions 2&3`, `§ Decision 4`, `§ Shared Memory Events Architecture`, `§ Player Pitch & Archetype Development`)
- Added `## Avoid` blocks to characters.md (Dataview indexes, transcripts/) and world.md (both Index files)
- Tightened CLAUDE.md Quick Navigation "when to read" for characters

**Key Files → "Only if" rename + list culling**
- Renamed `## Key Files` → `## Only if the summary above doesn't answer it` across all 5 lat.md/ files with source sections
- Culled read invitations: cosmology.md 7→1 entries, session0.md 5→2, characters.md 4→2, world.md 5→1, mechanics.md 6→2
- Principle: listed = read invitation; every removed entry is a prevented cascade read

**Stronger suppressors + inline link removal**
- Strengthened callout header: "stop here if the summary answers your question"
- Renamed `## Avoid` → `## Do not read`; added cosmology.md Do not read block (liberation_aftermath.md, MID_CAMPAIGN_CONVERGENCE_ARCHITECTURE.md)
- Removed wikilink to Session_0_Awakening_Design_Notes.md from characters.md body (was pulling 609 lines × 2 per Q3)

**DECISION_LOG removed from navigation chain**
- Added `## Do not read — archives only` to CLAUDE.md before Quick Navigation: blocks both DECISION_LOG files and transcripts/
- Removed DECISION_LOG from all "Only if" sections (cosmology, session0, characters, mechanics)
- De-wikilinked DECISION_LOG source-of-truth reference in decisions.md

## Baseline test results (5 passes)

| Pass | Q1 lines | Q2 lines | Q3 lines | Notes |
|---|---|---|---|---|
| 1 (baseline) | 1,480 | 1,206 | 1,423 | Pre-lat.md/ |
| 2 | 1,055 | 1,287 | 630 | Section anchors; Q2 regressed (added liberation_aftermath.md to Key Files) |
| 3 | 1,231 | 1,286 | 1,552 | Key Files culled; Q3 regressed |
| 4 | 778 | 1,898 | 1,223 | Stronger suppressors; Q2 worst pass |
| 5 | 908 | 1,307 | 515 | DECISION_LOG removed; Q3 stable win |

## Key finding

Navigation layer suppressors only work when the agent follows lat.md/ navigation first. Spawned subagents start cold, use filesystem search, and bypass CLAUDE.md entirely — every "do not read" instruction is invisible to them.

Next work: #128 (CLAUDE.md audit + subagent context block) — identify portable behavioral constraints that travel explicitly into spawned agent prompts.