### PR TITLE
infra: post-#128 follow-ups — validation data + MCP tool preference

### DIFF
--- a/.meta/DECISION_LOG.md
+++ b/.meta/DECISION_LOG.md
@@ -472,6 +472,8 @@ Remaining ancestries (Human, Elf, Dwarf, Orc, Katari, Goblin, Halfling, Giant, G
 
 **Rationale:** The two-value schema (`public` / `gm_secrets`) had no category for files that are neither campaign content nor player-facing — purely operational files like the `lat.md/` navigation layer. Using `public` for those files was semantically wrong (implies player visibility) and potentially confusing for pipeline logic, even if functionally harmless (`type: navigation` is not in `PIPELINE_TYPES`).
 
+**Applied to:** `CLAUDE.md` frontmatter spec (visibility field), all `lat.md/*.md` files.
+
 ---
 
 ## Subagent Context Architecture — `lat.md/subagent-context.md`
@@ -502,6 +504,14 @@ Remaining ancestries (Human, Elf, Dwarf, Orc, Katari, Goblin, Halfling, Giant, G
 
 **Concurrent changes (same session):**
 - `mechanics/design-decisions/DECISION_LOG.md` → `.meta/MECHANICS_DESIGN_DECISION_LOG.md` (consolidate archive)
-- CLAUDE.md slimmed 258→174 lines (removed redundant/stale sections; fixed stale Wizard constraint)
+- CLAUDE.md slimmed 258→191 lines (removed redundant/stale sections; fixed stale Wizard constraint; restored cloud session + branch inflation as per-session operational content)
 
-**Applied to:** `CLAUDE.md` frontmatter spec (visibility field), all `lat.md/*.md` files.
+### Validation (2026-04-11)
+
+Post-implementation baseline test — 3 parallel Explore agents with `lat.md/subagent-context.md` as sole injected context:
+
+| Question | Baseline (Pass 1) | Post | Suppressor result |
+|---|---|---|---|
+| "What are the locked decisions?" | 908 lines / 9 inv | **59 lines / 1 file** | `.meta/` never opened ✅ |
+| "What happened in previous sessions?" | 1,307 lines / 6 inv | **282 lines / 4 files** | `transcripts/` never opened ✅ |
+| "Write a Warrior archetype description" | 1,423 lines / 9 inv | **198 lines / 2 files** | Routed via `lat.md/characters.md` first; constraints applied correctly ✅ |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,8 @@ Examples:
 
 **Branching:** Single `main` branch. All work goes directly to main.
 
+**Remote operations:** Prefer `mcp__github__*` tools (create/update files, create branches) over Bash git commands for anything touching the remote. Bash git is for local operations; MCP tools are more reliable for remote ones and sidestep push/413 issues entirely.
+
 **Cloud session exception:** When running through the Claude Code cloud harness (e.g. Claude.ai Base), the harness enforces a `claude/*` branch and blocks pushes to `main` with a 403. In that case:
 1. Commit to `main` locally as normal
 2. Push to the harness-designated branch (`git push origin main:<harness-branch>`)


### PR DESCRIPTION
Two small follow-ups from the #128 session:

- **`.meta/DECISION_LOG.md`** — appends baseline comparison table to the subagent context architecture entry (Q1: 908→59 lines, Q2: 1307→282 lines, Q3: 1423→198 lines). Validation data belongs in the human audit trail, not a closed PR.
- **`CLAUDE.md`** — adds one note to Git Workflow: prefer `mcp__github__*` tools for remote operations over Bash git. Learned the hard way via a 413 detour that could have been avoided entirely.

https://claude.ai/code/session_014wrRv2mxbstHMgenSbNDCw