### PR TITLE
fix: audio embed rendering in batch lore pipeline

### DIFF
--- a/utilities/shared/html_render.py
+++ b/utilities/shared/html_render.py
@@ -29,7 +29,8 @@ def render_wiki_embed(p: str) -> str:
         return ''
 
     path_part  = obs_m.group(1).strip()
-    alias_part = (obs_m.group(2) or '').strip()
+    # Obsidian allows multiple pipes: ![[file|alias|width]] — take first segment only
+    alias_part = (obs_m.group(2) or '').split('|')[0].strip()
     fname = Path(path_part).name
     ext   = Path(fname).suffix.lower()
 
@@ -149,6 +150,7 @@ def render_body(body: str, vault: 'Path', docs: 'Path') -> 'tuple[str, list[dict
     body = re.sub(r'(?<!!)\[\[([^\]|]+)\|([^\]]+)\]\]', r'\2', body)  # wikilinks w/ alias
     body = re.sub(r'(?<!!)\[\[([^\]]+)\]\]', r'\1', body)             # bare wikilinks
     body = re.sub(r'^>\s*\[!\w+\]\s*$', '', body, flags=re.MULTILINE) # callout markers
+    body = body.replace('\u200b', '')                                   # Obsidian zero-width spaces
     body = re.sub(r'\n{3,}', '\n\n', body)
     body = body.strip()
 

--- a/world/lore/The Roads.md
+++ b/world/lore/The Roads.md
@@ -17,7 +17,7 @@ banner-fade: -70
 ### Narrative Summary
 
 ![[narrative/audio/The Road_A Fable.mp3|The Road_A Fable|The Roads - A Fable]]
-​
+
 The roads were here before the empire.
 
 That is the thing people forget.


### PR DESCRIPTION
render_body() was not stripping Obsidian zero-width spaces (U+200B) before paragraph splitting, causing the ![[...]] embed line to merge with the ZWS artefact line and fail the render_wiki_embed regex match.

- Add U+200B stripping to render_body() preprocessing (render_prose already did this)
- Fix render_wiki_embed() to split on | and use first alias segment only, matching Obsidian's ![[file|alias|width]] multi-pipe convention
- Remove the ZWS artefact line from world/lore/The Roads.md