### PR TITLE
fix: render markdown tables, hr, and fix underscore italic

### DIFF
--- a/utilities/shared/html_render.py
+++ b/utilities/shared/html_render.py
@@ -117,6 +117,46 @@ def render_prose(body: str) -> str:
 
     return html
 
+def render_md_table(para: str) -> str:
+    """Render a markdown table paragraph block as an HTML <table>.
+
+    Expects a multi-line block where the first line is the header row,
+    the second line is the separator (|---|---| pattern), and subsequent
+    lines are data rows.  Returns an empty string if the block is not a
+    recognisable table.
+    """
+    lines = [l.strip() for l in para.splitlines() if l.strip()]
+    # Need at least header + separator
+    if len(lines) < 2:
+        return ''
+    if not (lines[0].startswith('|') and lines[1].startswith('|')):
+        return ''
+    # Second line must be a separator: |---|  |:---:| etc.
+    if not re.match(r'^\|[\s\-:|]+\|', lines[1]):
+        return ''
+
+    def _parse_cells(line: str) -> list[str]:
+        return [cell.strip() for cell in line.strip('|').split('|')]
+
+    header_cells = _parse_cells(lines[0])
+    # lines[1] is the separator — skip it
+    data_lines = lines[2:]
+
+    thead = (
+        '<thead><tr>'
+        + ''.join(f'<th>{inline_md(c)}</th>' for c in header_cells)
+        + '</tr></thead>'
+    )
+    tbody_rows = [
+        '<tr>' + ''.join(f'<td>{inline_md(c)}</td>' for c in _parse_cells(l)) + '</tr>'
+        for l in data_lines
+        if l.startswith('|')
+    ]
+    tbody = '<tbody>' + ''.join(tbody_rows) + '</tbody>'
+
+    return f'<div class="table-wrap"><table class="md-table">{thead}{tbody}</table></div>\n'
+
+
 def _slug_anchor(text: str) -> str:
     """Convert a header string to a URL-safe anchor id."""
     return re.sub(r'[^\w\-]+', '-', text.lower()).strip('-')
@@ -221,6 +261,17 @@ def render_body(body: str, vault: 'Path', docs: 'Path') -> 'tuple[str, list[dict
             text = para[4:].strip()
             anchor = _slug_anchor(text)
             html_parts.append(f'<h3 id="{anchor}">{inline_md(text)}</h3>\n')
+            continue
+
+        # Horizontal rule
+        if para in ('---', '***', '___'):
+            html_parts.append('<div class="divider"></div>\n')
+            continue
+
+        # Markdown table
+        tbl = render_md_table(para)
+        if tbl:
+            html_parts.append(tbl)
             continue
 
         # Callout

--- a/utilities/shared/md_utils.py
+++ b/utilities/shared/md_utils.py
@@ -18,7 +18,7 @@ def inline_md(text: str) -> str:
     text = re.sub(r'\*{3}(.+?)\*{3}', r'<strong><em>\1</em></strong>', text)
     text = re.sub(r'\*\*(.+?)\*\*', r'<strong>\1</strong>', text)
     text = re.sub(r'\*(.+?)\*', r'<em>\1</em>', text)
-    text = re.sub(r'_(.+?)_', r'<em>\1</em>', text)
+    text = re.sub(r'(?<!\w)_(.+?)_(?!\w)', r'<em>\1</em>', text)
     return text
 
 

--- a/utilities/world/generate_all_world_html.py
+++ b/utilities/world/generate_all_world_html.py
@@ -34,7 +34,7 @@ from generate_world_html import render_timeline_html, build_myth_html
 sys.path.insert(0, str(HERE.parent))   # makes utilities/shared importable
 from shared.assets import prepare_image, prepare_audio_wiki
 from shared.frontmatter import parse_frontmatter
-from shared.html_render import render_wiki_embed, inline_md as shared_inline_md, render_body as shared_render_body
+from shared.html_render import render_wiki_embed, inline_md as shared_inline_md, render_body as shared_render_body, render_md_table
 
 # ── discovery config ──────────────────────────────────────────────────────────
 PIPELINE_TYPES = {'timeline', 'myth', 'lore'}
@@ -99,7 +99,7 @@ def inline_md(text: str) -> str:
     text = re.sub(r'\*{3}(.+?)\*{3}', r'<strong><em>\1</em></strong>', text)
     text = re.sub(r'\*\*(.+?)\*\*', r'<strong>\1</strong>', text)
     text = re.sub(r'\*(.+?)\*', r'<em>\1</em>', text)
-    text = re.sub(r'_(.+?)_', r'<em>\1</em>', text)
+    text = re.sub(r'(?<!\w)_(.+?)_(?!\w)', r'<em>\1</em>', text)
     return text
 
 
@@ -200,7 +200,18 @@ def render_category_body(body: str, vault: Path, docs: Path) -> tuple[str, list[
         
         # Flush features if we hit non-feature content
         _flush_features()
-        
+
+        # Horizontal rule
+        if para in ('---', '***', '___'):
+            html_parts.append('<div class="divider"></div>\n')
+            continue
+
+        # Markdown table
+        tbl = render_md_table(para)
+        if tbl:
+            html_parts.append(tbl)
+            continue
+
         # Headers with jump nav anchors
         if para.startswith('## '):
             header_text = para[3:].strip()

--- a/utilities/world/world_base.css
+++ b/utilities/world/world_base.css
@@ -277,6 +277,43 @@
       border-top: 1px solid var(--rule); line-height: 1.4;
     }
 
+    /* --- Markdown tables --- */
+    .table-wrap {
+      overflow-x: auto;
+      margin: 1.2rem 0 1.4rem;
+    }
+    .md-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.9rem;
+      line-height: 1.5;
+    }
+    .md-table th {
+      font-family: 'Cinzel', serif;
+      font-size: 0.7rem;
+      font-weight: 600;
+      letter-spacing: 0.07em;
+      text-transform: uppercase;
+      color: var(--steel);
+      background: var(--parchment2);
+      padding: 0.55rem 0.7rem;
+      border-bottom: 2px solid var(--rule);
+      text-align: left;
+      white-space: nowrap;
+    }
+    .md-table td {
+      padding: 0.45rem 0.7rem;
+      border-bottom: 1px solid rgba(184,146,44,0.18);
+      vertical-align: top;
+    }
+    .md-table tr:last-child td { border-bottom: none; }
+    .md-table tr:hover td { background: rgba(184,146,44,0.06); }
+
+    @media (max-width: 640px) {
+      .md-table { font-size: 0.82rem; }
+      .md-table th, .md-table td { padding: 0.35rem 0.45rem; }
+    }
+
     /* --- Audio player --- */
     .audio-player {
       margin: 2.4rem 0; padding: 1.1rem 1.4rem 1.2rem;


### PR DESCRIPTION
## Changes

- **Markdown tables**: Added `render_md_table()` function to parse and render markdown tables as HTML `<table>` elements with proper `<thead>` and `<tbody>` structure
- **Horizontal rules**: Added support for rendering `---`, `***`, and `___` as styled divider elements
- **Underscore italic fix**: Fixed regex pattern in `inline_md()` to use negative word boundaries `(?<!\w)` and `(?!\w)`, preventing underscores within words from being converted to italics
- **Styling**: Added comprehensive CSS for tables with responsive design, hover effects, and typography matching the design system
- **Integration**: Applied changes to both shared rendering pipeline and world-specific rendering in `generate_all_world_html.py`