### PR TITLE
world: add class files with standardized frontmatter and structure

### DIFF
--- a/world/classes/Bard.md
+++ b/world/classes/Bard.md
@@ -1,0 +1,61 @@
+---
+title: Bard
+project: TTRPG_Tarim_Shaiel
+type: character_framework
+visibility: gm_secrets
+domains:
+  - grace
+  - codex
+sub-classes:
+  - troubador
+  - wordsmith
+status: canon
+created: 2026-04-14
+last_updated: 2026-04-14
+tags:
+  - daggerheart
+  - daggerheart-srd
+  - pc
+  - reference
+---
+Bards are the most charismatic people in all the realms. Members of this class are masters of captivation and specialize in a variety of performance types, including singing, playing musical instruments, weaving tales, or telling jokes. Whether performing for an audience or speaking to an individual, bards thrive in social situations. Members of this profession bond and train at schools or guilds, but a current of egotism runs through those of the bardic persuasion. While they may be the most likely class to bring people together, a bard of ill temper can just as easily tear a party apart.
+
+- **DOMAINS -** [Grace](Grace.md) & [Codex](Codex.md)
+- **STARTING EVASION -** 10
+- **STARTING HIT POINTS -** 5
+- **CLASS ITEMS -** A romance novel or a letter never opened
+
+---
+
+- **SUGGESTED TRAITS -** 0, -1, +1, 0, +2, +1
+- **SUGGESTED PRIMARY -** Rapier
+- **SUGGESTED SECONDARY -** Small Dagger
+- **SUGGESTED ARMOR -** Gambeson Armor
+
+### HOPE FEATURE
+
+**_Make a Scene:_** **Spend 3 Hope** to temporarily _Distract_ a target within Close range, giving them a -2 penalty to their Difficulty.
+
+### CLASS FEATURE
+
+**_Rally:_** Once per session, describe how you rally the party and give yourself and each of your allies a Rally Die. At level 1, your Rally Die is a **d6**. A PC can spend their Rally Die to roll it, adding the result to their action roll, reaction roll, damage roll, or to clear a number of Stress equal to the result. At the end of each session, clear all unspent Rally Dice. At level 5, your Rally Die increases to a **d8**.
+
+### SUBCLASSES
+
+Choose either the **[Troubadour](world/classes/subclasses/Troubadour.md)** or **[Wordsmith](world/classes/subclasses/Wordsmith.md)** subclass.
+
+### BACKGROUND QUESTIONS
+
+_Answer any of the following background questions. You can also create your own questions._
+
+- Who from your community taught you to have such confidence in yourself?
+- You were in love once. Who did you adore, and how did they hurt you?
+- You've always looked up to another bard. Who are they, and why do you idolize them?
+
+### CONNECTIONS
+
+_Ask your fellow players one of the following questions for their character to answer, or create your own questions._
+
+- What made you realize we were going to be such good friends?
+- What do I do that annoys you?
+- Why do you grab my hand at night?

--- a/world/classes/Druid.md
+++ b/world/classes/Druid.md
@@ -1,0 +1,114 @@
+---
+title: Druid
+project: TTRPG_Tarim_Shaiel
+type: character_framework
+visibility: gm_secrets
+domains:
+  - sage
+  - arcana
+sub-classes:
+  - warden-of-the-elements
+  - warden-of-renewal
+status: canon
+created: 2026-04-14
+last_updated: 2026-04-14
+tags:
+  - daggerheart
+  - daggerheart-srd
+  - pc
+  - reference
+---
+Becoming a druid is more than an occupation; it's a calling for those who wish to learn from and protect the magic of the wilderness. While one might underestimate a gentle druid who practices the often-quiet work of cultivating flora, druids who channel the untamed forces of nature are terrifying to behold. Druids cultivate their abilities in small groups, often connected by a specific ethos or locale, but some choose to work alone. Through years of study and dedication, druids can learn to transform into beasts and shape nature itself.
+
+- **DOMAINS -** [Sage](Sage.md) & [Arcana](Arcana.md)
+- **STARTING EVASION -** 10
+- **STARTING HIT POINTS -** 6
+- **CLASS ITEMS -** A small bag of rocks and bones or a strange pendant found in the dirt
+
+---
+
+- **SUGGESTED TRAITS -** +1, 0, +1, +2, -1, 0
+- **SUGGESTED PRIMARY -** Shortstaff
+- **SUGGESTED SECONDARY -** Round Shield
+- **SUGGESTED ARMOR -** Leather Armor
+
+### HOPE FEATURE
+
+**_Evolution:_** **Spend 3 Hope** to transform into a Beastform without marking a Stress. When you do, choose one trait to raise by +1 until you drop out of that Beastform.
+
+### CLASS FEATURES
+
+**_Beastform:_** Mark a Stress to magically transform into a creature of your tier or lower from the Beastform list. You can drop out of this form at any time. While transformed, you can't use weapons or cast spells from domain cards, but you can still use other features or abilities you have access to. Spells you cast before you transform stay active and last for their normal duration, and you can talk and communicate as normal. Additionally, you gain the Beastform's features, add their Evasion bonus to your Evasion, and use the trait specified in their statistics for your attack. While you're in a Beastform, your armor becomes part of your body and you mark Armor Slots as usual; when you drop out of a Beastform, those marked Armor Slots remain marked. If you mark your last Hit Point, you automatically drop out of this form.
+
+**_Wildtouch:_** You can perform harmless, subtle effects that involve nature—such as causing a flower to rapidly grow, summoning a slight gust of wind, or starting a campfire at will.
+
+### BEASTFORM OPTIONS
+
+When you use your "Beastform" feature, choose a creature category of your tier or lower. At the GM's discretion, you can describe yourself transforming into any animal that reasonably fits into that category.
+
+Beastform categories are divided by tier. Each entry includes the following details:
+
+- **Creature Category:** Each category's name describes the common role or behavior of creatures in that category (such as Agile Scout). This name is followed by a few examples of animals that fit in that category (in this example, fox, mouse, and weasel).
+- **Character Trait:** While transformed, you gain a bonus to the listed trait. For example, while transformed into an Agile Scout, you gain a +1 bonus to your Agility. When this form drops, you lose this bonus.
+- **Attack Rolls:** When you make an attack while transformed, you use the creature's listed range, trait, and damage dice, but you use your Proficiency. For example, as an Agile Scout, you can attack a target within Melee range using your Agility. On a success, you deal d4 physical damage using your Proficiency.
+- **Evasion:** While transformed, you add the creature's Evasion bonus to your normal Evasion. For example, if your Evasion is usually 8 and your Beastform says "Evasion +2," your Evasion becomes 10 while you're in that form.
+- **Advantage:** Your form makes you especially suited to certain actions. When you make an action or reaction roll related to one of the verbs listed for that creature category, you gain advantage on that roll. For example, an Agile Scout gains advantage on rolls made to sneak around, search for objects or creatures, and related activities.
+- **Features:** Each form includes unique features. For example, an Agile Scout excels at silent, dexterous movement--but they're also fragile, making you more likely to drop out of Beastform.
+
+### BEASTFORMS
+
+#### TIER 1
+
+- [Agile Scout](Agile%20Scout.md)
+- [Household Friend](Household%20Friend.md)
+- [Nimble Grazer](Nimble%20Grazer.md)
+- [Pack Predator](Pack%20Predator.md)
+- [Aquatic Scout](Aquatic%20Scout.md)
+- [Stalking Arachnid](Stalking%20Arachnid.md)
+
+#### TIER 2
+
+- [Armored Sentry](Armored%20Sentry.md)
+- [Powerful Beast](Powerful%20Beast.md)
+- [Mighty Strider](Mighty%20Strider.md)
+- [Striking Serpent](Striking%20Serpent.md)
+- [Pouncing Predator](Pouncing%20Predator.md)
+- [Winged Beast](Winged%20Beast.md)
+
+#### TIER 3
+
+- [Great Predator](Great%20Predator.md)
+- [Mighty Lizard](Mighty%20Lizard.md)
+- [Great Winged Beast](Great%20Winged%20Beast.md)
+- [Aquatic Predator](Aquatic%20Predator.md)
+- [Legendary Beast](Legendary%20Beast.md)
+- [Legendary Hybrid](Legendary%20Hybrid.md)
+
+#### TIER 4
+
+- [Massive Behemoth](Massive%20Behemoth.md)
+- [Terrible Lizard](Terrible%20Lizard.md)
+- [Mythic Aerial Hunter](Mythic%20Aerial%20Hunter.md)
+- [Epic Aquatic Beast](Epic%20Aquatic%20Beast.md)
+- [Mythic Beast](Mythic%20Beast.md)
+- [Mythic Hybrid](Mythic%20Hybrid.md)
+
+### SUBCLASSES
+
+Choose either the **[Warden of the Elements](world/classes/subclasses/Warden of the Elements.md)** or **[Warden of Renewal](world/classes/subclasses/Warden of Renewal.md)** subclass.
+
+### BACKGROUND QUESTIONS
+
+_Answer any of the following background questions. You can also create your own questions._
+
+- Why was the community you grew up in so reliant on nature and its creatures?
+- Who was the first wild animal you bonded with? Why did your bond end?
+- Who has been trying to hunt you down? What do they want from you?
+
+### CONNECTIONS
+
+_Ask your fellow players one of the following questions for their character to answer, or create your own questions._
+
+- What did you confide in me that makes me leap into danger for you every time?
+- What animal do I say you remind me of?
+- What affectionate nickname have you given me?

--- a/world/classes/Guardian.md
+++ b/world/classes/Guardian.md
@@ -1,0 +1,68 @@
+---
+title: Guardian
+project: TTRPG_Tarim_Shaiel
+type: character_framework
+visibility: gm_secrets
+domains:
+  - valor
+  - blade
+sub-classes:
+  - stalwart
+  - vengeance
+status: canon
+created: 2026-04-14
+last_updated: 2026-04-14
+tags:
+  - daggerheart
+  - daggerheart-srd
+  - pc
+  - reference
+---
+The title of guardian represents an array of martial professions, speaking more to their moral compass and unshakeable fortitude than the means by which they fight. While many guardians join groups of militants for either a country or cause, they're more likely to follow those few they truly care for, majority be damned. Guardians are known for fighting with remarkable ferocity even against overwhelming odds, defending their cohort above all else. Woe betide those who harm the ally of a guardian, as the guardian will answer this injury in kind.
+
+- **DOMAINS -** [Valor](Valor.md) & [Blade](Blade.md)
+- **STARTING EVASION -** 9
+- **STARTING HIT POINTS -** 7
+- **CLASS ITEMS -** A totem from your mentor or a secret key
+
+---
+
+- **SUGGESTED TRAITS -** +1, +2, -1, 0, +1, 0
+- **SUGGESTED PRIMARY -** Battleaxe
+- **SUGGESTED ARMOR -** Chainmail Armor
+
+### HOPE FEATURE
+
+**_Frontline Tank:_** **Spend 3 Hope** to clear 2 Armor Slots.
+
+### CLASS FEATURE
+
+**_Unstoppable:_** Once per long rest, you can become _Unstoppable._ You gain an Unstoppable Die. At level 1, your Unstoppable Die is a **d4.** Place it on your character sheet in the space provided, starting with the 1 value facing up. After you make a damage roll that deals 1 or more Hit Points to a target, increase the Unstoppable Die value by one. When the die's value would exceed its maximum value or when the scene ends, remove the die and drop out of _Unstoppable_. At level 5, your Unstoppable Die increases to a **d6.**
+
+While _Unstoppable_, you gain the following benefits:
+
+- You reduce the severity of physical damage by one threshold (Severe to Major, Major to Minor, Minor to None).
+- You add the current value of the Unstoppable Die to your damage roll.
+- You can't be _Restrained_ or _Vulnerable_.
+
+> _**Tip:** If your Unstoppable Die is a d4 and the 4 is currently facing up, you remove the die the next time you would increase it. However, if your Unstoppable Die has increased to a d6 and the 4 is currently facing up, you'll turn it to 5 the next time you would increase it. In this case, you'll remove the die after you would need to increase it higher than 6._
+
+### SUBCLASSES
+
+Choose either the **[Stalwart](world/classes/subclasses/Stalwart.md)** or **[Vengeance](world/classes/subclasses/Vengeance.md)** subclass.
+
+### BACKGROUND QUESTIONS
+
+_Answer any of the following background questions. You can also create your own questions._
+
+- Who from your community did you fail to protect, and why do you still think of them?
+- You've been tasked with protecting something important and delivering it somewhere dangerous. What is it, and where does it need to go?
+- You consider an aspect of yourself to be a weakness. What is it, and how has it affected you?
+
+### CONNECTIONS
+
+_Ask your fellow players one of the following questions for their character to answer, or create your own questions._
+
+- How did I save your life the first time we met?
+- What small gift did you give me that you notice I always carry with me?
+- What lie have you told me about yourself that I absolutely believe?

--- a/world/classes/Ranger.md
+++ b/world/classes/Ranger.md
@@ -1,0 +1,64 @@
+---
+title: Ranger
+project: TTRPG_Tarim_Shaiel
+type: character_framework
+visibility: gm_secrets
+domains:
+  - bone
+  - sage
+sub-classes:
+  - beastbound
+  - wayfinder
+status: canon
+created: 2026-04-14
+last_updated: 2026-04-14
+tags:
+  - daggerheart
+  - daggerheart-srd
+  - pc
+  - reference
+---
+Rangers are highly skilled hunters who, despite their martial abilities, rarely lend their skills to an army. Through mastery of the body and a deep understanding of the wilderness, rangers become sly tacticians, pursuing their quarry with cunning and patience. Many rangers track and fight alongside an animal companion with whom they've forged a powerful spiritual bond. By honing their skills in the wild, rangers become expert trackers, as likely to ensnare their foes in a trap as they are to assail them head-on.
+
+- **DOMAINS -** [Bone](Bone.md) & [Sage](Sage.md)
+- **STARTING EVASION -** 12
+- **STARTING HIT POINTS -** 6
+- **CLASS ITEMS -** A trophy from your first kill or a seemingly broken compass
+
+---
+
+- **SUGGESTED TRAITS -** +2, 0, +1, +1, -1, 0
+- **SUGGESTED PRIMARY -** Shortbow
+- **SUGGESTED ARMOR -** Leather Armor
+
+### HOPE FEATURE
+
+**_Hold Them Off:_** **Spend 3 Hope** when you succeed on an attack with a weapon to use that same roll against two additional adversaries within range of the attack.
+
+### CLASS FEATURE
+
+**_Ranger's Focus:_** **Spend a Hope** and make an attack against a target. On a success, deal your attack's normal damage and temporarily make the attack's target your _Focus_. Until this feature ends or you make a different creature your _Focus_, you gain the following benefits against your _Focus:_
+
+- You know precisely what direction they are in.
+- When you deal damage to them, they must mark a Stress.
+- When you fail an attack against them, you can end your Ranger's Focus feature to reroll your Duality Dice.
+
+### SUBCLASSES
+
+Choose either the **[Beastbound](world/classes/subclasses/Beastbound.md)** or **[Wayfinder](world/classes/subclasses/Wayfinder.md)** subclass.
+
+### BACKGROUND QUESTIONS
+
+_Answer any of the following background questions. You can also create your own questions._
+
+- A terrible creature hurt your community, and you've vowed to hunt them down. What are they, and what unique trail or sign do they leave behind?
+- Your first kill almost killed you, too. What was it, and what part of you was never the same after that event?
+- You've traveled many dangerous lands, but what is the one place you refuse to go?
+
+### CONNECTIONS
+
+_Ask your fellow players one of the following questions for their character to answer, or create your own questions._
+
+- What friendly competition do we have?
+- Why do you act differently when we're alone than when others are around?
+- What threat have you asked me to watch for, and why are you worried about it?

--- a/world/classes/Rogue.md
+++ b/world/classes/Rogue.md
@@ -1,0 +1,68 @@
+---
+title: Rogue
+project: TTRPG_Tarim_Shaiel
+type: character_framework
+visibility: gm_secrets
+domains:
+  - midnight
+  - grace
+sub-classes:
+  - nightwalker
+  - syndicate
+status: canon
+created: 2026-04-14
+last_updated: 2026-04-14
+tags:
+  - daggerheart
+  - daggerheart-srd
+  - pc
+  - reference
+---
+Rogues are scoundrels, often in both attitude and practice. Broadly known as liars and thieves, the best among this class move through the world anonymously. Utilizing their sharp wits and blades, rogues trick their foes through social manipulation as easily as breaking locks, climbing through windows, or dealing underhanded blows. These masters of magical craft manipulate shadow and movement, adding an array of useful and deadly tools to their repertoire. Rogues frequently establish guilds to meet future accomplices, hire out jobs, and hone secret skills, proving that there's honor among thieves for those who know where to look.
+
+- **DOMAINS -** [Midnight](Midnight.md) & [Grace](Grace.md)
+- **STARTING EVASION -** 12
+- **STARTING HIT POINTS -** 6
+- **CLASS ITEMS -** A set of forgery tools or a grappling hook
+
+---
+
+- **SUGGESTED TRAITS -** +1, -1, +2, 0, +1, 0
+- **SUGGESTED PRIMARY -** Dagger
+- **SUGGESTED SECONDARY -** Small Dagger
+- **SUGGESTED ARMOR -** Gambeson Armor
+
+### HOPE FEATURE
+
+**_Rogue's Dodge:_** **Spend 3 Hope** to gain a +2 bonus to your Evasion until the next time an attack succeeds against you. Otherwise, this bonus lasts until your next rest.
+
+### CLASS FEATURES
+
+**_Cloaked:_** Any time you would be _Hidden,_ you are instead _Cloaked._ In addition to the benefits of the _Hidden_ condition, while _Cloaked_ you remain unseen if you are stationary when an adversary moves to where they would normally see you. After you make an attack or end a move within line of sight of an adversary, you are no longer _Cloaked_.
+
+**_Sneak Attack:_** When you succeed on an attack while _Cloaked_ or while an ally is within Melee range of your target, add a number of **d6s** equal to your tier to your damage roll.
+
+- Level 1 → Tier 1
+- Levels 2-4 → Tier 2
+- Levels 5-7 → Tier 3
+- Levels 8-10 → Tier 4
+
+### SUBCLASSES
+
+Choose either the **[Nightwalker](world/classes/subclasses/Nightwalker.md)** or **[Syndicate](world/classes/subclasses/Syndicate.md)** subclass.
+
+### BACKGROUND QUESTIONS
+
+_Answer any of the following background questions. You can also create your own questions._
+
+- What did you get caught doing that got you exiled from your home community?
+- You used to have a different life, but you've tried to leave it behind. Who from your past is still chasing you?
+- Who from your past were you most sad to say goodbye to?
+
+### CONNECTIONS
+
+_Ask your fellow players one of the following questions for their character to answer, or create your own questions._
+
+- What did I recently convince you to do that got us both in trouble?
+- What have I discovered about your past that I hold secret from the others?
+- Who do you know from my past, and how have they influenced your feelings about me?

--- a/world/classes/Seraph.md
+++ b/world/classes/Seraph.md
@@ -1,0 +1,61 @@
+---
+title: Seraph
+project: TTRPG_Tarim_Shaiel
+type: character_framework
+visibility: gm_secrets
+domains:
+  - splendor
+  - valor
+sub-classes:
+  - divine-wielder
+  - winged-sentinel
+status: canon
+created: 2026-04-14
+last_updated: 2026-04-14
+tags:
+  - daggerheart
+  - daggerheart-srd
+  - pc
+  - reference
+---
+Seraphs are divine fighters and healers imbued with sacred purpose. A wide array of deities exist within the realms, and thus numerous kinds of seraphs are appointed by these gods. Their ethos traditionally aligns with the domain or goals of their god, such as defending the weak, exacting vengeance, protecting a land or artifact, or upholding a particular faith. Some seraphs ally themselves with an army or locale, much to the satisfaction of their rulers, but other crusaders fight in opposition to the follies of the Mortal Realm. It is better to be a seraph's ally than their enemy, as they are terrifying foes to those who defy their purpose.
+
+- **DOMAINS -** [Splendor](Splendor.md) & [Valor](Valor.md)
+- **STARTING EVASION -** 9
+- **STARTING HIT POINTS -** 7
+- **CLASS ITEMS -** A bundle of offerings or a sigil of your god
+
+---
+
+- **SUGGESTED TRAITS -** 0, +2, 0, +1, +1, -1
+- **SUGGESTED PRIMARY -** Hallowed Axe
+- **SUGGESTED SECONDARY -** Round Shield
+- **SUGGESTED ARMOR -** Chainmail Armor
+
+### HOPE FEATURE
+
+**_Life Support:_** **Spend 3 Hope** to clear a Hit Point on an ally within Close range.
+
+### CLASS FEATURE
+
+**_Prayer Dice:_** At the beginning of each session, roll a number of **d4s** equal to your subclass's Spellcast trait and place them on your character sheet in the space provided. These are your Prayer Dice. You can spend any number of Prayer Dice to aid yourself or an ally within Far range. You can use a spent die's value to reduce incoming damage, add to a roll's result after the roll is made, or gain Hope equal to the result. At the end of each session, clear all unspent Prayer Dice.
+
+### SUBCLASSES
+
+Choose either the **[Divine Wielder](world/classes/subclasses/Divine Wielder.md)** or **[Winged Sentinel](world/classes/subclasses/Winged Sentinel.md)** subclass.
+
+### BACKGROUND QUESTIONS
+
+_Answer any of the following background questions. You can also create your own questions._
+
+- Which god did you devote yourself to? What incredible feat did they perform for you in a moment of desperation?
+- How did your appearance change after taking your oath?
+- In what strange or unique way do you communicate with your god?
+
+### CONNECTIONS
+
+_Ask your fellow players one of the following questions for their character to answer, or create your own questions._
+
+- What promise did you make me agree to, should you die on the battlefield?
+- Why do you ask me so many questions about my god?
+- You've told me to protect one member of our party above all others, even yourself. Who are they and why?

--- a/world/classes/Sorcerer.md
+++ b/world/classes/Sorcerer.md
@@ -1,0 +1,67 @@
+---
+title: Sorcerer
+project: TTRPG_Tarim_Shaiel
+type: character_framework
+visibility: gm_secrets
+domains:
+  - arcana
+  - midnight
+sub-classes:
+  - elemental-origin
+  - primal-origin
+status: canon
+created: 2026-04-14
+last_updated: 2026-04-14
+tags:
+  - daggerheart
+  - daggerheart-srd
+  - pc
+  - reference
+---
+Not all innate magic users choose to hone their craft, but those who do can become powerful sorcerers. The gifts of these wielders are passed down through families, even if the family is unaware of or reluctant to practice them. A sorcerer's abilities can range from the elemental to the illusionary and beyond, and many practitioners band together into collectives based on their talents. The act of becoming a formidable sorcerer is not the practice of acquiring power, but learning to cultivate and control the power one already possesses. The magic of a misguided or undisciplined sorcerer is a dangerous force indeed.
+
+- **DOMAINS -** [Arcana](Arcana.md) & [Midnight](Midnight.md)
+- **STARTING EVASION -** 10
+- **STARTING HIT POINTS -** 6
+- **CLASS ITEMS -** A whispering orb or a family heirloom
+
+---
+
+- **SUGGESTED TRAITS -** 0, -1, +1, +2, +1, 0
+- **SUGGESTED PRIMARY -** Dualstaff
+- **SUGGESTED ARMOR -** Gambeson Armor
+
+### HOPE FEATURE
+
+**_Volatile Magic:_** **Spend 3 Hope** to reroll any number of your damage dice on an attack that deals magic damage.
+
+### CLASS FEATURES
+
+**_Arcane Sense:_** You can sense the presence of magical people and objects within Close range.
+
+**_Minor Illusion:_** Make a **Spellcast Roll (10).** On a success, you create a minor visual illusion no larger than yourself within Close range. This illusion is convincing to anyone at Close range or farther.
+
+**_Channel Raw Power:_** Once per long rest, you can place a domain card from your loadout into your vault and choose to either:
+
+- Gain Hope equal to the level of the card.
+- Enhance a spell that deals damage, gaining a bonus to your damage roll equal to twice the level of the card.
+
+### SUBCLASSES
+
+Choose either the **[Elemental Origin](world/classes/subclasses/Elemental Origin.md)** or **[Primal Origin](world/classes/subclasses/Primal Origin.md)** subclass.
+
+### BACKGROUND QUESTIONS
+
+_Answer any of the following background questions. You can also create your own questions._
+
+- What did you do that made the people in your community wary of you?
+- What mentor taught you to control your untamed magic, and why are they no longer able to guide you?
+- You have a deep fear you hide from everyone. What is it, and why does it scare you?
+
+### CONNECTIONS
+
+_Ask your fellow players one of the following questions for their character to answer, or create your own questions._
+
+- Why do you trust me so deeply?
+- What did I do that makes you cautious around me?
+- Why do we keep our shared past a secret?

--- a/world/classes/Warrior.md
+++ b/world/classes/Warrior.md
@@ -1,0 +1,66 @@
+---
+title: Warrior
+project: TTRPG_Tarim_Shaiel
+type: character_framework
+visibility: gm_secrets
+domains:
+  - blade
+  - bone
+sub-classes:
+  - call-of-the-brave
+  - call-of-the-slayer
+status: canon
+created: 2026-04-14
+last_updated: 2026-04-14
+tags:
+  - daggerheart
+  - daggerheart-srd
+  - pc
+  - reference
+---
+Becoming a warrior requires years, often a lifetime, of training and dedication to the mastery of weapons and violence. While many who seek to fight hone only their strength, warriors understand the importance of an agile body and mind, making them some of the most sought-after fighters across the realms. Frequently, warriors find employment within an army, a band of mercenaries, or even a royal guard, but their potential is wasted in any position where they cannot continue to improve and expand their skills. Warriors are known to have a favored weapon; to come between them and their blade would be a grievous mistake.
+
+- **DOMAINS -** [Blade](Blade.md) & [Bone](Bone.md)
+- **STARTING EVASION -** 11
+- **STARTING HIT POINTS -** 6
+- **CLASS ITEMS -** The drawing of a lover or a sharpening stone
+
+---
+
+- **SUGGESTED TRAITS -** +2, +1, 0, +1, -1, 0
+- **SUGGESTED PRIMARY -** Longsword
+- **SUGGESTED ARMOR -** Chainmail Armor
+
+### HOPE FEATURE
+
+**_No Mercy:_** **Spend 3 Hope** to gain a +1 bonus to your attack rolls until your next rest.
+
+### CLASS FEATURES
+
+**_Attack of Opportunity:_** If an adversary within Melee range attempts to leave that range, make a reaction roll using a trait of your choice against their Difficulty. Choose one effect on a success, or two if you critically succeed:
+
+- They can't move from where they are.
+- You deal damage to them equal to your primary weapon's damage.
+- You move with them.
+
+**_Combat Training:_** You ignore burden when equipping weapons. When you deal physical damage, you gain a bonus to your damage roll equal to your level.
+
+### SUBCLASSES
+
+Choose either the **[Call of the Brave](world/classes/subclasses/Call of the Brave.md)** or **[Call of the Slayer](world/classes/subclasses/Call of the Slayer.md)** subclass.
+
+### BACKGROUND QUESTIONS
+
+_Answer any of the following background questions. You can also create your own questions._
+
+- Who taught you to fight, and why did they stay behind when you left home?
+- Somebody defeated you in battle years ago and left you to die. Who was it, and how did they betray you?
+- What legendary place have you always wanted to visit, and why is it so special?
+
+### CONNECTIONS
+
+_Ask your fellow players one of the following questions for their character to answer, or create your own questions._
+
+- We knew each other long before this party came together. How?
+- What mundane task do you usually help me with off the battlefield?
+- What fear am I helping you overcome?

--- a/world/classes/Wizard.md
+++ b/world/classes/Wizard.md
@@ -1,0 +1,64 @@
+---
+title: Wizard
+project: TTRPG_Tarim_Shaiel
+type: character_framework
+visibility: gm_secrets
+domains:
+  - codex
+  - splendor
+sub-classes:
+  - school-of-knowledge
+  - school-of-war
+status: canon
+created: 2026-04-14
+last_updated: 2026-04-14
+tags:
+  - daggerheart
+  - daggerheart-srd
+  - pc
+  - reference
+---
+Whether through an institution or individual study, those known as wizards acquire and hone immense magical power over years of learning using a variety of tools, including books, stones, potions, and herbs. Some wizards dedicate their lives to mastering a particular school of magic, while others learn from a wide variety of disciplines. Many wizards become wise and powerful figures in their communities, advising rulers, providing medicines and healing, and even leading war councils. While these mages all work toward the common goal of collecting magical knowledge, wizards often have the most conflict within their own ranks, as the acquisition, keeping, and sharing of powerful secrets is a topic of intense debate that has resulted in innumerable deaths.
+
+- **DOMAINS -** [Codex](Codex.md) & [Splendor](Splendor.md)
+- **STARTING EVASION -** 11
+- **STARTING HIT POINTS -** 5
+- **CLASS ITEMS -** A book you're trying to translate or a tiny, harmless elemental pet
+
+---
+
+- **SUGGESTED TRAITS -** -1, 0, 0, +1, +1, +2
+- **SUGGESTED PRIMARY -** Greatstaff
+- **SUGGESTED ARMOR -** Leather Armor
+
+### HOPE FEATURE
+
+**_Not This Time:_** **Spend 3 Hope** to force an adversary within Far range to reroll an attack or damage roll.
+
+### CLASS FEATURES
+
+**_Prestidigitation:_** You can perform harmless, subtle magical effects at will. For example, you can change an object's color, create a smell, light a candle, cause a tiny object to float, illuminate a room, or repair a small object.
+
+**_Strange Patterns:_** Choose a number between 1 and 12. When you roll that number on a Duality Die, gain a Hope or clear a Stress.
+
+You can change this number when you take a long rest.
+
+### SUBCLASSES
+
+Choose either the **[School of Knowledge](world/classes/subclasses/School of Knowledge.md)** or **[School of War](world/classes/subclasses/School of War.md)** subclass.
+
+### BACKGROUND QUESTIONS
+
+_Answer any of the following background questions. You can also create your own questions._
+
+- What responsibilities did your community once count on you for? How did you let them down?
+- You've spent your life searching for a book or object of great significance. What is it, and why is it so important to you?
+- You have a powerful rival. Who are they, and why are you so determined to defeat them?
+
+### CONNECTIONS
+
+_Ask your fellow players one of the following questions for their character to answer, or create your own questions._
+
+- What favor have I asked of you that you're not sure you can fulfill?
+- What weird hobby or strange fascination do we both share?
+- What secret about yourself have you entrusted only to me?

--- a/world/classes/_category.md
+++ b/world/classes/_category.md
@@ -1,0 +1,20 @@
+---
+title: Character Classes
+description: Class descriptions for Tarim Shaiel
+published: true
+banner_left: TARIM-SHAIEL * Character Creation
+banner_right: Classes
+jump_nav: false
+---
+## Player Classes
+
+Players in the world Tarim-Shaiel have choices as to how they express themselves. One of the more direct and methods is by choosing a character path, oftewn described as "classes".
+
+> **Note for Players:** This section collects list of available class definitions as they are expressed in the base Daggerheart game (with, perhaps, a few surprises)...
+
+### Clarifying Questions
+
+Consider:
+- How does your character present themselves?
+- What kinds of heroic actions do you see them performing?
+- What does a class mean to you and ?

--- a/world/classes/subclasses/Beastbound.md
+++ b/world/classes/subclasses/Beastbound.md
@@ -1,0 +1,81 @@
+# Beastbound
+
+Play the Beastbound if you want to form a deep bond with an animal ally.
+
+### SPELLCAST TRAIT
+
+Agility
+
+### FOUNDATION FEATURE
+
+**_Companion:_** You have an animal companion of your choice (at the GM's discretion). They stay by your side unless you tell them otherwise.
+
+Take the Ranger Companion sheet. When you level up your character, choose a level-up option for your companion from this sheet as well.
+
+### SPECIALIZATION FEATURES
+
+**_Expert Training:_** Choose an additional level-up option for your companion.
+
+**_Battle-Bonded:_** When an adversary attacks you while they're within your companion's Melee range, you gain a +2 bonus to your Evasion against the attack.
+
+### MASTERY FEATURES
+
+**_Advanced Training:_** Choose two additional level-up options for your companion.
+
+**_Loyal Friend:_** Once per long rest, when the damage from an attack would mark your companion's last Stress or your last Hit Point and you're within Close range of each other, you or your companion can rush to the other's side and take that damage instead.
+
+### RANGER COMPANION
+
+When you choose the Beastbound Ranger subclass, take a companion sheet. This sheet is for tracking important information about your character's companion and can be tucked beneath the right side of your character sheet for ease of viewing.
+
+##### STEP 1: NAME YOUR COMPANION
+
+Work with the GM to decide what kind of animal you have as your companion. Give them a name and add a picture of them to the companion sheet.
+
+##### STEP 2: WRITE THEIR EVASION
+
+Fill in their Evasion, which starts at 10.
+
+##### STEP 3: CHOOSE THEIR COMPANION EXPERIENCE
+
+Create two Experiences for your companion based on their training and the history you have together.
+
+Start with +2 in both Experiences. Whenever you gain a new Experience, your companion also gains one. All new Experiences start at +2.
+
+> **Example Companion Experiences**
+>
+> _Bold Distraction, Expert Climber, Fetch, Friendly, Guardian of the Forest, Horrifying, Intimidating, Loyal Until the End, Navigation, Nimble, Nobody Left Behind, On High Alert, Protective, Royal Companion, Scout, Service Animal, Trusted Mount, Vigilant, We Always Find Them, You Can't Hit What You Can't Find_
+
+##### STEP 4: CHOOSE THEIR ATTACK AND RECORD DAMAGE DIE
+
+Finally, describe your companion's method of dealing damage (their standard attack) and record it in the "Attack & Damage" section. At level 1, your companion's damage die is a d6 and their range is Melee. Choose whether they deal physical or magic damage.
+
+#### WORKING WITH YOUR COMPANION
+
+The following sections will run you through the basics of working with your companion.
+
+##### USING SPELLCAST ROLLS, HOPE, AND EXPERIENCES
+
+Make a Spellcast Roll to connect with your companion and command them to take action. Spend a Hope to add an applicable Companion Experience to the roll. On a success with Hope, if your next action builds on their success, you gain advantage on the roll.
+
+##### ATTACKING WITH YOUR COMPANION
+
+When you command your companion to attack, they gain any benefits that would normally only apply to you (such as the effects of "Ranger's Focus"). On a success, their damage roll uses your Proficiency and their damage die.
+
+##### TAKING DAMAGE AS STRESS
+
+- When your companion would take any amount of damage, they mark a Stress. When they mark their last Stress, they drop out of the scene (by hiding, fleeing, or a similar action). They remain unavailable until the start of your next long rest, where they return with 1 Stress cleared.
+- When you choose a downtime move that clears Stress on yourself, your companion clears an equal number of Stress.
+
+#### LEVELING UP YOUR COMPANION
+
+When your character levels up, choose one available option for your companion from the following list and mark it on your sheet:
+
+- _Intelligent:_ Your companion gains a permanent +1 bonus to a Companion Experience of your choice.
+- _Light in the Dark:_ Use this as an additional Hope slot your character can mark.
+- _Creature Comfort:_ Once per rest, when you take time during a quiet moment to give your companion love and attention, you can gain a Hope or you can both clear a Stress.
+- _Armored:_ When your companion takes damage, you can **mark one of your Armor Slots** instead of marking one of their Stress.
+- _Vicious:_ Increase your companion's damage dice or range by one step (d6 to d8, Close to Far, etc.).
+- _Resilient:_ Your companion gains an additional Stress slot.
+- _Bonded:_ When you mark your last Hit Point, your companion rushes to your side to comfort you. Roll a number of **d6s** equal to the unmarked Stress slots they have and mark them. If any roll a 6, your companion helps you up. Clear your last Hit Point and return to the scene.
+- _Aware:_ Your companion gains a permanent +2 bonus to their Evasion.

--- a/world/classes/subclasses/Call of the Brave.md
+++ b/world/classes/subclasses/Call of the Brave.md
@@ -1,0 +1,17 @@
+# Call of the Brave
+
+Play the Call of the Brave if you want to use the might of your enemies to fuel your own power.
+
+### FOUNDATION FEATURES
+
+**_Courage:_** When you fail a roll with Fear, you gain a Hope.
+
+**_Battle Ritual:_** Once per long rest, before you attempt something incredibly dangerous or face off against a foe who clearly outmatches you, describe what ritual you perform or preparations you make. When you do, clear 2 Stress and gain 2 Hope.
+
+### SPECIALIZATION FEATURE
+
+**_Rise to the Challenge:_** You are vigilant in the face of mounting danger. While you have 2 or fewer Hit Points unmarked, you can roll a **d20** as your Hope Die.
+
+### MASTERY FEATURE
+
+**_Camaraderie:_** Your unwavering bravery is a rallying point for your allies. You can initiate a Tag Team Roll one additional time per session. Additionally, when an ally initiates a Tag Team Roll with you, they only need to spend 2 Hope to do so.

--- a/world/classes/subclasses/Call of the Slayer.md
+++ b/world/classes/subclasses/Call of the Slayer.md
@@ -1,0 +1,15 @@
+# Call of the Slayer
+
+Play the Call of the Slayer if you want to strike down adversaries with immense force.
+
+### FOUNDATION FEATURE
+
+**_Slayer:_** You gain a pool of dice called Slayer Dice. On a roll with Hope, you can place a **d6** on this card instead of gaining a Hope, adding the die to the pool. You can store a number of Slayer Dice equal to your Proficiency. When you make an attack roll or damage roll, you can spend any number of these Slayer Dice, rolling them and adding their result to the roll. At the end of each session, clear any unspent Slayer Dice on this card and gain a Hope per die cleared.
+
+### SPECIALIZATION FEATURE
+
+**_Weapon Specialist:_** You can wield multiple weapons with dangerous ease. When you succeed on an attack, you can **spend a Hope** to add one of the damage dice from your secondary weapon to the damage roll. Additionally, once per long rest when you roll your Slayer Dice, reroll any 1s.
+
+### MASTERY FEATURE
+
+**_Martial Preparation:_** You're an inspirational warrior to all who travel with you. Your party gains access to the Martial Preparation downtime move. To use this move during a rest, describe how you instruct and train with your party. You and each ally who chooses this downtime move gain a **d6** Slayer Die. A PC with a Slayer Die can spend it to roll the die and add the result to an attack or damage roll of their choice.

--- a/world/classes/subclasses/Divine Wielder.md
+++ b/world/classes/subclasses/Divine Wielder.md
@@ -1,0 +1,21 @@
+# Divine Wielder
+
+Play the Divine Wielder if you want to dominate the battlefield with a legendary weapon.
+
+### SPELLCAST TRAIT
+
+Strength
+
+### FOUNDATION FEATURES
+
+**_Spirit Weapon:_** When you have an equipped weapon with a range of Melee or Very Close, it can fly from your hand to attack an adversary within Close range and then return to you. You can **mark a Stress** to target an additional adversary within range with the same attack roll.
+
+**_Sparing Touch:_** Once per long rest, touch a creature and clear 2 Hit Points or 2 Stress from them.
+
+### SPECIALIZATION FEATURE
+
+**_Devout:_** When you roll your Prayer Dice, you can roll an additional die and discard the lowest result. Additionally, you can use your "Sparing Touch" feature twice instead of once per long rest.
+
+### MASTERY FEATURE
+
+**_Sacred Resonance:_** When you roll damage for your "Spirit Weapon" feature, if any of the die results match, double the value of each matching die. For example, if you roll two 5s, they count as two 10s.

--- a/world/classes/subclasses/Elemental Origin.md
+++ b/world/classes/subclasses/Elemental Origin.md
@@ -1,0 +1,26 @@
+# Elemental Origin
+
+Play the Elemental Origin if you want to channel raw magic to take the shape of a particular element.
+
+### SPELLCAST TRAIT
+
+Instinct
+
+### FOUNDATION FEATURE
+
+**_Elementalist:_** Choose one of the following elements at character creation: air, earth, fire, lightning, water.
+
+You can shape this element into harmless effects. Additionally, **spend a Hope** and describe how your control over this element helps an action roll you're about to make, then either gain a +2 bonus to the roll or a +3 bonus to the roll's damage.
+
+### SPECIALIZATION FEATURE
+
+**_Natural Evasion:_** You can call forth your element to protect you from harm. When an attack roll against you succeeds, you can **mark a Stress** and describe how you use your element to defend you. When you do, roll a **d6** and add its result to your Evasion against the attack.
+
+### MASTERY FEATURE
+
+**_Transcendence:_** Once per long rest, you can transform into a physical manifestation of your element. When you do, describe your transformation and choose two of the following benefits to gain until your next rest:
+
+- +4 bonus to your Severe threshold
+- +1 bonus to a character trait of your choice
+- +1 bonus to your Proficiency
+- +2 bonus to your Evasion

--- a/world/classes/subclasses/Nightwalker.md
+++ b/world/classes/subclasses/Nightwalker.md
@@ -1,0 +1,23 @@
+# Nightwalker
+
+Play the Nightwalker if you want to manipulate shadows to maneuver through the environment.
+
+### SPELLCAST TRAIT
+
+Finesse
+
+### FOUNDATION FEATURE
+
+**_Shadow Stepper:_** You can move from shadow to shadow. When you move into an area of darkness or a shadow cast by another creature or object, you can **mark a Stress** to disappear from where you are and reappear inside another shadow within Far range. When you reappear, you are _Cloaked._
+
+### SPECIALIZATION FEATURES
+
+**_Dark Cloud:_** Make a **Spellcast Roll (15).** On a success, create a temporary dark cloud that covers any area within Close range. Anyone in this cloud can't see outside of it, and anyone outside of it can't see in. You're considered _Cloaked_ from any adversary for whom the cloud blocks line of sight.
+
+**_Adrenaline:_** While you're _Vulnerable,_ add your level to your damage rolls.
+
+### MASTERY FEATURES
+
+**_Fleeting Shadow:_** Gain a permanent +1 bonus to your Evasion. You can use your "Shadow Stepper" feature to move within Very Far range.
+
+**_Vanishing Act:_** **Mark a Stress** to become _Cloaked_ at any time. When _Cloaked_ from this feature, you automatically clear the _Restrained_ condition if you have it. You remain _Cloaked_ in this way until you roll with Fear or until your next rest.

--- a/world/classes/subclasses/Primal Origin.md
+++ b/world/classes/subclasses/Primal Origin.md
@@ -1,0 +1,24 @@
+# Primal Origin
+
+Play the Primal Origin if you want to extend the versatility of your spells in powerful ways.
+
+### SPELLCAST TRAIT
+
+Instinct
+
+### FOUNDATION FEATURE
+
+**_Manipulate Magic:_** Your primal origin allows you to modify the essence of magic itself. After you cast a spell or make an attack using a weapon that deals magic damage, you can **mark a Stress** to do one of the following:
+
+- Extend the spell or attack's reach by one range
+- Gain a +2 bonus to the action roll's result
+- Double a damage die of your choice
+- Hit an additional target within range
+
+### SPECIALIZATION FEATURE
+
+**_Enchanted Aid:_** You can enhance the magic of others with your essence. When you Help an Ally with a Spellcast Roll, you can roll a **d8** as your advantage die. Once per long rest, after an ally has made a Spellcast Roll with your help, you can swap the results of their Duality Dice.
+
+### MASTERY FEATURE
+
+**_Arcane Charge:_** You can gather magical energy to enhance your capabilities. When you take magic damage, you become _Charged_. Alternatively, you can **spend 2 Hope** to become _Charged_. When you successfully make an attack that deals magic damage while _Charged_, you can clear your _Charge_ to either gain a +10 bonus to the damage roll or gain a +3 bonus to the Difficulty of a reaction roll the spell causes the target to make. You stop being _Charged_ at your next long rest.

--- a/world/classes/subclasses/School of Knowledge.md
+++ b/world/classes/subclasses/School of Knowledge.md
@@ -1,0 +1,25 @@
+# School of Knowledge
+
+Play the School of Knowledge if you want a keen understanding of the world around you.
+
+### SPELLCAST TRAIT
+
+Knowledge
+
+### FOUNDATION FEATURES
+
+**_Prepared:_** Take an additional domain card of your level or lower from a domain you have access to.
+
+**_Adept:_** When you Utilize an Experience, you can **mark a Stress** instead of spending a Hope. If you do, double your Experience modifier for that roll.
+
+### SPECIALIZATION FEATURES
+
+**_Accomplished:_** Take an additional domain card of your level or lower from a domain you have access to.
+
+**_Perfect Recall:_** Once per rest, when you recall a domain card in your vault, you can reduce its Recall Cost by 1.
+
+### MASTERY FEATURES
+
+**_Brilliant:_** Take an additional domain card of your level or lower from a domain you have access to.
+
+**_Honed Expertise:_** When you use an Experience, roll a **d6.** On a result of 5 or higher, you can use it without spending Hope.

--- a/world/classes/subclasses/School of War.md
+++ b/world/classes/subclasses/School of War.md
@@ -1,0 +1,25 @@
+# School of War
+
+Play the School of War if you want to utilize trained magic for violence.
+
+### SPELLCAST TRAIT
+
+Knowledge
+
+### FOUNDATION FEATURES
+
+**_Battlemage:_** You've focused your studies on becoming an unconquerable force on the battlefield. Gain an additional Hit Point slot.
+
+**_Face Your Fear:_** When you succeed with Fear on an attack roll, you deal an extra **1d10** magic damage.
+
+### SPECIALIZATION FEATURES
+
+**_Conjure Shield:_** You can maintain a protective barrier of magic. While you have at least 2 Hope, you add your Proficiency to your Evasion.
+
+**_Fueled by Fear:_** The extra magic damage from your "Face Your Fear" feature increases to **2d10**.
+
+### MASTERY FEATURES
+
+**_Thrive in Chaos:_** When you succeed on an attack, you can **mark a Stress** after rolling damage to force the target to mark an additional Hit Point.
+
+**_Have No Fear:_** The extra magic damage from your "Face Your Fear" feature increases to **3d10.**

--- a/world/classes/subclasses/Stalwart.md
+++ b/world/classes/subclasses/Stalwart.md
@@ -1,0 +1,21 @@
+# Stalwart
+
+Play the Stalwart if you want to take heavy blows and keep fighting.
+
+### FOUNDATION FEATURES
+
+**_Unwavering:_** Gain a permanent +1 bonus to your damage thresholds.
+
+**_Iron Will:_** When you take physical damage, you can **mark an additional Armor Slot** to reduce the severity.
+
+### SPECIALIZATION FEATURES
+
+**_Unrelenting:_** Gain a permanent +2 bonus to your damage thresholds.
+
+**_Partners-in-Arms:_** When an ally within Very Close range takes damage, you can **mark an Armor Slot** to reduce the severity by one threshold.
+
+### MASTERY FEATURES
+
+**_Undaunted:_** Gain a permanent +3 bonus to your damage thresholds.
+
+**_Loyal Protector:_** When an ally within Close range has 2 or fewer Hit Points and would take damage, you can **mark a Stress** to sprint to their side and take the damage instead.

--- a/world/classes/subclasses/Syndicate.md
+++ b/world/classes/subclasses/Syndicate.md
@@ -1,0 +1,32 @@
+# Syndicate
+
+Play the Syndicate if you want to have a web of contacts everywhere you go.
+
+### SPELLCAST TRAIT
+
+Finesse
+
+### FOUNDATION FEATURE
+
+**_Well-Connected:_** When you arrive in a prominent town or environment, you know somebody who calls this place home. Give them a name, note how you think they could be useful, and choose one fact from the following list:
+
+- They owe me a favor, but they'll be hard to find.
+- They're going to ask for something in exchange.
+- They're always in a great deal of trouble.
+- We used to be together. It's a long story.
+- We didn't part on great terms.
+
+### SPECIALIZATION FEATURE
+
+**_Contacts Everywhere:_** Once per session, you can briefly call on a shady contact. Choose one of the following benefits and describe what brought them here to help you in this moment:
+
+- They provide 1 handful of gold, a unique tool, or a mundane object that the situation requires.
+- On your next action roll, their help provides a +3 bonus to the result of your Hope or Fear Die.
+- The next time you deal damage, they snipe from the shadows, adding **2d8** to your damage roll.
+
+### MASTERY FEATURE
+
+**_Reliable Backup:_** You can use your "Contacts Everywhere" feature three times per session. The following options are added to the list of benefits you can choose from when you use that feature:
+
+- When you mark 1 or more Hit Points, they can rush out to shield you, reducing the Hit Points marked by 1.
+- When you make a Presence Roll in conversation, they back you up. You can roll a **d20** as your Hope Die.

--- a/world/classes/subclasses/Troubadour.md
+++ b/world/classes/subclasses/Troubadour.md
@@ -1,0 +1,23 @@
+# Troubadour
+
+Play the Troubadour if you want to play music to bolster your allies.
+
+### SPELLCAST TRAIT
+
+Presence
+
+### FOUNDATION FEATURE
+
+**_Gifted Performer:_** You can play three different types of songs, once each per long rest; describe how you perform for others to gain the listed benefit:
+
+- _Relaxing Song:_ You and all allies within Close range clear a Hit Point.
+- _Epic Song:_ Make a target within Close range temporarily _Vulnerable._
+- _Heartbreaking Song:_ You and all allies within Close range gain a Hope.
+
+### SPECIALIZATION FEATURE
+
+**_Maestro:_** Your rallying songs steel the courage of those who listen. When you give a Rally Die to an ally, they can gain a Hope or clear a Stress.
+
+### MASTERY FEATURE
+
+**_Virtuoso:_** You are among the greatest of your craft and your skill is boundless. You can perform each of your "Gifted Performer" feature's songs twice per long rest.

--- a/world/classes/subclasses/Vengeance.md
+++ b/world/classes/subclasses/Vengeance.md
@@ -1,0 +1,17 @@
+# Vengeance
+
+Play the Vengeance if you want to strike down enemies who harm you or your allies.
+
+### FOUNDATION FEATURES
+
+**_At Ease:_** Gain an additional Stress slot.
+
+**_Revenge:_** When an adversary within Melee range succeeds on an attack against you, you can **mark 2 Stress** to force the attacker to mark a Hit Point.
+
+### SPECIALIZATION FEATURE
+
+**_Act of Reprisal:_** When an adversary damages an ally within Melee range, you gain a +1 bonus to your Proficiency for the next successful attack you make against that adversary.
+
+### MASTERY FEATURE
+
+**_Nemesis:_** **Spend 2 Hope** to _Prioritize_ an adversary until your next rest. When you make an attack against your _Prioritized_ adversary, you can swap the results of your Hope and Fear Dice. You can only _Prioritize_ one adversary at a time.

--- a/world/classes/subclasses/Warden of Renewal.md
+++ b/world/classes/subclasses/Warden of Renewal.md
@@ -1,0 +1,23 @@
+# Warden of Renewal
+
+_Play the Warden of Renewal if you want to use powerful magic to heal your party._
+
+### SPELLCAST TRAIT
+
+Instinct
+
+### FOUNDATION FEATURES
+
+**_Clarity of Nature:_** Once per long rest, you can create a space of natural serenity within Close range. When you spend a few minutes resting within the space, clear Stress equal to your Instinct, distributed as you choose between you and your allies.
+
+**_Regeneration:_** Touch a creature and **spend 3 Hope.** That creature clears **1d4** Hit Points.
+
+### SPECIALIZATION FEATURES
+
+**_Regenerative Reach:_** You can target creatures within Very Close range with your "Regeneration" feature.
+
+**_Warden's Protection:_** Once per long rest, **spend 2 Hope** to clear 2 Hit Points on **1d4** allies within Close range.
+
+### MASTERY FEATURE
+
+**_Defender:_** Your animal transformation embodies a healing guardian spirit. When you're in Beastform and an ally within Close range marks 2 or more Hit Points, you can **mark a Stress** to reduce the number of Hit Points they mark by 1.

--- a/world/classes/subclasses/Warden of the Elements.md
+++ b/world/classes/subclasses/Warden of the Elements.md
@@ -1,0 +1,34 @@
+# Warden of the Elements
+
+Play the Warden of the Elements if you want to embody the natural elements of the wild.
+
+### SPELLCAST TRAIT
+
+Instinct
+
+### FOUNDATION FEATURE
+
+**_Elemental Incarnation:_** **Mark a Stress** to _Channel_ one of the following elements until you take Severe damage or until your next rest:
+
+- _Fire:_ When an adversary within Melee range deals damage to you, they take **1d10** magic damage.
+- _Earth:_ Gain a bonus to your damage thresholds equal to your Proficiency.
+- _Water:_ When you deal damage to an adversary within Melee range, all other adversaries within Very Close range must mark a Stress.
+- _Air:_ You can hover, gaining advantage on Agility Rolls.
+
+### SPECIALIZATION FEATURE
+
+**_Elemental Aura:_** Once per rest while _Channeling_, you can assume an aura matching your element. The aura affects targets within Close range until your _Channeling_ ends.
+
+- _Fire:_ When an adversary marks 1 or more Hit Points, they must also mark a Stress.
+- _Earth:_ Your allies gain a +1 bonus to Strength.
+- _Water:_ When an adversary deals damage to you, you can **mark a Stress** to move them anywhere within Very Close range of where they are.
+- _Air:_ When you or an ally takes damage from an attack beyond Melee range, reduce the damage by **1d8**.
+
+### MASTERY FEATURE
+
+**_Elemental Dominion:_** You further embody your element. While _Channeling_, you gain the following benefit:
+
+- _Fire:_ You gain a +1 bonus to your Proficiency for attacks and spells that deal damage.
+- _Earth:_ When you would mark Hit Points, roll a **d6** per Hit Point marked. For each result of 6, reduce the number of Hit Points you mark by 1.
+- _Water:_ When an attack against you succeeds, you can **mark a Stress** to make the attacker temporarily _Vulnerable_.
+- _Air:_ You gain a +1 bonus to your Evasion and can fly.

--- a/world/classes/subclasses/Wayfinder.md
+++ b/world/classes/subclasses/Wayfinder.md
@@ -1,0 +1,21 @@
+# Wayfinder
+
+Play the Wayfinder if you want to hunt your prey and strike with deadly force.
+
+### SPELLCAST TRAIT
+
+Agility
+
+### FOUNDATION FEATURES
+
+**_Ruthless Predator:_** When you make a damage roll, you can **mark a Stress** to gain a +1 bonus to your Proficiency. Additionally, when you deal Severe damage to an adversary, they must mark a Stress.
+
+**_Path Forward:_** When you're traveling to a place you've previously visited or you carry an object that has been at the location before, you can identify the shortest, most direct path to your destination.
+
+### SPECIALIZATION FEATURE
+
+**_Elusive Predator:_** When your Focus makes an attack against you, you gain a +2 bonus to your Evasion against the attack.
+
+### MASTERY FEATURE
+
+**_Apex Predator:_** Before you make an attack roll against your _Focus_, you can **spend a Hope.** On a successful attack, you remove a Fear from the GM's Fear pool.

--- a/world/classes/subclasses/Winged Sentinel.md
+++ b/world/classes/subclasses/Winged Sentinel.md
@@ -1,0 +1,24 @@
+# Winged Sentinel
+
+Play the Winged Sentinel if you want to take flight and strike crushing blows from the sky.
+
+### SPELLCAST TRAIT
+
+Strength
+
+### FOUNDATION FEATURE
+
+**_Wings of Light:_** You can fly. While flying, you can do the following:
+
+- **Mark a Stress** to pick up and carry another willing creature approximately your size or smaller.
+- **Spend a Hope** to deal an extra **1d8** damage on a successful attack.
+
+### SPECIALIZATION FEATURE
+
+**_Ethereal Visage:_** Your supernatural visage strikes awe and fear. While flying, you have advantage on Presence Rolls. When you succeed with Hope on a Presence Roll, you can remove a Fear from the GM's Fear pool instead of gaining Hope.
+
+### MASTERY FEATURES
+
+**_Ascendant:_** Gain a permanent +4 bonus to your Severe damage threshold.
+
+**_Power of the Gods:_** While flying, you deal an extra **1d12** damage instead of 1d8 from your "Wings of Light" feature.

--- a/world/classes/subclasses/Wordsmith.md
+++ b/world/classes/subclasses/Wordsmith.md
@@ -1,0 +1,25 @@
+# Wordsmith
+
+Play the Wordsmith if you want to use clever wordplay and captivate crowds.
+
+### SPELLCAST TRAIT
+
+Presence
+
+### FOUNDATION FEATURES
+
+**_Rousing Speech:_** Once per long rest, you can give a heartfelt, inspiring speech. All allies within Far range clear 2 Stress.
+
+**_Heart of a Poet:_** After you make an action roll to impress, persuade, or offend someone, you can **spend a Hope** to add a **d4** to the roll.
+
+### SPECIALIZATION FEATURE
+
+**_Eloquent:_** Your moving words boost morale. Once per session, when you encourage an ally, you can do one of the following:
+
+- Allow them to find a mundane object or tool they need.
+- Help an Ally without spending Hope.
+- Give them an additional downtime move during their next rest.
+
+### MASTERY FEATURE
+
+**_Epic Poetry:_** Your Rally Die increases to a **d10.** Additionally, when you Help an Ally, you can narrate the moment as if you were writing the tale of their heroism in a memoir. When you do, roll a **d10** as your advantage die.


### PR DESCRIPTION
All 8 non-Bard class files (Warrior, Wizard, Druid, Ranger, Rogue, Seraph, Sorcerer, Guardian) standardized to match Bard.md template for publishing:

- Added full frontmatter (project, type, visibility, status, tags) with class-specific title, domains, and sub-classes extracted from content
- Removed stray H1 headers (title now carried by frontmatter)
- Removed extraneous --- dividers (one kept between stats and suggested traits)
- Updated subclass links from references/daggerheart-srd/subclasses/ to world/classes/subclasses/ with %20 URL encoding decoded to plain spaces
- Fixed Wizard.md which had copy-pasted Bard frontmatter (wrong title/domains)

Also adds Bard.md and all subclass files as new tracked content.