### PR TITLE
chore: add character_framework to pipeline + fix faction wikilinks

### DIFF
--- a/utilities/world/generate_all_world_html.py
+++ b/utilities/world/generate_all_world_html.py
@@ -37,7 +37,7 @@ from shared.frontmatter import parse_frontmatter
 from shared.html_render import render_wiki_embed, inline_md as shared_inline_md, render_body as shared_render_body, render_md_table
 
 # ── discovery config ──────────────────────────────────────────────────────────
-PIPELINE_TYPES = {'timeline', 'myth', 'lore'}
+PIPELINE_TYPES = {'timeline', 'myth', 'lore', 'character_framework'}
 
 # Directories to search (relative to vault root)
 SCAN_ROOTS = ['world', 'narrative']

--- a/world/factions/human-empire.md
+++ b/world/factions/human-empire.md
@@ -120,7 +120,7 @@ Options B and C are recommended for development (per prior session notes). This 
 
 ## References
 
-- Index: [[_category]]
+- Index: [[world/factions/_category]]
 - Legacy faction: [[human-imperial-remnants]]
 - Related decision: Wizard awareness/motivation (Options A/B/C) — see `lat.md/decisions.md`
-- Design note source: [[_category]] § Historical Factions
+- Design note source: [[world/factions/_category]] § Historical Factions


### PR DESCRIPTION
## Summary

Two small pre-existing fixes bundled together.

- **Pipeline:** `character_framework` added to `PIPELINE_TYPES` in `generate_all_world_html.py` so the new class files (`type: character_framework`) are picked up by the HTML generator automatically on build
- **Faction wikilinks:** Two `[[_category]]` references in `human-empire.md` qualified to `[[world/factions/_category]]` to resolve correctly in the vault

## Why separate from the class-file PR?

The pipeline change is infrastructure (generator script); the class file cleanup is content. Keeping them in separate PRs makes each reviewable and revertable on its own terms. The pipeline change is also a prerequisite for the class files to render — once both PRs are merged, the full pipeline from `.md` → `.html` is wired up for class content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)