### PR TITLE
fix(pipeline): render class features as feature-boxes, convert md links, fix type label

### DIFF
--- a/utilities/shared/html_render.py
+++ b/utilities/shared/html_render.py
@@ -239,8 +239,8 @@ def render_body(body: str, vault: 'Path', docs: 'Path') -> 'tuple[str, list[dict
             )
             continue
 
-        # Feature box: **Feature Name:** description text
-        feat = re.match(r'^\*\*(.+?):\*\*\s*(.+)', para, re.DOTALL)
+        # Feature box: **Name:** text  OR  **_Name:_** text  (bold-italic name variant)
+        feat = re.match(r'^\*\*_?(.+?):_?\*\*\s*(.+)', para, re.DOTALL)
         if feat:
             feature_buffer.append((feat.group(1).strip(), feat.group(2).strip()))
             continue

--- a/utilities/shared/md_utils.py
+++ b/utilities/shared/md_utils.py
@@ -9,16 +9,32 @@ import re
 from html import escape as html_escape
 
 
+def _md_link_sub(m: 're.Match') -> str:
+    """Replacement function for markdown link [text](url) patterns.
+
+    Converts .md paths to slug.html using spaces→underscores convention.
+    Non-.md URLs are passed through unchanged.
+    """
+    link_text = m.group(1)
+    href = m.group(2)
+    if href.endswith('.md'):
+        stem = href.rsplit('/', 1)[-1][:-3]          # filename without extension
+        href = stem.lower().replace(' ', '_') + '.html'
+    return f'<a href="{href}">{link_text}</a>'
+
+
 def inline_md(text: str) -> str:
-    """Convert inline markdown to HTML (bold, italic, bold-italic).
+    """Convert inline markdown to HTML (bold, italic, bold-italic, links).
 
     HTML-escapes the input first so caller does not need to pre-escape.
+    Handles (in order): bold-italic, bold, italic, markdown links [t](url).
     """
     text = html_escape(text)
     text = re.sub(r'\*{3}(.+?)\*{3}', r'<strong><em>\1</em></strong>', text)
     text = re.sub(r'\*\*(.+?)\*\*', r'<strong>\1</strong>', text)
     text = re.sub(r'\*(.+?)\*', r'<em>\1</em>', text)
     text = re.sub(r'(?<!\w)_(.+?)_(?!\w)', r'<em>\1</em>', text)
+    text = re.sub(r'\[([^\]]*)\]\(([^)]+)\)', _md_link_sub, text)
     return text
 
 

--- a/utilities/world/generate_world_html.py
+++ b/utilities/world/generate_world_html.py
@@ -324,7 +324,7 @@ def build_myth_html(fm: dict, body: str, folder: str | None = None) -> str:
         )
 
     # --- Banner (frontmatter-overridable) ---
-    doc_type_label = str(fm.get('type', 'lore')).capitalize()
+    doc_type_label = str(fm.get('type', 'lore')).replace('_', ' ').title()
     banner_left  = fm.get('banner_left',  'Tarim-Shaiel')
     banner_right = fm.get('banner_right', doc_type_label)
     banner_html = (


### PR DESCRIPTION
## Summary

Three rendering fixes for `character_framework` (class) documents, verified against `warrior.html`:

- **Feature boxes** — extended the feature-box regex in `shared/html_render.py` from `**Name:**` to also match `**_Name:_**` (bold-italic name, the format Daggerheart SRD uses for class features). Hope features and class features now render as `.feature-box` elements instead of plain paragraphs.
- **Markdown links** — added `[text](url)` → `<a href>` conversion to `inline_md` in `shared/md_utils.py`. `.md` targets are slugged as `stem.lower().replace(' ', '_') + '.html'` (spaces→underscores convention for future subclass/domain pages).
- **Banner type label** — `character_framework` now renders as `Character Framework` in the banner strip (was showing raw underscore).

## Verified

Confirmed in `warrior.html`: No Mercy / Attack of Opportunity / Combat Training all render as feature boxes; Blade and Bone domain links are live anchors; banner reads "CHARACTER FRAMEWORK".

🤖 Generated with [Claude Code](https://claude.com/claude-code)