### PR TITLE
feat(pipeline): range: frontmatter migration + jump-nav group-by

### DIFF
--- a/utilities/world/generate_all_world_html.py
+++ b/utilities/world/generate_all_world_html.py
@@ -430,6 +430,19 @@ def _slug(text: str) -> str:
     return re.sub(r'[^\w\-]+', '-', text.lower()).strip('-')
 
 
+def _parse_list_field(value) -> list[str]:
+    """Normalize a frontmatter field that should be a list.
+
+    Handles pyyaml-parsed lists and comma-separated string fallback (e.g.
+    '[Melee, Close, Far]' from the regex parser).
+    """
+    if isinstance(value, list):
+        return [str(v).strip() for v in value]
+    if not value:
+        return []
+    return [item.strip() for item in str(value).strip().strip('[]').split(',') if item.strip()]
+
+
 # ── generation ────────────────────────────────────────────────────────────────
 
 def generate_all(
@@ -497,6 +510,7 @@ def generate_all(
                 'calendar':    fm.get('calendar', ''),
                 'description': fm.get('description', ''),
                 'filename':    f'{slug}.html',
+                'range':       str(fm.get('range') or '').strip(),
             })
 
     return grouped
@@ -948,9 +962,28 @@ def generate_category_page(
             child_label  = child_cfg.get('title') or _category_label(child)
             subcat_nav_items.append({'text': child_label, 'anchor': _slug(child_label), 'level': 2})
 
-    # Collect doc-card items into jump nav before building nav HTML
+    # Collect doc-card items into jump nav (flat or grouped)
     sorted_docs = sorted(folder_docs, key=lambda d: d['title'].lower())
-    if cfg.get('jump_nav'):
+    group_by_field = str(cfg.get('jump_nav_group_by') or '').strip()
+
+    if cfg.get('jump_nav') and group_by_field:
+        group_order = _parse_list_field(cfg.get('jump_nav_group_order', []))
+        groups: dict[str, list] = {}
+        for d in sorted_docs:
+            gval = str(d.get(group_by_field) or '').strip()
+            groups.setdefault(gval, []).append(d)
+
+        def _gkey(g: str) -> tuple:
+            try:
+                return (0, group_order.index(g))
+            except ValueError:
+                return (1, g.lower())
+
+        for gname in sorted(groups, key=_gkey):
+            jump_nav_items.append({'text': gname, 'anchor': None, 'level': 'group_label'})
+            for d in groups[gname]:
+                jump_nav_items.append({'text': d['title'], 'anchor': _slug(d['title']), 'level': 2})
+    elif cfg.get('jump_nav'):
         jump_nav_items += [{'text': d['title'], 'anchor': _slug(d['title']), 'level': 2}
                            for d in sorted_docs]
 
@@ -977,8 +1010,15 @@ def generate_category_page(
             nav_items.append(f'  <li class="nav-subcategory"><a href="#{item["anchor"]}">{escape(item["text"])}</a></li>')
         if subcat_nav_items and jump_nav_items:
             nav_items.append('  <li class="nav-divider"></li>')
+        first_group = True
         for item in jump_nav_items:
-            nav_items.append(f'  <li><a href="#{item["anchor"]}">{escape(item["text"])}</a></li>')
+            if item.get('level') == 'group_label':
+                if not first_group or subcat_nav_items:
+                    nav_items.append('  <li class="nav-divider"></li>')
+                nav_items.append(f'  <li class="nav-group-label">{escape(item["text"])}</li>')
+                first_group = False
+            else:
+                nav_items.append(f'  <li><a href="#{item["anchor"]}">{escape(item["text"])}</a></li>')
         nav_items.append('  <li class="nav-divider"></li>')
         nav_items.append('  <li style="list-style:none"><a href="#">&#8593; Top</a></li>')
         jump_nav_html = '<div class="jump-nav">\n<ul>\n' + '\n'.join(nav_items) + '\n</ul>\n</div>\n'

--- a/utilities/world/migrate_weapon_range.py
+++ b/utilities/world/migrate_weapon_range.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+ONE-SHOT MIGRATION SCRIPT — DELETE AFTER USE.
+
+Reads every weapon .md under world/weapons/ (recursively, skipping _category.md),
+extracts the Range value from the body line `- **Range:** <Value>`, and inserts
+`range: <Value>` into the YAML frontmatter block.
+
+Usage:
+    python migrate_weapon_range.py [--dry-run] [--vault /path/to/vault]
+"""
+import argparse
+import re
+from pathlib import Path
+
+
+def migrate(vault: Path, dry_run: bool) -> None:
+    weapons_root = vault / 'world' / 'weapons'
+    files = sorted(f for f in weapons_root.rglob('*.md') if f.name != '_category.md')
+
+    total = migrated = already_done = no_range = 0
+
+    for path in files:
+        total += 1
+        text = path.read_text(encoding='utf-8')
+
+        # Skip if range: already in frontmatter (idempotent)
+        parts = text.split('---\n', 2)
+        if len(parts) < 3:
+            print(f'  SKIP (no frontmatter): {path.relative_to(vault)}')
+            no_range += 1
+            continue
+
+        fm_block = parts[1]
+        if re.search(r'^range:', fm_block, re.MULTILINE):
+            already_done += 1
+            continue
+
+        # Extract Range from body
+        body = parts[2]
+        m = re.search(r'\*\*Range:\*\*\s+(.+)', body)
+        if not m:
+            print(f'  WARNING (no Range found): {path.relative_to(vault)}')
+            no_range += 1
+            continue
+
+        range_value = m.group(1).strip()
+        new_fm = fm_block.rstrip('\n') + f'\nrange: {range_value}\n'
+        new_text = f'---\n{new_fm}---\n{body}'
+
+        rel = path.relative_to(vault)
+        if dry_run:
+            print(f'  DRY-RUN: {rel}  →  range: {range_value}')
+        else:
+            path.write_text(new_text, encoding='utf-8')
+            print(f'  MIGRATED: {rel}  →  range: {range_value}')
+        migrated += 1
+
+    print(f'\nDone. total={total} migrated={migrated} already-done={already_done} no-range={no_range}')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='ONE-SHOT: add range: to weapon frontmatter')
+    parser.add_argument('--dry-run', action='store_true')
+    parser.add_argument('--vault', default=None)
+    args = parser.parse_args()
+
+    vault = Path(args.vault) if args.vault else Path(__file__).parent.parent.parent
+    migrate(vault, args.dry_run)
+
+
+if __name__ == '__main__':
+    main()

--- a/utilities/world/world_base.css
+++ b/utilities/world/world_base.css
@@ -236,6 +236,11 @@
     .jump-nav .nav-divider { list-style: none; border-top: 1px solid rgba(184,146,44,0.3); margin: 0.5rem 0; padding: 0; }
     .jump-nav .nav-subcategory { list-style: none; }
     .jump-nav .nav-subcategory a { color: var(--gold-light); font-weight: 600; letter-spacing: 0.06em; }
+    .jump-nav .nav-group-label {
+      list-style: none; font-family: 'Cinzel', serif; font-size: 0.68rem;
+      font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase;
+      color: var(--parchment2); padding: 0.2rem 0 0.1rem; cursor: default;
+    }
 
     @media (max-width: 640px) {
       body { flex-direction: column; justify-content: flex-start; }

--- a/world/weapons/Battleaxe.md
+++ b/world/weapons/Battleaxe.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Bladed Whip.md
+++ b/world/weapons/Bladed Whip.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Broadsword.md
+++ b/world/weapons/Broadsword.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Buckler.md
+++ b/world/weapons/Buckler.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Crossbow.md
+++ b/world/weapons/Crossbow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Curved Dagger.md
+++ b/world/weapons/Curved Dagger.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Cutlass.md
+++ b/world/weapons/Cutlass.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Dagger.md
+++ b/world/weapons/Dagger.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Double Flail.md
+++ b/world/weapons/Double Flail.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Dual-Ended Sword.md
+++ b/world/weapons/Dual-Ended Sword.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Extended Polearm.md
+++ b/world/weapons/Extended Polearm.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Grappler.md
+++ b/world/weapons/Grappler.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Close
 ---
 
 **Tier 1:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Greatbow.md
+++ b/world/weapons/Greatbow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Greatsword.md
+++ b/world/weapons/Greatsword.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Halberd.md
+++ b/world/weapons/Halberd.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Hand Crossbow.md
+++ b/world/weapons/Hand Crossbow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 1:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Hand Sling.md
+++ b/world/weapons/Hand Sling.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Far
 ---
 
 **Tier 3:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Knuckle Blades.md
+++ b/world/weapons/Knuckle Blades.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Knuckle Claws.md
+++ b/world/weapons/Knuckle Claws.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Longbow.md
+++ b/world/weapons/Longbow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Far
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Longsword.md
+++ b/world/weapons/Longsword.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-03-10
 last_updated: 2026-04-01
+range: Melee
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Mace.md
+++ b/world/weapons/Mace.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Meridian Cutlass.md
+++ b/world/weapons/Meridian Cutlass.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Parrying Dagger.md
+++ b/world/weapons/Parrying Dagger.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Powered Gauntlet.md
+++ b/world/weapons/Powered Gauntlet.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Close
 ---
 
 **Tier 3:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Primer Shard.md
+++ b/world/weapons/Primer Shard.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 4:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Rapier.md
+++ b/world/weapons/Rapier.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Retractable Saber.md
+++ b/world/weapons/Retractable Saber.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Returning Axe.md
+++ b/world/weapons/Returning Axe.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Close
 ---
 
 **Tier 2:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Ricochet Axes.md
+++ b/world/weapons/Ricochet Axes.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Round Shield.md
+++ b/world/weapons/Round Shield.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 1:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Shortbow.md
+++ b/world/weapons/Shortbow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Shortsword.md
+++ b/world/weapons/Shortsword.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 1:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Sledge Axe.md
+++ b/world/weapons/Sledge Axe.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Small Dagger.md
+++ b/world/weapons/Small Dagger.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 1:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Spear.md
+++ b/world/weapons/Spear.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Spiked Bow.md
+++ b/world/weapons/Spiked Bow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Far
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Spiked Shield.md
+++ b/world/weapons/Spiked Shield.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Swinging Ropeblade.md
+++ b/world/weapons/Swinging Ropeblade.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Close
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Talon Blades.md
+++ b/world/weapons/Talon Blades.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Close
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Tower Shield.md
+++ b/world/weapons/Tower Shield.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 1:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/War Scythe.md
+++ b/world/weapons/War Scythe.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Warhammer.md
+++ b/world/weapons/Warhammer.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Whip.md
+++ b/world/weapons/Whip.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 1:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/_category.md
+++ b/world/weapons/_category.md
@@ -4,6 +4,8 @@ description: Primary and secondary weapons of Tarim-Shaiel.
 banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapons
 jump_nav: true
+jump_nav_group_by: range
+jump_nav_group_order: [Melee, Very Close, Close, Far, Very Far]
 published: true
 type: lore
 ---

--- a/world/weapons/advanced-weapons/Advanced Arcane Gauntlets.md
+++ b/world/weapons/advanced-weapons/Advanced Arcane Gauntlets.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Battleaxe.md
+++ b/world/weapons/advanced-weapons/Advanced Battleaxe.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Broadsword.md
+++ b/world/weapons/advanced-weapons/Advanced Broadsword.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Crossbow.md
+++ b/world/weapons/advanced-weapons/Advanced Crossbow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Cutlass.md
+++ b/world/weapons/advanced-weapons/Advanced Cutlass.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Dagger.md
+++ b/world/weapons/advanced-weapons/Advanced Dagger.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Dualstaff.md
+++ b/world/weapons/advanced-weapons/Advanced Dualstaff.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Glowing Rings.md
+++ b/world/weapons/advanced-weapons/Advanced Glowing Rings.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Grappler.md
+++ b/world/weapons/advanced-weapons/Advanced Grappler.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Close
 ---
 
 **Tier 3:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Greatstaff.md
+++ b/world/weapons/advanced-weapons/Advanced Greatstaff.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Far
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Greatsword.md
+++ b/world/weapons/advanced-weapons/Advanced Greatsword.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Halberd.md
+++ b/world/weapons/advanced-weapons/Advanced Halberd.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Hallowed Axe.md
+++ b/world/weapons/advanced-weapons/Advanced Hallowed Axe.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Hand Crossbow.md
+++ b/world/weapons/advanced-weapons/Advanced Hand Crossbow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 3:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Hand Runes.md
+++ b/world/weapons/advanced-weapons/Advanced Hand Runes.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Longbow.md
+++ b/world/weapons/advanced-weapons/Advanced Longbow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Far
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Longsword.md
+++ b/world/weapons/advanced-weapons/Advanced Longsword.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Mace.md
+++ b/world/weapons/advanced-weapons/Advanced Mace.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Quarterstaff.md
+++ b/world/weapons/advanced-weapons/Advanced Quarterstaff.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Rapier.md
+++ b/world/weapons/advanced-weapons/Advanced Rapier.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Returning Blade.md
+++ b/world/weapons/advanced-weapons/Advanced Returning Blade.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Close
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Round Shield.md
+++ b/world/weapons/advanced-weapons/Advanced Round Shield.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Scepter.md
+++ b/world/weapons/advanced-weapons/Advanced Scepter.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Shortbow.md
+++ b/world/weapons/advanced-weapons/Advanced Shortbow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Shortstaff.md
+++ b/world/weapons/advanced-weapons/Advanced Shortstaff.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Close
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Shortsword.md
+++ b/world/weapons/advanced-weapons/Advanced Shortsword.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Small Dagger.md
+++ b/world/weapons/advanced-weapons/Advanced Small Dagger.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Spear.md
+++ b/world/weapons/advanced-weapons/Advanced Spear.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Tower Shield.md
+++ b/world/weapons/advanced-weapons/Advanced Tower Shield.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Wand.md
+++ b/world/weapons/advanced-weapons/Advanced Wand.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Warhammer.md
+++ b/world/weapons/advanced-weapons/Advanced Warhammer.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Whip.md
+++ b/world/weapons/advanced-weapons/Advanced Whip.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 3:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/_category.md
+++ b/world/weapons/advanced-weapons/_category.md
@@ -4,6 +4,8 @@ description: Advanced weapons of Tarim-Shaiel.
 banner_left: TARIM-SHAIEL * Lore
 banner_right: Advanced Weapons
 jump_nav: true
+jump_nav_group_by: range
+jump_nav_group_order: [Melee, Very Close, Close, Far, Very Far]
 parent: weapons
 ---
 Advanced!

--- a/world/weapons/improved-weapons/Improved Arcane Gauntlets.md
+++ b/world/weapons/improved-weapons/Improved Arcane Gauntlets.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Battleaxe.md
+++ b/world/weapons/improved-weapons/Improved Battleaxe.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Broadsword.md
+++ b/world/weapons/improved-weapons/Improved Broadsword.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Crossbow.md
+++ b/world/weapons/improved-weapons/Improved Crossbow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Cutlass.md
+++ b/world/weapons/improved-weapons/Improved Cutlass.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Dagger.md
+++ b/world/weapons/improved-weapons/Improved Dagger.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Dualstaff.md
+++ b/world/weapons/improved-weapons/Improved Dualstaff.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Glowing Rings.md
+++ b/world/weapons/improved-weapons/Improved Glowing Rings.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Grappler.md
+++ b/world/weapons/improved-weapons/Improved Grappler.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Close
 ---
 
 **Tier 2:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Greatstaff.md
+++ b/world/weapons/improved-weapons/Improved Greatstaff.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Far
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Greatsword.md
+++ b/world/weapons/improved-weapons/Improved Greatsword.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Halberd.md
+++ b/world/weapons/improved-weapons/Improved Halberd.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Hallowed Axe.md
+++ b/world/weapons/improved-weapons/Improved Hallowed Axe.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Hand Crossbow.md
+++ b/world/weapons/improved-weapons/Improved Hand Crossbow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 2:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Hand Runes.md
+++ b/world/weapons/improved-weapons/Improved Hand Runes.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Longbow.md
+++ b/world/weapons/improved-weapons/Improved Longbow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Far
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Longsword.md
+++ b/world/weapons/improved-weapons/Improved Longsword.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Mace.md
+++ b/world/weapons/improved-weapons/Improved Mace.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Quarterstaff.md
+++ b/world/weapons/improved-weapons/Improved Quarterstaff.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Rapier.md
+++ b/world/weapons/improved-weapons/Improved Rapier.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Returning Blade.md
+++ b/world/weapons/improved-weapons/Improved Returning Blade.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Close
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Round Shield.md
+++ b/world/weapons/improved-weapons/Improved Round Shield.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Scepter.md
+++ b/world/weapons/improved-weapons/Improved Scepter.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Shortbow.md
+++ b/world/weapons/improved-weapons/Improved Shortbow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Shortstaff.md
+++ b/world/weapons/improved-weapons/Improved Shortstaff.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Close
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Shortsword.md
+++ b/world/weapons/improved-weapons/Improved Shortsword.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Small Dagger.md
+++ b/world/weapons/improved-weapons/Improved Small Dagger.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Spear.md
+++ b/world/weapons/improved-weapons/Improved Spear.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Tower Shield.md
+++ b/world/weapons/improved-weapons/Improved Tower Shield.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Wand.md
+++ b/world/weapons/improved-weapons/Improved Wand.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Warhammer.md
+++ b/world/weapons/improved-weapons/Improved Warhammer.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Whip.md
+++ b/world/weapons/improved-weapons/Improved Whip.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 2:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/_category.md
+++ b/world/weapons/improved-weapons/_category.md
@@ -4,6 +4,8 @@ description: Improved weapons of Tarim-Shaiel.
 banner_left: TARIM-SHAIEL * Lore
 banner_right: Improved Weapons
 jump_nav: true
+jump_nav_group_by: range
+jump_nav_group_order: [Melee, Very Close, Close, Far, Very Far]
 parent: weapons
 ---
 Improved!

--- a/world/weapons/legendary-weapons/Legendary Arcane Gauntlets.md
+++ b/world/weapons/legendary-weapons/Legendary Arcane Gauntlets.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Battleaxe.md
+++ b/world/weapons/legendary-weapons/Legendary Battleaxe.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Broadsword.md
+++ b/world/weapons/legendary-weapons/Legendary Broadsword.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Crossbow.md
+++ b/world/weapons/legendary-weapons/Legendary Crossbow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Cutlass.md
+++ b/world/weapons/legendary-weapons/Legendary Cutlass.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Dagger.md
+++ b/world/weapons/legendary-weapons/Legendary Dagger.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Dualstaff.md
+++ b/world/weapons/legendary-weapons/Legendary Dualstaff.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Glowing Rings.md
+++ b/world/weapons/legendary-weapons/Legendary Glowing Rings.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Grappler.md
+++ b/world/weapons/legendary-weapons/Legendary Grappler.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Close
 ---
 
 **Tier 4:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Greatstaff.md
+++ b/world/weapons/legendary-weapons/Legendary Greatstaff.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Far
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Greatsword.md
+++ b/world/weapons/legendary-weapons/Legendary Greatsword.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Halberd.md
+++ b/world/weapons/legendary-weapons/Legendary Halberd.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Hallowed Axe.md
+++ b/world/weapons/legendary-weapons/Legendary Hallowed Axe.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Hand Crossbow.md
+++ b/world/weapons/legendary-weapons/Legendary Hand Crossbow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 4:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Hand Runes.md
+++ b/world/weapons/legendary-weapons/Legendary Hand Runes.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Longbow.md
+++ b/world/weapons/legendary-weapons/Legendary Longbow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Far
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Longsword.md
+++ b/world/weapons/legendary-weapons/Legendary Longsword.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Mace.md
+++ b/world/weapons/legendary-weapons/Legendary Mace.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Quarterstaff.md
+++ b/world/weapons/legendary-weapons/Legendary Quarterstaff.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Rapier.md
+++ b/world/weapons/legendary-weapons/Legendary Rapier.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Returning Blade.md
+++ b/world/weapons/legendary-weapons/Legendary Returning Blade.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Close
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Round Shield.md
+++ b/world/weapons/legendary-weapons/Legendary Round Shield.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Scepter.md
+++ b/world/weapons/legendary-weapons/Legendary Scepter.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Shortbow.md
+++ b/world/weapons/legendary-weapons/Legendary Shortbow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Shortstaff.md
+++ b/world/weapons/legendary-weapons/Legendary Shortstaff.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Close
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Shortsword.md
+++ b/world/weapons/legendary-weapons/Legendary Shortsword.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Small Dagger.md
+++ b/world/weapons/legendary-weapons/Legendary Small Dagger.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Spear.md
+++ b/world/weapons/legendary-weapons/Legendary Spear.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Tower Shield.md
+++ b/world/weapons/legendary-weapons/Legendary Tower Shield.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Wand.md
+++ b/world/weapons/legendary-weapons/Legendary Wand.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Warhammer.md
+++ b/world/weapons/legendary-weapons/Legendary Warhammer.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Whip.md
+++ b/world/weapons/legendary-weapons/Legendary Whip.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 4:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/_category.md
+++ b/world/weapons/legendary-weapons/_category.md
@@ -4,6 +4,8 @@ description: Legendary weapons of Tarim-Shaiel.
 banner_left: TARIM-SHAIEL * Lore
 banner_right: Legendary Weapons
 jump_nav: true
+jump_nav_group_by: range
+jump_nav_group_order: [Melee, Very Close, Close, Far, Very Far]
 parent: weapons
 ---
 Legendary

--- a/world/weapons/magical-weapons/Arcane Gauntlets.md
+++ b/world/weapons/magical-weapons/Arcane Gauntlets.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 1:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Axe of Fortunis.md
+++ b/world/weapons/magical-weapons/Axe of Fortunis.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Blessed Anlace.md
+++ b/world/weapons/magical-weapons/Blessed Anlace.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Bloodstaff.md
+++ b/world/weapons/magical-weapons/Bloodstaff.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Casting Sword.md
+++ b/world/weapons/magical-weapons/Casting Sword.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Devouring Dagger.md
+++ b/world/weapons/magical-weapons/Devouring Dagger.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Dualstaff.md
+++ b/world/weapons/magical-weapons/Dualstaff.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 1:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Ego Blade.md
+++ b/world/weapons/magical-weapons/Ego Blade.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Elder Bow.md
+++ b/world/weapons/magical-weapons/Elder Bow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Firestaff.md
+++ b/world/weapons/magical-weapons/Firestaff.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Floating Bladeshards.md
+++ b/world/weapons/magical-weapons/Floating Bladeshards.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Close
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Fusion Gloves.md
+++ b/world/weapons/magical-weapons/Fusion Gloves.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Far
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Ghostblade.md
+++ b/world/weapons/magical-weapons/Ghostblade.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Gilded Bow.md
+++ b/world/weapons/magical-weapons/Gilded Bow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Glowing Rings.md
+++ b/world/weapons/magical-weapons/Glowing Rings.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 1:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Greatstaff.md
+++ b/world/weapons/magical-weapons/Greatstaff.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Far
 ---
 
 **Tier 1:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Hallowed Axe.md
+++ b/world/weapons/magical-weapons/Hallowed Axe.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 1:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Hammer of Exota.md
+++ b/world/weapons/magical-weapons/Hammer of Exota.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Hand Runes.md
+++ b/world/weapons/magical-weapons/Hand Runes.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 1:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Ilmaris Rifle.md
+++ b/world/weapons/magical-weapons/Ilmaris Rifle.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Far
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Keepers Staff.md
+++ b/world/weapons/magical-weapons/Keepers Staff.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Mage Orb.md
+++ b/world/weapons/magical-weapons/Mage Orb.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Magus Revolver.md
+++ b/world/weapons/magical-weapons/Magus Revolver.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Far
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Midas Scythe.md
+++ b/world/weapons/magical-weapons/Midas Scythe.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Quarterstaff.md
+++ b/world/weapons/magical-weapons/Quarterstaff.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/magical-weapons/Returning Blade.md
+++ b/world/weapons/magical-weapons/Returning Blade.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Close
 ---
 
 **Tier 1:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Runes of Ruination.md
+++ b/world/weapons/magical-weapons/Runes of Ruination.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Scepter of Elias.md
+++ b/world/weapons/magical-weapons/Scepter of Elias.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Scepter.md
+++ b/world/weapons/magical-weapons/Scepter.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 1:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Shortstaff.md
+++ b/world/weapons/magical-weapons/Shortstaff.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Close
 ---
 
 **Tier 1:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Siphoning Gauntlets.md
+++ b/world/weapons/magical-weapons/Siphoning Gauntlets.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Sword of Light and Flame.md
+++ b/world/weapons/magical-weapons/Sword of Light and Flame.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Thistlebow.md
+++ b/world/weapons/magical-weapons/Thistlebow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Wand of Enthrallment.md
+++ b/world/weapons/magical-weapons/Wand of Enthrallment.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Wand of Essek.md
+++ b/world/weapons/magical-weapons/Wand of Essek.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Wand.md
+++ b/world/weapons/magical-weapons/Wand.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 1:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Widogast Pendant.md
+++ b/world/weapons/magical-weapons/Widogast Pendant.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Close
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Yutari Bloodbow.md
+++ b/world/weapons/magical-weapons/Yutari Bloodbow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/powder-weapons/Black Powder Revolver.md
+++ b/world/weapons/powder-weapons/Black Powder Revolver.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/powder-weapons/Blunderbuss.md
+++ b/world/weapons/powder-weapons/Blunderbuss.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Close
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/powder-weapons/Hand Cannon.md
+++ b/world/weapons/powder-weapons/Hand Cannon.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Far
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/speacial-weapons/Aantari Bow.md
+++ b/world/weapons/speacial-weapons/Aantari Bow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Far
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/speacial-weapons/Braveshield.md
+++ b/world/weapons/speacial-weapons/Braveshield.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/speacial-weapons/Bravesword.md
+++ b/world/weapons/speacial-weapons/Bravesword.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/speacial-weapons/Finehair Bow.md
+++ b/world/weapons/speacial-weapons/Finehair Bow.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Far
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/speacial-weapons/Flickerfly Blade.md
+++ b/world/weapons/speacial-weapons/Flickerfly Blade.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/speacial-weapons/Gilded Falchion.md
+++ b/world/weapons/speacial-weapons/Gilded Falchion.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/speacial-weapons/Hammer of Wrath.md
+++ b/world/weapons/speacial-weapons/Hammer of Wrath.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/speacial-weapons/Impact Gauntlet.md
+++ b/world/weapons/speacial-weapons/Impact Gauntlet.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/speacial-weapons/Labrys Axe.md
+++ b/world/weapons/speacial-weapons/Labrys Axe.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/speacial-weapons/Steelforged Halberd.md
+++ b/world/weapons/speacial-weapons/Steelforged Halberd.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Very Close
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/speacial-weapons/Urok Broadsword.md
+++ b/world/weapons/speacial-weapons/Urok Broadsword.md
@@ -9,6 +9,7 @@ banner_left: TARIM-SHAIEL * Lore
 banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
+range: Melee
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_


### PR DESCRIPTION
Migrates Range from weapon body text to YAML frontmatter across all 192 weapon files (96 base + 32×3 tier), then implements a generic jump_nav_group_by: mechanism in the category pipeline.

Changes:
- utilities/world/migrate_weapon_range.py: one-shot migration script (rglob, idempotent, --dry-run flag) — to be deleted after merge
- generate_all_world_html.py:
  - add 'range' field to doc dict in generate_all()
  - add _parse_list_field() helper (pyyaml list + comma-string fallback)
  - generate_category_page(): grouped jump-nav mode when jump_nav_group_by: is set in _category.md; nav-group-label items with dividers between groups; first_group guard prevents double-divider above first group
- world_base.css: add .nav-group-label (Cinzel, parchment2, no bullet, cursor:default — visually distinct from gold link entries)
- world/weapons/_category.md (×4): add jump_nav_group_by: range and jump_nav_group_order: [Melee, Very Close, Close, Far, Very Far]
- world/weapons/**/*.md (192 files): add range: <value> to frontmatter

https://claude.ai/code/session_01KxUPGmLbF9VKhAXAR6uYWd