### PR TITLE
feat(pipeline): tier: frontmatter migration for all weapon files

### DIFF
--- a/utilities/world/generate_all_world_html.py
+++ b/utilities/world/generate_all_world_html.py
@@ -511,6 +511,7 @@ def generate_all(
                 'description': fm.get('description', ''),
                 'filename':    f'{slug}.html',
                 'range':       str(fm.get('range') or '').strip(),
+                'tier':        str(fm.get('tier') or '').strip(),
             })
 
     return grouped

--- a/utilities/world/migrate_weapon_tier.py
+++ b/utilities/world/migrate_weapon_tier.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+ONE-SHOT MIGRATION SCRIPT — DELETE AFTER USE.
+
+Reads every weapon .md under world/weapons/ (recursively, skipping _category.md),
+extracts the Tier value from the body line `**Tier N:**` and inserts
+`tier: N` (integer) into the YAML frontmatter block.
+
+Usage:
+    python migrate_weapon_tier.py [--dry-run] [--vault /path/to/vault]
+"""
+import argparse
+import re
+from pathlib import Path
+
+
+def migrate(vault: Path, dry_run: bool) -> None:
+    weapons_root = vault / 'world' / 'weapons'
+    files = sorted(f for f in weapons_root.rglob('*.md') if f.name != '_category.md')
+
+    total = migrated = already_done = no_tier = 0
+
+    for path in files:
+        total += 1
+        text = path.read_text(encoding='utf-8')
+
+        parts = text.split('---\n', 2)
+        if len(parts) < 3:
+            print(f'  SKIP (no frontmatter): {path.relative_to(vault)}')
+            no_tier += 1
+            continue
+
+        fm_block = parts[1]
+        if re.search(r'^tier:', fm_block, re.MULTILINE):
+            already_done += 1
+            continue
+
+        body = parts[2]
+        m = re.search(r'\*\*Tier\s+(\d+)', body)
+        if not m:
+            print(f'  WARNING (no Tier found): {path.relative_to(vault)}')
+            no_tier += 1
+            continue
+
+        tier_value = int(m.group(1))
+        new_fm = fm_block.rstrip('\n') + f'\ntier: {tier_value}\n'
+        new_text = f'---\n{new_fm}---\n{body}'
+
+        rel = path.relative_to(vault)
+        if dry_run:
+            print(f'  DRY-RUN: {rel}  →  tier: {tier_value}')
+        else:
+            path.write_text(new_text, encoding='utf-8')
+        migrated += 1
+
+    print(f'\nDone. total={total} migrated={migrated} already-done={already_done} no-tier={no_tier}')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='ONE-SHOT: add tier: to weapon frontmatter')
+    parser.add_argument('--dry-run', action='store_true')
+    parser.add_argument('--vault', default=None)
+    args = parser.parse_args()
+
+    vault = Path(args.vault) if args.vault else Path(__file__).parent.parent.parent
+    migrate(vault, args.dry_run)
+
+
+if __name__ == '__main__':
+    main()

--- a/world/weapons/Battleaxe.md
+++ b/world/weapons/Battleaxe.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Bladed Whip.md
+++ b/world/weapons/Bladed Whip.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Broadsword.md
+++ b/world/weapons/Broadsword.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Buckler.md
+++ b/world/weapons/Buckler.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Crossbow.md
+++ b/world/weapons/Crossbow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Curved Dagger.md
+++ b/world/weapons/Curved Dagger.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Cutlass.md
+++ b/world/weapons/Cutlass.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Dagger.md
+++ b/world/weapons/Dagger.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Double Flail.md
+++ b/world/weapons/Double Flail.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Dual-Ended Sword.md
+++ b/world/weapons/Dual-Ended Sword.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Extended Polearm.md
+++ b/world/weapons/Extended Polearm.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Grappler.md
+++ b/world/weapons/Grappler.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Close
+tier: 1
 ---
 
 **Tier 1:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Greatbow.md
+++ b/world/weapons/Greatbow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Greatsword.md
+++ b/world/weapons/Greatsword.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Halberd.md
+++ b/world/weapons/Halberd.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Hand Crossbow.md
+++ b/world/weapons/Hand Crossbow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 1
 ---
 
 **Tier 1:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Hand Sling.md
+++ b/world/weapons/Hand Sling.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Far
+tier: 3
 ---
 
 **Tier 3:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Knuckle Blades.md
+++ b/world/weapons/Knuckle Blades.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Knuckle Claws.md
+++ b/world/weapons/Knuckle Claws.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Longbow.md
+++ b/world/weapons/Longbow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Far
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Longsword.md
+++ b/world/weapons/Longsword.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-03-10
 last_updated: 2026-04-01
 range: Melee
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Mace.md
+++ b/world/weapons/Mace.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Meridian Cutlass.md
+++ b/world/weapons/Meridian Cutlass.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Parrying Dagger.md
+++ b/world/weapons/Parrying Dagger.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Powered Gauntlet.md
+++ b/world/weapons/Powered Gauntlet.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Close
+tier: 3
 ---
 
 **Tier 3:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Primer Shard.md
+++ b/world/weapons/Primer Shard.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 4
 ---
 
 **Tier 4:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Rapier.md
+++ b/world/weapons/Rapier.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Retractable Saber.md
+++ b/world/weapons/Retractable Saber.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Returning Axe.md
+++ b/world/weapons/Returning Axe.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Close
+tier: 2
 ---
 
 **Tier 2:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Ricochet Axes.md
+++ b/world/weapons/Ricochet Axes.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Round Shield.md
+++ b/world/weapons/Round Shield.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 1
 ---
 
 **Tier 1:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Shortbow.md
+++ b/world/weapons/Shortbow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Shortsword.md
+++ b/world/weapons/Shortsword.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 1
 ---
 
 **Tier 1:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Sledge Axe.md
+++ b/world/weapons/Sledge Axe.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Small Dagger.md
+++ b/world/weapons/Small Dagger.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 1
 ---
 
 **Tier 1:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Spear.md
+++ b/world/weapons/Spear.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Spiked Bow.md
+++ b/world/weapons/Spiked Bow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Far
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Spiked Shield.md
+++ b/world/weapons/Spiked Shield.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/Swinging Ropeblade.md
+++ b/world/weapons/Swinging Ropeblade.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Close
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Talon Blades.md
+++ b/world/weapons/Talon Blades.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Close
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Tower Shield.md
+++ b/world/weapons/Tower Shield.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 1
 ---
 
 **Tier 1:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/War Scythe.md
+++ b/world/weapons/War Scythe.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Warhammer.md
+++ b/world/weapons/Warhammer.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/Whip.md
+++ b/world/weapons/Whip.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 1
 ---
 
 **Tier 1:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Arcane Gauntlets.md
+++ b/world/weapons/advanced-weapons/Advanced Arcane Gauntlets.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Battleaxe.md
+++ b/world/weapons/advanced-weapons/Advanced Battleaxe.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Broadsword.md
+++ b/world/weapons/advanced-weapons/Advanced Broadsword.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Crossbow.md
+++ b/world/weapons/advanced-weapons/Advanced Crossbow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Cutlass.md
+++ b/world/weapons/advanced-weapons/Advanced Cutlass.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Dagger.md
+++ b/world/weapons/advanced-weapons/Advanced Dagger.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Dualstaff.md
+++ b/world/weapons/advanced-weapons/Advanced Dualstaff.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Glowing Rings.md
+++ b/world/weapons/advanced-weapons/Advanced Glowing Rings.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Grappler.md
+++ b/world/weapons/advanced-weapons/Advanced Grappler.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Close
+tier: 3
 ---
 
 **Tier 3:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Greatstaff.md
+++ b/world/weapons/advanced-weapons/Advanced Greatstaff.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Far
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Greatsword.md
+++ b/world/weapons/advanced-weapons/Advanced Greatsword.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Halberd.md
+++ b/world/weapons/advanced-weapons/Advanced Halberd.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Hallowed Axe.md
+++ b/world/weapons/advanced-weapons/Advanced Hallowed Axe.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Hand Crossbow.md
+++ b/world/weapons/advanced-weapons/Advanced Hand Crossbow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 3
 ---
 
 **Tier 3:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Hand Runes.md
+++ b/world/weapons/advanced-weapons/Advanced Hand Runes.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Longbow.md
+++ b/world/weapons/advanced-weapons/Advanced Longbow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Far
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Longsword.md
+++ b/world/weapons/advanced-weapons/Advanced Longsword.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Mace.md
+++ b/world/weapons/advanced-weapons/Advanced Mace.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Quarterstaff.md
+++ b/world/weapons/advanced-weapons/Advanced Quarterstaff.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Rapier.md
+++ b/world/weapons/advanced-weapons/Advanced Rapier.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Returning Blade.md
+++ b/world/weapons/advanced-weapons/Advanced Returning Blade.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Close
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Round Shield.md
+++ b/world/weapons/advanced-weapons/Advanced Round Shield.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Scepter.md
+++ b/world/weapons/advanced-weapons/Advanced Scepter.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Shortbow.md
+++ b/world/weapons/advanced-weapons/Advanced Shortbow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Shortstaff.md
+++ b/world/weapons/advanced-weapons/Advanced Shortstaff.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Close
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Shortsword.md
+++ b/world/weapons/advanced-weapons/Advanced Shortsword.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Small Dagger.md
+++ b/world/weapons/advanced-weapons/Advanced Small Dagger.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Spear.md
+++ b/world/weapons/advanced-weapons/Advanced Spear.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Tower Shield.md
+++ b/world/weapons/advanced-weapons/Advanced Tower Shield.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Wand.md
+++ b/world/weapons/advanced-weapons/Advanced Wand.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Warhammer.md
+++ b/world/weapons/advanced-weapons/Advanced Warhammer.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/advanced-weapons/Advanced Whip.md
+++ b/world/weapons/advanced-weapons/Advanced Whip.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 3
 ---
 
 **Tier 3:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Arcane Gauntlets.md
+++ b/world/weapons/improved-weapons/Improved Arcane Gauntlets.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Battleaxe.md
+++ b/world/weapons/improved-weapons/Improved Battleaxe.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Broadsword.md
+++ b/world/weapons/improved-weapons/Improved Broadsword.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Crossbow.md
+++ b/world/weapons/improved-weapons/Improved Crossbow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Cutlass.md
+++ b/world/weapons/improved-weapons/Improved Cutlass.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Dagger.md
+++ b/world/weapons/improved-weapons/Improved Dagger.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Dualstaff.md
+++ b/world/weapons/improved-weapons/Improved Dualstaff.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Glowing Rings.md
+++ b/world/weapons/improved-weapons/Improved Glowing Rings.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Grappler.md
+++ b/world/weapons/improved-weapons/Improved Grappler.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Close
+tier: 2
 ---
 
 **Tier 2:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Greatstaff.md
+++ b/world/weapons/improved-weapons/Improved Greatstaff.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Far
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Greatsword.md
+++ b/world/weapons/improved-weapons/Improved Greatsword.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Halberd.md
+++ b/world/weapons/improved-weapons/Improved Halberd.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Hallowed Axe.md
+++ b/world/weapons/improved-weapons/Improved Hallowed Axe.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Hand Crossbow.md
+++ b/world/weapons/improved-weapons/Improved Hand Crossbow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 2
 ---
 
 **Tier 2:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Hand Runes.md
+++ b/world/weapons/improved-weapons/Improved Hand Runes.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Longbow.md
+++ b/world/weapons/improved-weapons/Improved Longbow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Far
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Longsword.md
+++ b/world/weapons/improved-weapons/Improved Longsword.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Mace.md
+++ b/world/weapons/improved-weapons/Improved Mace.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Quarterstaff.md
+++ b/world/weapons/improved-weapons/Improved Quarterstaff.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Rapier.md
+++ b/world/weapons/improved-weapons/Improved Rapier.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Returning Blade.md
+++ b/world/weapons/improved-weapons/Improved Returning Blade.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Close
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Round Shield.md
+++ b/world/weapons/improved-weapons/Improved Round Shield.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Scepter.md
+++ b/world/weapons/improved-weapons/Improved Scepter.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Shortbow.md
+++ b/world/weapons/improved-weapons/Improved Shortbow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Shortstaff.md
+++ b/world/weapons/improved-weapons/Improved Shortstaff.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Close
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Shortsword.md
+++ b/world/weapons/improved-weapons/Improved Shortsword.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Small Dagger.md
+++ b/world/weapons/improved-weapons/Improved Small Dagger.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Spear.md
+++ b/world/weapons/improved-weapons/Improved Spear.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Tower Shield.md
+++ b/world/weapons/improved-weapons/Improved Tower Shield.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Wand.md
+++ b/world/weapons/improved-weapons/Improved Wand.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Warhammer.md
+++ b/world/weapons/improved-weapons/Improved Warhammer.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/improved-weapons/Improved Whip.md
+++ b/world/weapons/improved-weapons/Improved Whip.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 2
 ---
 
 **Tier 2:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Arcane Gauntlets.md
+++ b/world/weapons/legendary-weapons/Legendary Arcane Gauntlets.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Battleaxe.md
+++ b/world/weapons/legendary-weapons/Legendary Battleaxe.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Broadsword.md
+++ b/world/weapons/legendary-weapons/Legendary Broadsword.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Crossbow.md
+++ b/world/weapons/legendary-weapons/Legendary Crossbow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Cutlass.md
+++ b/world/weapons/legendary-weapons/Legendary Cutlass.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Dagger.md
+++ b/world/weapons/legendary-weapons/Legendary Dagger.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Dualstaff.md
+++ b/world/weapons/legendary-weapons/Legendary Dualstaff.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Glowing Rings.md
+++ b/world/weapons/legendary-weapons/Legendary Glowing Rings.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Grappler.md
+++ b/world/weapons/legendary-weapons/Legendary Grappler.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Close
+tier: 4
 ---
 
 **Tier 4:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Greatstaff.md
+++ b/world/weapons/legendary-weapons/Legendary Greatstaff.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Far
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Greatsword.md
+++ b/world/weapons/legendary-weapons/Legendary Greatsword.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Halberd.md
+++ b/world/weapons/legendary-weapons/Legendary Halberd.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Hallowed Axe.md
+++ b/world/weapons/legendary-weapons/Legendary Hallowed Axe.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Hand Crossbow.md
+++ b/world/weapons/legendary-weapons/Legendary Hand Crossbow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 4
 ---
 
 **Tier 4:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Hand Runes.md
+++ b/world/weapons/legendary-weapons/Legendary Hand Runes.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Longbow.md
+++ b/world/weapons/legendary-weapons/Legendary Longbow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Far
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Longsword.md
+++ b/world/weapons/legendary-weapons/Legendary Longsword.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Mace.md
+++ b/world/weapons/legendary-weapons/Legendary Mace.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Quarterstaff.md
+++ b/world/weapons/legendary-weapons/Legendary Quarterstaff.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Rapier.md
+++ b/world/weapons/legendary-weapons/Legendary Rapier.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Returning Blade.md
+++ b/world/weapons/legendary-weapons/Legendary Returning Blade.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Close
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Round Shield.md
+++ b/world/weapons/legendary-weapons/Legendary Round Shield.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Scepter.md
+++ b/world/weapons/legendary-weapons/Legendary Scepter.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Shortbow.md
+++ b/world/weapons/legendary-weapons/Legendary Shortbow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Shortstaff.md
+++ b/world/weapons/legendary-weapons/Legendary Shortstaff.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Close
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Shortsword.md
+++ b/world/weapons/legendary-weapons/Legendary Shortsword.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Small Dagger.md
+++ b/world/weapons/legendary-weapons/Legendary Small Dagger.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Spear.md
+++ b/world/weapons/legendary-weapons/Legendary Spear.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Tower Shield.md
+++ b/world/weapons/legendary-weapons/Legendary Tower Shield.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Wand.md
+++ b/world/weapons/legendary-weapons/Legendary Wand.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Warhammer.md
+++ b/world/weapons/legendary-weapons/Legendary Warhammer.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/legendary-weapons/Legendary Whip.md
+++ b/world/weapons/legendary-weapons/Legendary Whip.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 4
 ---
 
 **Tier 4:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/magical-weapons/Arcane Gauntlets.md
+++ b/world/weapons/magical-weapons/Arcane Gauntlets.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Axe of Fortunis.md
+++ b/world/weapons/magical-weapons/Axe of Fortunis.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Blessed Anlace.md
+++ b/world/weapons/magical-weapons/Blessed Anlace.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Bloodstaff.md
+++ b/world/weapons/magical-weapons/Bloodstaff.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Casting Sword.md
+++ b/world/weapons/magical-weapons/Casting Sword.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Devouring Dagger.md
+++ b/world/weapons/magical-weapons/Devouring Dagger.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Dualstaff.md
+++ b/world/weapons/magical-weapons/Dualstaff.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Ego Blade.md
+++ b/world/weapons/magical-weapons/Ego Blade.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Elder Bow.md
+++ b/world/weapons/magical-weapons/Elder Bow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Firestaff.md
+++ b/world/weapons/magical-weapons/Firestaff.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Floating Bladeshards.md
+++ b/world/weapons/magical-weapons/Floating Bladeshards.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Close
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Fusion Gloves.md
+++ b/world/weapons/magical-weapons/Fusion Gloves.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Far
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Ghostblade.md
+++ b/world/weapons/magical-weapons/Ghostblade.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Gilded Bow.md
+++ b/world/weapons/magical-weapons/Gilded Bow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Glowing Rings.md
+++ b/world/weapons/magical-weapons/Glowing Rings.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Greatstaff.md
+++ b/world/weapons/magical-weapons/Greatstaff.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Far
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Hallowed Axe.md
+++ b/world/weapons/magical-weapons/Hallowed Axe.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Hammer of Exota.md
+++ b/world/weapons/magical-weapons/Hammer of Exota.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Hand Runes.md
+++ b/world/weapons/magical-weapons/Hand Runes.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Ilmaris Rifle.md
+++ b/world/weapons/magical-weapons/Ilmaris Rifle.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Far
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Keepers Staff.md
+++ b/world/weapons/magical-weapons/Keepers Staff.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Mage Orb.md
+++ b/world/weapons/magical-weapons/Mage Orb.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Magus Revolver.md
+++ b/world/weapons/magical-weapons/Magus Revolver.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Far
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Midas Scythe.md
+++ b/world/weapons/magical-weapons/Midas Scythe.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Quarterstaff.md
+++ b/world/weapons/magical-weapons/Quarterstaff.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/magical-weapons/Returning Blade.md
+++ b/world/weapons/magical-weapons/Returning Blade.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Close
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Runes of Ruination.md
+++ b/world/weapons/magical-weapons/Runes of Ruination.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Scepter of Elias.md
+++ b/world/weapons/magical-weapons/Scepter of Elias.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Scepter.md
+++ b/world/weapons/magical-weapons/Scepter.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Shortstaff.md
+++ b/world/weapons/magical-weapons/Shortstaff.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Close
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Siphoning Gauntlets.md
+++ b/world/weapons/magical-weapons/Siphoning Gauntlets.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Sword of Light and Flame.md
+++ b/world/weapons/magical-weapons/Sword of Light and Flame.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Thistlebow.md
+++ b/world/weapons/magical-weapons/Thistlebow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Wand of Enthrallment.md
+++ b/world/weapons/magical-weapons/Wand of Enthrallment.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Wand of Essek.md
+++ b/world/weapons/magical-weapons/Wand of Essek.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Wand.md
+++ b/world/weapons/magical-weapons/Wand.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 1
 ---
 
 **Tier 1:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Widogast Pendant.md
+++ b/world/weapons/magical-weapons/Widogast Pendant.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Close
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/magical-weapons/Yutari Bloodbow.md
+++ b/world/weapons/magical-weapons/Yutari Bloodbow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Magical_ _Weapon_

--- a/world/weapons/powder-weapons/Black Powder Revolver.md
+++ b/world/weapons/powder-weapons/Black Powder Revolver.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/powder-weapons/Blunderbuss.md
+++ b/world/weapons/powder-weapons/Blunderbuss.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Close
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/powder-weapons/Hand Cannon.md
+++ b/world/weapons/powder-weapons/Hand Cannon.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Far
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/speacial-weapons/Aantari Bow.md
+++ b/world/weapons/speacial-weapons/Aantari Bow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Far
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/speacial-weapons/Braveshield.md
+++ b/world/weapons/speacial-weapons/Braveshield.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Secondary_ _Physical_ _Weapon_

--- a/world/weapons/speacial-weapons/Bravesword.md
+++ b/world/weapons/speacial-weapons/Bravesword.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/speacial-weapons/Finehair Bow.md
+++ b/world/weapons/speacial-weapons/Finehair Bow.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Far
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/speacial-weapons/Flickerfly Blade.md
+++ b/world/weapons/speacial-weapons/Flickerfly Blade.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/speacial-weapons/Gilded Falchion.md
+++ b/world/weapons/speacial-weapons/Gilded Falchion.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/speacial-weapons/Hammer of Wrath.md
+++ b/world/weapons/speacial-weapons/Hammer of Wrath.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/speacial-weapons/Impact Gauntlet.md
+++ b/world/weapons/speacial-weapons/Impact Gauntlet.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 4
 ---
 
 **Tier 4:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/speacial-weapons/Labrys Axe.md
+++ b/world/weapons/speacial-weapons/Labrys Axe.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 3
 ---
 
 **Tier 3:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/speacial-weapons/Steelforged Halberd.md
+++ b/world/weapons/speacial-weapons/Steelforged Halberd.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Very Close
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_

--- a/world/weapons/speacial-weapons/Urok Broadsword.md
+++ b/world/weapons/speacial-weapons/Urok Broadsword.md
@@ -10,6 +10,7 @@ banner_right: Weapon
 created: 2026-04-15
 last_updated: 2026-04-15
 range: Melee
+tier: 2
 ---
 
 **Tier 2:** Primary_ _Physical_ _Weapon_


### PR DESCRIPTION
Adds `tier: N` (integer 1–4) to YAML frontmatter of all 192 weapon .md files across all subdirectories (base, advanced, improved, legendary, magical, powder, speacial). Extracted from body text `**Tier N:**`.

- utilities/world/migrate_weapon_tier.py: one-shot migration script (rglob, idempotent, --dry-run) — delete after merge
- generate_all_world_html.py: add 'tier' field to doc dict in generate_all() alongside 'range' (empty string default for non-weapons)
- world/weapons/**/*.md (192 files): tier: 1/2/3/4 added to frontmatter

Counts: tier 1 × 32, tier 2 × 53, tier 3 × 54, tier 4 × 53

https://claude.ai/code/session_01KxUPGmLbF9VKhAXAR6uYWd