### PR TITLE
feat(content): add tier:/level: frontmatter to classes, armor, and ab…

### DIFF
--- a/utilities/world/migrate_numeric_field.py
+++ b/utilities/world/migrate_numeric_field.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+ONE-SHOT MIGRATION SCRIPT — DELETE AFTER USE.
+
+Adds a numeric frontmatter field (e.g. `tier: 3` or `level: 7`) to .md files
+by extracting the value from a body pattern like `**_Tier 3_**` or `**_Level 7_**`.
+
+Usage examples:
+    # Add tier: to all classes and armor files
+    python migrate_numeric_field.py --field tier --dir world/classes world/armor
+
+    # Add level: to all abilities files
+    python migrate_numeric_field.py --field level --dir world/abilities
+
+    # Dry run
+    python migrate_numeric_field.py --field tier --dir world/classes --dry-run
+"""
+import argparse
+import re
+from pathlib import Path
+
+
+def migrate_dir(vault: Path, directory: Path, field: str, dry_run: bool) -> dict:
+    files = sorted(f for f in directory.rglob('*.md') if f.name != '_category.md')
+    counts = {'total': 0, 'migrated': 0, 'already_done': 0, 'not_found': 0}
+
+    pattern = re.compile(r'\*\*_?' + re.escape(field.title()) + r'\s+(\d+)', re.IGNORECASE)
+
+    for path in files:
+        counts['total'] += 1
+        text = path.read_text(encoding='utf-8')
+
+        parts = text.split('---\n', 2)
+        has_frontmatter = len(parts) == 3
+
+        if has_frontmatter:
+            fm_block = parts[1]
+            if re.search(rf'^{re.escape(field)}:', fm_block, re.MULTILINE):
+                counts['already_done'] += 1
+                continue
+            body = parts[2]
+        else:
+            fm_block = None
+            body = text
+
+        m = pattern.search(body)
+        if not m:
+            print(f'  WARNING (no {field.title()} found): {path.relative_to(vault)}')
+            counts['not_found'] += 1
+            continue
+
+        value = int(m.group(1))
+        if has_frontmatter:
+            new_fm = fm_block.rstrip('\n') + f'\n{field}: {value}\n'
+            new_text = f'---\n{new_fm}---\n{body}'
+        else:
+            new_text = f'---\n{field}: {value}\n---\n{body}'
+
+        rel = path.relative_to(vault)
+        if dry_run:
+            print(f'  DRY-RUN: {rel}  →  {field}: {value}')
+        else:
+            path.write_text(new_text, encoding='utf-8')
+        counts['migrated'] += 1
+
+    return counts
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='ONE-SHOT: add a numeric field to .md frontmatter')
+    parser.add_argument('--field', required=True, help='Frontmatter field name (e.g. tier, level)')
+    parser.add_argument('--dir', nargs='+', required=True, help='Directories relative to vault root')
+    parser.add_argument('--dry-run', action='store_true')
+    parser.add_argument('--vault', default=None)
+    args = parser.parse_args()
+
+    vault = Path(args.vault) if args.vault else Path(__file__).parent.parent.parent
+
+    totals = {'total': 0, 'migrated': 0, 'already_done': 0, 'not_found': 0}
+    for d in args.dir:
+        directory = vault / d
+        if not directory.exists():
+            print(f'  SKIP (directory not found): {d}')
+            continue
+        print(f'\n[{d}]')
+        counts = migrate_dir(vault, directory, args.field, args.dry_run)
+        for k in totals:
+            totals[k] += counts[k]
+
+    print(f'\nTotal: {totals["total"]} files — '
+          f'migrated={totals["migrated"]} already-done={totals["already_done"]} '
+          f'not-found={totals["not_found"]}')
+
+
+if __name__ == '__main__':
+    main()

--- a/world/abilities/A Soldiers Bond.md
+++ b/world/abilities/A Soldiers Bond.md
@@ -1,3 +1,6 @@
+---
+level: 2
+---
 # A Soldier's Bond
 
 **_Level 2_** _Blade Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Adjust Reality.md
+++ b/world/abilities/Adjust Reality.md
@@ -1,3 +1,6 @@
+---
+level: 10
+---
 # Adjust Reality
 
 **_Level 10_** _Arcana Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Arcana-Touched.md
+++ b/world/abilities/Arcana-Touched.md
@@ -1,3 +1,6 @@
+---
+level: 7
+---
 # Arcana-Touched
 
 **_Level 7_** _Arcana Ability._ **_Recall Cost_** _2._

--- a/world/abilities/Arcane Reflection.md
+++ b/world/abilities/Arcane Reflection.md
@@ -1,3 +1,6 @@
+---
+level: 8
+---
 # Arcane Reflection
 
 **_Level 8_** _Arcana Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Armorer.md
+++ b/world/abilities/Armorer.md
@@ -1,3 +1,6 @@
+---
+level: 5
+---
 # Armorer
 
 **_Level 5_** _Valor Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Astral Projection.md
+++ b/world/abilities/Astral Projection.md
@@ -1,3 +1,6 @@
+---
+level: 8
+---
 # Astral Projection
 
 **_Level 8_** _Grace Spell._ **_Recall Cost_** _0._

--- a/world/abilities/Banish.md
+++ b/world/abilities/Banish.md
@@ -1,3 +1,6 @@
+---
+level: 6
+---
 # Banish
 
 **_Level 6_** _Codex Spell._ **_Recall Cost_** _0._

--- a/world/abilities/Bare Bones.md
+++ b/world/abilities/Bare Bones.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Bare Bones
 
 **_Level 1_** _Valor Ability._ **_Recall Cost_** _0._

--- a/world/abilities/Battle Cry.md
+++ b/world/abilities/Battle Cry.md
@@ -1,3 +1,6 @@
+---
+level: 8
+---
 # Battle Cry
 
 **_Level 8_** _Blade Ability._ **_Recall Cost_** _2._

--- a/world/abilities/Battle Monster.md
+++ b/world/abilities/Battle Monster.md
@@ -1,3 +1,6 @@
+---
+level: 10
+---
 # Battle Monster
 
 **_Level 10_** _Blade Ability._ **_Recall Cost_** _0._

--- a/world/abilities/Battle-Hardened.md
+++ b/world/abilities/Battle-Hardened.md
@@ -1,3 +1,6 @@
+---
+level: 6
+---
 # Battle-Hardened
 
 **_Level 6_** _Blade Ability._ **_Recall Cost_** _2._

--- a/world/abilities/Blade-Touched.md
+++ b/world/abilities/Blade-Touched.md
@@ -1,3 +1,6 @@
+---
+level: 7
+---
 # Blade-Touched
 
 **_Level 7_** _Blade Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Blink Out.md
+++ b/world/abilities/Blink Out.md
@@ -1,3 +1,6 @@
+---
+level: 4
+---
 # Blink Out
 
 **_Level 4_** _Arcana Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Body Basher.md
+++ b/world/abilities/Body Basher.md
@@ -1,3 +1,6 @@
+---
+level: 2
+---
 # Body Basher
 
 **_Level 2_** _Valor Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Bold Presence.md
+++ b/world/abilities/Bold Presence.md
@@ -1,3 +1,6 @@
+---
+level: 2
+---
 # Bold Presence
 
 **_Level 2_** _Valor Ability._ **_Recall Cost_** _0._

--- a/world/abilities/Bolt Beacon.md
+++ b/world/abilities/Bolt Beacon.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Bolt Beacon
 
 **_Level 1_** _Splendor Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Bone-Touched.md
+++ b/world/abilities/Bone-Touched.md
@@ -1,3 +1,6 @@
+---
+level: 7
+---
 # Bone-Touched
 
 **_Level 7_** _Bone Ability._ **_Recall Cost_** _2._

--- a/world/abilities/Book of Ava.md
+++ b/world/abilities/Book of Ava.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Book of Ava
 
 **_Level 1_** _Codex Grimoire._ **_Recall Cost_** _2._

--- a/world/abilities/Book of Exota.md
+++ b/world/abilities/Book of Exota.md
@@ -1,3 +1,6 @@
+---
+level: 4
+---
 # Book of Exota
 
 **_Level 4_** _Codex Grimoire._ **_Recall Cost_** _3._

--- a/world/abilities/Book of Grynn.md
+++ b/world/abilities/Book of Grynn.md
@@ -1,3 +1,6 @@
+---
+level: 4
+---
 # Book of Grynn
 
 **_Level 4_** _Codex Grimoire._ **_Recall Cost_** _2._

--- a/world/abilities/Book of Homet.md
+++ b/world/abilities/Book of Homet.md
@@ -1,3 +1,6 @@
+---
+level: 7
+---
 # Book of Homet
 
 **_Level 7_** _Codex Grimoire._ **_Recall Cost_** _0._

--- a/world/abilities/Book of Illiat.md
+++ b/world/abilities/Book of Illiat.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Book of Illiat
 
 **_Level 1_** _Codex Grimoire._ **_Recall Cost_** _2._

--- a/world/abilities/Book of Korvax.md
+++ b/world/abilities/Book of Korvax.md
@@ -1,3 +1,6 @@
+---
+level: 3
+---
 # Book of Korvax
 
 **_Level 3_** _Codex Grimoire._ **_Recall Cost_** _2._

--- a/world/abilities/Book of Norai.md
+++ b/world/abilities/Book of Norai.md
@@ -1,3 +1,6 @@
+---
+level: 3
+---
 # Book of Norai
 
 **_Level 3_** _Codex Grimoire._ **_Recall Cost_** _2._

--- a/world/abilities/Book of Ronin.md
+++ b/world/abilities/Book of Ronin.md
@@ -1,3 +1,6 @@
+---
+level: 9
+---
 # Book of Ronin
 
 **_Level 9_** _Codex Grimoire._ **_Recall Cost_** _4._

--- a/world/abilities/Book of Sitil.md
+++ b/world/abilities/Book of Sitil.md
@@ -1,3 +1,6 @@
+---
+level: 2
+---
 # Book of Sitil
 
 **_Level 2_** _Codex Grimoire._ **_Recall Cost_** _2._

--- a/world/abilities/Book of Tyfar.md
+++ b/world/abilities/Book of Tyfar.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Book of Tyfar
 
 **_Level 1_** _Codex Grimoire._ **_Recall Cost_** _2._

--- a/world/abilities/Book of Vagras.md
+++ b/world/abilities/Book of Vagras.md
@@ -1,3 +1,6 @@
+---
+level: 2
+---
 # Book of Vagras
 
 **_Level 2_** _Codex Grimoire._ **_Recall Cost_** _2._

--- a/world/abilities/Book of Vyola.md
+++ b/world/abilities/Book of Vyola.md
@@ -1,3 +1,6 @@
+---
+level: 8
+---
 # Book of Vyola
 
 **_Level 8_** _Codex Grimoire._ **_Recall Cost_** _2._

--- a/world/abilities/Book of Yarrow.md
+++ b/world/abilities/Book of Yarrow.md
@@ -1,3 +1,6 @@
+---
+level: 10
+---
 # Book of Yarrow
 
 **_Level 10_** _Codex Grimoire._ **_Recall Cost_** _2._

--- a/world/abilities/Boost.md
+++ b/world/abilities/Boost.md
@@ -1,3 +1,6 @@
+---
+level: 4
+---
 # Boost
 
 **_Level 4_** _Bone Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Brace.md
+++ b/world/abilities/Brace.md
@@ -1,3 +1,6 @@
+---
+level: 3
+---
 # Brace
 
 **_Level 3_** _Bone Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Breaking Blow.md
+++ b/world/abilities/Breaking Blow.md
@@ -1,3 +1,6 @@
+---
+level: 8
+---
 # Breaking Blow
 
 **_Level 8_** _Bone Ability._ **_Recall Cost_** _3._

--- a/world/abilities/Chain Lightning.md
+++ b/world/abilities/Chain Lightning.md
@@ -1,3 +1,6 @@
+---
+level: 5
+---
 # Chain Lightning
 
 **_Level 5_** _Arcana Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Champions Edge.md
+++ b/world/abilities/Champions Edge.md
@@ -1,3 +1,6 @@
+---
+level: 5
+---
 # Champion's Edge
 
 **_Level 5_** _Blade Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Chokehold.md
+++ b/world/abilities/Chokehold.md
@@ -1,3 +1,6 @@
+---
+level: 3
+---
 # Chokehold
 
 **_Level 3_** _Midnight Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Cinder Grasp.md
+++ b/world/abilities/Cinder Grasp.md
@@ -1,3 +1,6 @@
+---
+level: 2
+---
 # Cinder Grasp
 
 **_Level 2_** _Arcana Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Cloaking Blast.md
+++ b/world/abilities/Cloaking Blast.md
@@ -1,3 +1,6 @@
+---
+level: 7
+---
 # Cloaking Blast
 
 **_Level 7_** _Arcana Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Codex-Touched.md
+++ b/world/abilities/Codex-Touched.md
@@ -1,3 +1,6 @@
+---
+level: 7
+---
 # Codex-Touched
 
 **_Level 7_** _Codex Ability._ **_Recall Cost_** _2._

--- a/world/abilities/Confusing Aura.md
+++ b/world/abilities/Confusing Aura.md
@@ -1,3 +1,6 @@
+---
+level: 8
+---
 # Confusing Aura
 
 **_Level 8_** _Arcana Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Conjure Swarm.md
+++ b/world/abilities/Conjure Swarm.md
@@ -1,3 +1,6 @@
+---
+level: 2
+---
 # Conjure Swarm
 
 **_Level 2_** _Sage Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Conjured Steeds.md
+++ b/world/abilities/Conjured Steeds.md
@@ -1,3 +1,6 @@
+---
+level: 6
+---
 # Conjured Steeds
 
 **_Level 6_** _Sage Spell._ **_Recall Cost_** _0._

--- a/world/abilities/Copycat.md
+++ b/world/abilities/Copycat.md
@@ -1,3 +1,6 @@
+---
+level: 9
+---
 # Copycat
 
 **_Level 9_** _Grace Spell._ **_Recall Cost_** _3._

--- a/world/abilities/Corrosive Projectile.md
+++ b/world/abilities/Corrosive Projectile.md
@@ -1,3 +1,6 @@
+---
+level: 3
+---
 # Corrosive Projectile
 
 **_Level 3_** _Sage Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Counterspell.md
+++ b/world/abilities/Counterspell.md
@@ -1,3 +1,6 @@
+---
+level: 3
+---
 # Counterspell
 
 **_Level 3_** _Arcana Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Critical Inspiration.md
+++ b/world/abilities/Critical Inspiration.md
@@ -1,3 +1,6 @@
+---
+level: 3
+---
 # Critical Inspiration
 
 **_Level 3_** _Valor Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Cruel Precision.md
+++ b/world/abilities/Cruel Precision.md
@@ -1,3 +1,6 @@
+---
+level: 7
+---
 # Cruel Precision
 
 **_Level 7_** _Bone Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Dark Whispers.md
+++ b/world/abilities/Dark Whispers.md
@@ -1,3 +1,6 @@
+---
+level: 6
+---
 # Dark Whispers
 
 **_Level 6_** _Midnight Spell._ **_Recall Cost_** _0._

--- a/world/abilities/Deadly Focus.md
+++ b/world/abilities/Deadly Focus.md
@@ -1,3 +1,6 @@
+---
+level: 4
+---
 # Deadly Focus
 
 **_Level 4_** _Blade Ability._ **_Recall Cost_** _2._

--- a/world/abilities/Death Grip.md
+++ b/world/abilities/Death Grip.md
@@ -1,3 +1,6 @@
+---
+level: 4
+---
 # Death Grip
 
 **_Level 4_** _Sage Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Deathrun.md
+++ b/world/abilities/Deathrun.md
@@ -1,3 +1,6 @@
+---
+level: 10
+---
 # Deathrun
 
 **_Level 10_** _Bone Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Deft Deceiver.md
+++ b/world/abilities/Deft Deceiver.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Deft Deceiver
 
 **_Level 1_** _Grace Ability._ **_Recall Cost_** _0._

--- a/world/abilities/Deft Maneuvers.md
+++ b/world/abilities/Deft Maneuvers.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Deft Maneuvers
 
 **_Level 1_** _Bone Ability._ **_Recall Cost_** _0._

--- a/world/abilities/Disintegration Wave.md
+++ b/world/abilities/Disintegration Wave.md
@@ -1,3 +1,6 @@
+---
+level: 9
+---
 # Disintegration Wave
 
 **_Level 9_** _Codex Spell._ **_Recall Cost_** _4._

--- a/world/abilities/Divination.md
+++ b/world/abilities/Divination.md
@@ -1,3 +1,6 @@
+---
+level: 4
+---
 # Divination
 
 **_Level 4_** _Splendor Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Earthquake.md
+++ b/world/abilities/Earthquake.md
@@ -1,3 +1,6 @@
+---
+level: 9
+---
 # Earthquake
 
 **_Level 9_** _Arcana Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Eclipse.md
+++ b/world/abilities/Eclipse.md
@@ -1,3 +1,6 @@
+---
+level: 10
+---
 # Eclipse
 
 **_Level 10_** _Midnight Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Encore.md
+++ b/world/abilities/Encore.md
@@ -1,3 +1,6 @@
+---
+level: 10
+---
 # Encore
 
 **_Level 10_** _Grace Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Endless Charisma.md
+++ b/world/abilities/Endless Charisma.md
@@ -1,3 +1,6 @@
+---
+level: 7
+---
 # Endless Charisma
 
 **_Level 7_** _Grace Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Enrapture.md
+++ b/world/abilities/Enrapture.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Enrapture
 
 **_Level 1_** _Grace Spell._ **_Recall Cost_** _0._

--- a/world/abilities/Falling Sky.md
+++ b/world/abilities/Falling Sky.md
@@ -1,3 +1,6 @@
+---
+level: 10
+---
 # Falling Sky
 
 **_Level 10_** _Arcana Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Fane of the Wilds.md
+++ b/world/abilities/Fane of the Wilds.md
@@ -1,3 +1,6 @@
+---
+level: 9
+---
 # Fane of the Wilds
 
 **_Level 9_** _Sage Ability._ **_Recall Cost_** _2._

--- a/world/abilities/Ferocity.md
+++ b/world/abilities/Ferocity.md
@@ -1,3 +1,6 @@
+---
+level: 2
+---
 # Ferocity
 
 **_Level 2_** _Bone Ability._ **_Recall Cost_** _2._

--- a/world/abilities/Final Words.md
+++ b/world/abilities/Final Words.md
@@ -1,3 +1,6 @@
+---
+level: 2
+---
 # Final Words
 
 **_Level 2_** _Splendor Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Flight.md
+++ b/world/abilities/Flight.md
@@ -1,3 +1,6 @@
+---
+level: 3
+---
 # Flight
 
 **_Level 3_** _Arcana Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Floating Eye.md
+++ b/world/abilities/Floating Eye.md
@@ -1,3 +1,6 @@
+---
+level: 2
+---
 # Floating Eye
 
 **_Level 2_** _Arcana Spell._ **_Recall Cost_** _0._

--- a/world/abilities/Forager.md
+++ b/world/abilities/Forager.md
@@ -1,3 +1,6 @@
+---
+level: 6
+---
 # Forager
 
 **_Level 6_** _Sage Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Force of Nature.md
+++ b/world/abilities/Force of Nature.md
@@ -1,3 +1,6 @@
+---
+level: 10
+---
 # Force of Nature
 
 **_Level 10_** _Sage Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Forceful Push.md
+++ b/world/abilities/Forceful Push.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Forceful Push
 
 **_Level 1_** _Valor Ability._ **_Recall Cost_** _0._

--- a/world/abilities/Forest Sprites.md
+++ b/world/abilities/Forest Sprites.md
@@ -1,3 +1,6 @@
+---
+level: 8
+---
 # Forest Sprites
 
 **_Level 8_** _Sage Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Fortified Armor.md
+++ b/world/abilities/Fortified Armor.md
@@ -1,3 +1,6 @@
+---
+level: 4
+---
 # Fortified Armor
 
 **_Level 4_** _Blade Ability._ **_Recall Cost_** _0._

--- a/world/abilities/Frenzy.md
+++ b/world/abilities/Frenzy.md
@@ -1,3 +1,6 @@
+---
+level: 8
+---
 # Frenzy
 
 **_Level 8_** _Blade Ability._ **_Recall Cost_** _3._

--- a/world/abilities/Full Surge.md
+++ b/world/abilities/Full Surge.md
@@ -1,3 +1,6 @@
+---
+level: 8
+---
 # Full Surge
 
 **_Level 8_** _Valor Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Get Back Up.md
+++ b/world/abilities/Get Back Up.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Get Back Up
 
 **_Level 1_** _Blade Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Gifted Tracker.md
+++ b/world/abilities/Gifted Tracker.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Gifted Tracker
 
 **_Level 1_** _Sage Ability._ **_Recall Cost_** _0._

--- a/world/abilities/Glancing Blow.md
+++ b/world/abilities/Glancing Blow.md
@@ -1,3 +1,6 @@
+---
+level: 7
+---
 # Glancing Blow
 
 **_Level 7_** _Blade Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Glyph of Nightfall.md
+++ b/world/abilities/Glyph of Nightfall.md
@@ -1,3 +1,6 @@
+---
+level: 4
+---
 # Glyph of Nightfall
 
 **_Level 4_** _Midnight Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Goad Them On.md
+++ b/world/abilities/Goad Them On.md
@@ -1,3 +1,6 @@
+---
+level: 4
+---
 # Goad Them on
 
 **_Level 4_** _Valor Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Gore and Glory.md
+++ b/world/abilities/Gore and Glory.md
@@ -1,3 +1,6 @@
+---
+level: 9
+---
 # Gore and Glory
 
 **_Level 9_** _Blade Ability._ **_Recall Cost_** _2._

--- a/world/abilities/Grace-Touched.md
+++ b/world/abilities/Grace-Touched.md
@@ -1,3 +1,6 @@
+---
+level: 7
+---
 # Grace-Touched
 
 **_Level 7_** _Grace Ability._ **_Recall Cost_** _2._

--- a/world/abilities/Ground Pound.md
+++ b/world/abilities/Ground Pound.md
@@ -1,3 +1,6 @@
+---
+level: 8
+---
 # Ground Pound
 
 **_Level 8_** _Valor Ability._ **_Recall Cost_** _2._

--- a/world/abilities/Healing Field.md
+++ b/world/abilities/Healing Field.md
@@ -1,3 +1,6 @@
+---
+level: 4
+---
 # Healing Field
 
 **_Level 4_** _Sage Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Healing Hands.md
+++ b/world/abilities/Healing Hands.md
@@ -1,3 +1,6 @@
+---
+level: 2
+---
 # Healing Hands
 
 **_Level 2_** _Splendor Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Healing Strike.md
+++ b/world/abilities/Healing Strike.md
@@ -1,3 +1,6 @@
+---
+level: 7
+---
 # Healing Strike
 
 **_Level 7_** _Splendor Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Hold the Line.md
+++ b/world/abilities/Hold the Line.md
@@ -1,3 +1,6 @@
+---
+level: 9
+---
 # Hold the Line
 
 **_Level 9_** _Valor Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Hush.md
+++ b/world/abilities/Hush.md
@@ -1,3 +1,6 @@
+---
+level: 5
+---
 # Hush
 
 **_Level 5_** _Midnight Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Hypnotic Shimmer.md
+++ b/world/abilities/Hypnotic Shimmer.md
@@ -1,3 +1,6 @@
+---
+level: 3
+---
 # Hypnotic Shimmer
 
 **_Level 3_** _Grace Spell._ **_Recall Cost_** _1._

--- a/world/abilities/I Am Your Shield.md
+++ b/world/abilities/I Am Your Shield.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # I Am Your Shield
 
 **_Level 1_** _Valor Ability._ **_Recall Cost_** _1._

--- a/world/abilities/I See It Coming.md
+++ b/world/abilities/I See It Coming.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # I See It Coming
 
 **_Level 1_** _Bone Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Inevitable.md
+++ b/world/abilities/Inevitable.md
@@ -1,3 +1,6 @@
+---
+level: 6
+---
 # Inevitable
 
 **_Level 6_** _Valor Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Inspirational Words.md
+++ b/world/abilities/Inspirational Words.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Inspirational Words
 
 **_Level 1_** _Grace Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Invigoration.md
+++ b/world/abilities/Invigoration.md
@@ -1,3 +1,6 @@
+---
+level: 10
+---
 # Invigoration
 
 **_Level 10_** _Splendor Spell._ **_Recall Cost_** _3._

--- a/world/abilities/Invisibility.md
+++ b/world/abilities/Invisibility.md
@@ -1,3 +1,6 @@
+---
+level: 3
+---
 # Invisibility
 
 **_Level 3_** _Grace Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Know Thy Enemy.md
+++ b/world/abilities/Know Thy Enemy.md
@@ -1,3 +1,6 @@
+---
+level: 5
+---
 # Know Thy Enemy
 
 **_Level 5_** _Bone Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Lead by Example.md
+++ b/world/abilities/Lead by Example.md
@@ -1,3 +1,6 @@
+---
+level: 9
+---
 # Lead by Example
 
 **_Level 9_** _Valor Ability._ **_Recall Cost_** _3._

--- a/world/abilities/Lean on Me.md
+++ b/world/abilities/Lean on Me.md
@@ -1,3 +1,6 @@
+---
+level: 3
+---
 # Lean on Me
 
 **_Level 3_** _Valor Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Life Ward.md
+++ b/world/abilities/Life Ward.md
@@ -1,3 +1,6 @@
+---
+level: 4
+---
 # Life Ward
 
 **_Level 4_** _Splendor Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Manifest Wall.md
+++ b/world/abilities/Manifest Wall.md
@@ -1,3 +1,6 @@
+---
+level: 5
+---
 # Manifest Wall
 
 **_Level 5_** _Codex Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Mass Disguise.md
+++ b/world/abilities/Mass Disguise.md
@@ -1,3 +1,6 @@
+---
+level: 6
+---
 # Mass Disguise
 
 **_Level 6_** _Midnight Spell._ **_Recall Cost_** _0._

--- a/world/abilities/Mass Enrapture.md
+++ b/world/abilities/Mass Enrapture.md
@@ -1,3 +1,6 @@
+---
+level: 8
+---
 # Mass Enrapture
 
 **_Level 8_** _Grace Spell._ **_Recall Cost_** _3._

--- a/world/abilities/Master of the Craft.md
+++ b/world/abilities/Master of the Craft.md
@@ -1,3 +1,6 @@
+---
+level: 9
+---
 # Master of the Craft
 
 **_Level 9_** _Grace Ability._ **_Recall Cost_** _0._

--- a/world/abilities/Mending Touch.md
+++ b/world/abilities/Mending Touch.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Mending Touch
 
 **_Level 1_** _Splendor Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Midnight Spirit.md
+++ b/world/abilities/Midnight Spirit.md
@@ -1,3 +1,6 @@
+---
+level: 2
+---
 # Midnight Spirit
 
 **_Level 2_** _Midnight Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Midnight-Touched.md
+++ b/world/abilities/Midnight-Touched.md
@@ -1,3 +1,6 @@
+---
+level: 7
+---
 # Midnight-Touched
 
 **_Level 7_** _Midnight Ability._ **_Recall Cost_** _2._

--- a/world/abilities/Natural Familiar.md
+++ b/world/abilities/Natural Familiar.md
@@ -1,3 +1,6 @@
+---
+level: 2
+---
 # Natural Familiar
 
 **_Level 2_** _Sage Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Natures Tongue.md
+++ b/world/abilities/Natures Tongue.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Nature's Tongue
 
 **_Level 1_** _Sage Ability._ **_Recall Cost_** _0._

--- a/world/abilities/Never Upstaged.md
+++ b/world/abilities/Never Upstaged.md
@@ -1,3 +1,6 @@
+---
+level: 6
+---
 # Never Upstaged
 
 **_Level 6_** _Grace Ability._ **_Recall Cost_** _2._

--- a/world/abilities/Night Terror.md
+++ b/world/abilities/Night Terror.md
@@ -1,3 +1,6 @@
+---
+level: 9
+---
 # Night Terror
 
 **_Level 9_** _Midnight Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Not Good Enough.md
+++ b/world/abilities/Not Good Enough.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Not Good Enough
 
 **_Level 1_** _Blade Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Notorious.md
+++ b/world/abilities/Notorious.md
@@ -1,3 +1,6 @@
+---
+level: 10
+---
 # Notorious
 
 **_Level 10_** _Grace Ability._ **_Recall Cost_** _0._

--- a/world/abilities/On the Brink.md
+++ b/world/abilities/On the Brink.md
@@ -1,3 +1,6 @@
+---
+level: 9
+---
 # On the Brink
 
 **_Level 9_** _Bone Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Onslaught.md
+++ b/world/abilities/Onslaught.md
@@ -1,3 +1,6 @@
+---
+level: 10
+---
 # Onslaught
 
 **_Level 10_** _Blade Ability._ **_Recall Cost_** _3._

--- a/world/abilities/Overwhelming Aura.md
+++ b/world/abilities/Overwhelming Aura.md
@@ -1,3 +1,6 @@
+---
+level: 9
+---
 # Overwhelming Aura
 
 **_Level 9_** _Splendor Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Phantom Retreat.md
+++ b/world/abilities/Phantom Retreat.md
@@ -1,3 +1,6 @@
+---
+level: 5
+---
 # Phantom Retreat
 
 **_Level 5_** _Midnight Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Pick and Pull.md
+++ b/world/abilities/Pick and Pull.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Pick and Pull
 
 **_Level 1_** _Midnight Ability._ **_Recall Cost_** _0._

--- a/world/abilities/Plant Dominion.md
+++ b/world/abilities/Plant Dominion.md
@@ -1,3 +1,6 @@
+---
+level: 9
+---
 # Plant Dominion
 
 **_Level 9_** _Sage Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Premonition.md
+++ b/world/abilities/Premonition.md
@@ -1,3 +1,6 @@
+---
+level: 5
+---
 # Premonition
 
 **_Level 5_** _Arcana Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Preservation Blast.md
+++ b/world/abilities/Preservation Blast.md
@@ -1,3 +1,6 @@
+---
+level: 4
+---
 # Preservation Blast
 
 **_Level 4_** _Arcana Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Rage Up.md
+++ b/world/abilities/Rage Up.md
@@ -1,3 +1,6 @@
+---
+level: 6
+---
 # Rage Up
 
 **_Level 6_** _Blade Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Rain of Blades.md
+++ b/world/abilities/Rain of Blades.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Rain of Blades
 
 **_Level 1_** _Midnight Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Rapid Riposte.md
+++ b/world/abilities/Rapid Riposte.md
@@ -1,3 +1,6 @@
+---
+level: 6
+---
 # Rapid Riposte
 
 **_Level 6_** _Bone Ability._ **_Recall Cost_** _0._

--- a/world/abilities/Reapers Strike.md
+++ b/world/abilities/Reapers Strike.md
@@ -1,3 +1,6 @@
+---
+level: 9
+---
 # Reaper's Strike
 
 **_Level 9_** _Blade Ability._ **_Recall Cost_** _3._

--- a/world/abilities/Reassurance.md
+++ b/world/abilities/Reassurance.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Reassurance
 
 **_Level 1_** _Splendor Ability._ **_Recall Cost_** _0._

--- a/world/abilities/Reckless.md
+++ b/world/abilities/Reckless.md
@@ -1,3 +1,6 @@
+---
+level: 2
+---
 # Reckless
 
 **_Level 2_** _Blade Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Recovery.md
+++ b/world/abilities/Recovery.md
@@ -1,3 +1,6 @@
+---
+level: 6
+---
 # Recovery
 
 **_Level 6_** _Bone Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Redirect.md
+++ b/world/abilities/Redirect.md
@@ -1,3 +1,6 @@
+---
+level: 4
+---
 # Redirect
 
 **_Level 4_** _Bone Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Rejuvenation Barrier.md
+++ b/world/abilities/Rejuvenation Barrier.md
@@ -1,3 +1,6 @@
+---
+level: 8
+---
 # Rejuvenation Barrier
 
 **_Level 8_** _Sage Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Restoration.md
+++ b/world/abilities/Restoration.md
@@ -1,3 +1,6 @@
+---
+level: 6
+---
 # Restoration
 
 **_Level 6_** _Splendor Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Resurrection.md
+++ b/world/abilities/Resurrection.md
@@ -1,3 +1,6 @@
+---
+level: 10
+---
 # Resurrection
 
 **_Level 10_** _Splendor Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Rift Walker.md
+++ b/world/abilities/Rift Walker.md
@@ -1,3 +1,6 @@
+---
+level: 6
+---
 # Rift Walker
 
 **_Level 6_** _Arcana Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Rise Up.md
+++ b/world/abilities/Rise Up.md
@@ -1,3 +1,6 @@
+---
+level: 6
+---
 # Rise Up
 
 **_Level 6_** _Valor Ability._ **_Recall Cost_** _2._

--- a/world/abilities/Rousing Strike.md
+++ b/world/abilities/Rousing Strike.md
@@ -1,3 +1,6 @@
+---
+level: 5
+---
 # Rousing Strike
 
 **_Level 5_** _Valor Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Rune Ward.md
+++ b/world/abilities/Rune Ward.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Rune Ward
 
 **_Level 1_** _Arcana Spell._ **_Recall Cost_** _0._

--- a/world/abilities/Safe Haven.md
+++ b/world/abilities/Safe Haven.md
@@ -1,3 +1,6 @@
+---
+level: 8
+---
 # Safe Haven
 
 **_Level 8_** _Codex Spell._ **_Recall Cost_** _3._

--- a/world/abilities/Sage-Touched.md
+++ b/world/abilities/Sage-Touched.md
@@ -1,3 +1,6 @@
+---
+level: 7
+---
 # Sage-Touched
 
 **_Level 7_** _Sage Ability._ **_Recall Cost_** _2._

--- a/world/abilities/Salvation Beam.md
+++ b/world/abilities/Salvation Beam.md
@@ -1,3 +1,6 @@
+---
+level: 9
+---
 # Salvation Beam
 
 **_Level 9_** _Splendor Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Scramble.md
+++ b/world/abilities/Scramble.md
@@ -1,3 +1,6 @@
+---
+level: 3
+---
 # Scramble
 
 **_Level 3_** _Blade Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Second Wind.md
+++ b/world/abilities/Second Wind.md
@@ -1,3 +1,6 @@
+---
+level: 3
+---
 # Second Wind
 
 **_Level 3_** _Splendor Ability._ **_Recall Cost_** _2._

--- a/world/abilities/Sensory Projection.md
+++ b/world/abilities/Sensory Projection.md
@@ -1,3 +1,6 @@
+---
+level: 9
+---
 # Sensory Projection
 
 **_Level 9_** _Arcana Spell._ **_Recall Cost_** _0._

--- a/world/abilities/Shadowbind.md
+++ b/world/abilities/Shadowbind.md
@@ -1,3 +1,6 @@
+---
+level: 2
+---
 # Shadowbind
 
 **_Level 2_** _Midnight Spell._ **_Recall Cost_** _0._

--- a/world/abilities/Shadowhunter.md
+++ b/world/abilities/Shadowhunter.md
@@ -1,3 +1,6 @@
+---
+level: 8
+---
 # Shadowhunter
 
 **_Level 8_** _Midnight Ability._ **_Recall Cost_** _2._

--- a/world/abilities/Shape Material.md
+++ b/world/abilities/Shape Material.md
@@ -1,3 +1,6 @@
+---
+level: 5
+---
 # Shape Material
 
 **_Level 5_** _Splendor Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Share the Burden.md
+++ b/world/abilities/Share the Burden.md
@@ -1,3 +1,6 @@
+---
+level: 6
+---
 # Share the Burden
 
 **_Level 6_** _Grace Spell._ **_Recall Cost_** _0._

--- a/world/abilities/Shield Aura.md
+++ b/world/abilities/Shield Aura.md
@@ -1,3 +1,6 @@
+---
+level: 8
+---
 # Shield Aura
 
 **_Level 8_** _Splendor Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Shrug It Off.md
+++ b/world/abilities/Shrug It Off.md
@@ -1,3 +1,6 @@
+---
+level: 7
+---
 # Shrug It Off
 
 **_Level 7_** _Valor Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Sigil of Retribution.md
+++ b/world/abilities/Sigil of Retribution.md
@@ -1,3 +1,6 @@
+---
+level: 6
+---
 # Sigil of Retribution
 
 **_Level 6_** _Codex Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Signature Move.md
+++ b/world/abilities/Signature Move.md
@@ -1,3 +1,6 @@
+---
+level: 5
+---
 # Signature Move
 
 **_Level 5_** _Bone Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Smite.md
+++ b/world/abilities/Smite.md
@@ -1,3 +1,6 @@
+---
+level: 5
+---
 # Smite
 
 **_Level 5_** _Splendor Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Soothing Speech.md
+++ b/world/abilities/Soothing Speech.md
@@ -1,3 +1,6 @@
+---
+level: 4
+---
 # Soothing Speech
 
 **_Level 4_** _Grace Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Specter of the Dark.md
+++ b/world/abilities/Specter of the Dark.md
@@ -1,3 +1,6 @@
+---
+level: 10
+---
 # Specter of the Dark
 
 **_Level 10_** _Midnight Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Spellcharge.md
+++ b/world/abilities/Spellcharge.md
@@ -1,3 +1,6 @@
+---
+level: 8
+---
 # Spellcharge
 
 **_Level 8_** _Midnight Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Splendor-Touched.md
+++ b/world/abilities/Splendor-Touched.md
@@ -1,3 +1,6 @@
+---
+level: 7
+---
 # Splendor-Touched
 
 **_Level 7_** _Splendor Ability._ **_Recall Cost_** _2._

--- a/world/abilities/Splintering Strike.md
+++ b/world/abilities/Splintering Strike.md
@@ -1,3 +1,6 @@
+---
+level: 9
+---
 # Splintering Strike
 
 **_Level 9_** _Bone Ability._ **_Recall Cost_** _3._

--- a/world/abilities/Stealth Expertise.md
+++ b/world/abilities/Stealth Expertise.md
@@ -1,3 +1,6 @@
+---
+level: 4
+---
 # Stealth Expertise
 
 **_Level 4_** _Midnight Ability._ **_Recall Cost_** _0._

--- a/world/abilities/Strategic Approach.md
+++ b/world/abilities/Strategic Approach.md
@@ -1,3 +1,6 @@
+---
+level: 2
+---
 # Strategic Approach
 
 **_Level 2_** _Bone Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Stunning Sunlight.md
+++ b/world/abilities/Stunning Sunlight.md
@@ -1,3 +1,6 @@
+---
+level: 8
+---
 # Stunning Sunlight
 
 **_Level 8_** _Splendor Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Support Tank.md
+++ b/world/abilities/Support Tank.md
@@ -1,3 +1,6 @@
+---
+level: 4
+---
 # Support Tank
 
 **_Level 4_** _Valor Ability._ **_Recall Cost_** _2._

--- a/world/abilities/Swift Step.md
+++ b/world/abilities/Swift Step.md
@@ -1,3 +1,6 @@
+---
+level: 10
+---
 # Swift Step
 
 **_Level 10_** _Bone Ability._ **_Recall Cost_** _2._

--- a/world/abilities/Tactician.md
+++ b/world/abilities/Tactician.md
@@ -1,3 +1,6 @@
+---
+level: 3
+---
 # Tactician
 
 **_Level 3_** _Bone Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Telekinesis.md
+++ b/world/abilities/Telekinesis.md
@@ -1,3 +1,6 @@
+---
+level: 6
+---
 # Telekinesis
 
 **_Level 6_** _Arcana Spell._ **_Recall Cost_** _0._

--- a/world/abilities/Teleport.md
+++ b/world/abilities/Teleport.md
@@ -1,3 +1,6 @@
+---
+level: 5
+---
 # Teleport
 
 **_Level 5_** _Codex Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Tell No Lies.md
+++ b/world/abilities/Tell No Lies.md
@@ -1,3 +1,6 @@
+---
+level: 2
+---
 # Tell No Lies
 
 **_Level 2_** _Grace Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Tempest.md
+++ b/world/abilities/Tempest.md
@@ -1,3 +1,6 @@
+---
+level: 10
+---
 # Tempest
 
 **_Level 10_** _Sage Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Thorn Skin.md
+++ b/world/abilities/Thorn Skin.md
@@ -1,3 +1,6 @@
+---
+level: 5
+---
 # Thorn Skin
 
 **_Level 5_** _Sage Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Thought Delver.md
+++ b/world/abilities/Thought Delver.md
@@ -1,3 +1,6 @@
+---
+level: 5
+---
 # Thought Delver
 
 **_Level 5_** _Grace Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Through Your Eyes.md
+++ b/world/abilities/Through Your Eyes.md
@@ -1,3 +1,6 @@
+---
+level: 4
+---
 # Through Your Eyes
 
 **_Level 4_** _Grace Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Towering Stalk.md
+++ b/world/abilities/Towering Stalk.md
@@ -1,3 +1,6 @@
+---
+level: 3
+---
 # Towering Stalk
 
 **_Level 3_** _Sage Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Transcendent Union.md
+++ b/world/abilities/Transcendent Union.md
@@ -1,3 +1,6 @@
+---
+level: 10
+---
 # Transcendent Union
 
 **_Level 10_** _Codex Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Troublemaker.md
+++ b/world/abilities/Troublemaker.md
@@ -1,3 +1,6 @@
+---
+level: 2
+---
 # Troublemaker
 
 **_Level 2_** _Grace Ability._ **_Recall Cost_** _2._

--- a/world/abilities/Twilight Toll.md
+++ b/world/abilities/Twilight Toll.md
@@ -1,3 +1,6 @@
+---
+level: 9
+---
 # Twilight Toll
 
 **_Level 9_** _Midnight Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Unbreakable.md
+++ b/world/abilities/Unbreakable.md
@@ -1,3 +1,6 @@
+---
+level: 10
+---
 # Unbreakable
 
 **_Level 10_** _Valor Ability._ **_Recall Cost_** _4._

--- a/world/abilities/Uncanny Disguise.md
+++ b/world/abilities/Uncanny Disguise.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Uncanny Disguise
 
 **_Level 1_** _Midnight Spell._ **_Recall Cost_** _0._

--- a/world/abilities/Unleash Chaos.md
+++ b/world/abilities/Unleash Chaos.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Unleash Chaos
 
 **_Level 1_** _Arcana Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Untouchable.md
+++ b/world/abilities/Untouchable.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Untouchable
 
 **_Level 1_** _Bone Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Unyielding Armor.md
+++ b/world/abilities/Unyielding Armor.md
@@ -1,3 +1,6 @@
+---
+level: 10
+---
 # Unyielding Armor
 
 **_Level 10_** _Valor Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Valor-Touched.md
+++ b/world/abilities/Valor-Touched.md
@@ -1,3 +1,6 @@
+---
+level: 7
+---
 # Valor-Touched
 
 **_Level 7_** _Valor Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Vanishing Dodge.md
+++ b/world/abilities/Vanishing Dodge.md
@@ -1,3 +1,6 @@
+---
+level: 7
+---
 # Vanishing Dodge
 
 **_Level 7_** _Midnight Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Veil of Night.md
+++ b/world/abilities/Veil of Night.md
@@ -1,3 +1,6 @@
+---
+level: 3
+---
 # Veil of Night
 
 **_Level 3_** _Midnight Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Versatile Fighter.md
+++ b/world/abilities/Versatile Fighter.md
@@ -1,3 +1,6 @@
+---
+level: 3
+---
 # Versatile Fighter
 
 **_Level 3_** _Blade Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Vicious Entangle.md
+++ b/world/abilities/Vicious Entangle.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Vicious Entangle
 
 **_Level 1_** _Sage Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Vitality.md
+++ b/world/abilities/Vitality.md
@@ -1,3 +1,6 @@
+---
+level: 5
+---
 # Vitality
 
 **_Level 5_** _Blade Ability._ **_Recall Cost_** _0._

--- a/world/abilities/Voice of Reason.md
+++ b/world/abilities/Voice of Reason.md
@@ -1,3 +1,6 @@
+---
+level: 3
+---
 # Voice of Reason
 
 **_Level 3_** _Splendor Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Wall Walk.md
+++ b/world/abilities/Wall Walk.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Wall Walk
 
 **_Level 1_** _Arcana Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Whirlwind.md
+++ b/world/abilities/Whirlwind.md
@@ -1,3 +1,6 @@
+---
+level: 1
+---
 # Whirlwind
 
 **_Level 1_** _Blade Ability._ **_Recall Cost_** _0._

--- a/world/abilities/Wild Fortress.md
+++ b/world/abilities/Wild Fortress.md
@@ -1,3 +1,6 @@
+---
+level: 5
+---
 # Wild Fortress
 
 **_Level 5_** _Sage Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Wild Surge.md
+++ b/world/abilities/Wild Surge.md
@@ -1,3 +1,6 @@
+---
+level: 7
+---
 # Wild Surge
 
 **_Level 7_** _Sage Spell._ **_Recall Cost_** _2._

--- a/world/abilities/Words of Discord.md
+++ b/world/abilities/Words of Discord.md
@@ -1,3 +1,6 @@
+---
+level: 5
+---
 # Words of Discord
 
 **_Level 5_** _Grace Spell._ **_Recall Cost_** _1._

--- a/world/abilities/Wrangle.md
+++ b/world/abilities/Wrangle.md
@@ -1,3 +1,6 @@
+---
+level: 8
+---
 # Wrangle
 
 **_Level 8_** _Bone Ability._ **_Recall Cost_** _1._

--- a/world/abilities/Zone of Protection.md
+++ b/world/abilities/Zone of Protection.md
@@ -1,3 +1,6 @@
+---
+level: 6
+---
 # Zone of Protection
 
 **_Level 6_** _Splendor Spell._ **_Recall Cost_** _2._

--- a/world/armor/Advanced Chainmail Armor.md
+++ b/world/armor/Advanced Chainmail Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 3
+---
 # Advanced Chainmail Armor
 
 **_Tier 3_** _Armor_

--- a/world/armor/Advanced Full Plate Armor.md
+++ b/world/armor/Advanced Full Plate Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 3
+---
 # Advanced Full Plate Armor
 
 **_Tier 3_** _Armor_

--- a/world/armor/Advanced Gambeson Armor.md
+++ b/world/armor/Advanced Gambeson Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 3
+---
 # Advanced Gambeson Armor
 
 **_Tier 3_** _Armor_

--- a/world/armor/Advanced Leather Armor.md
+++ b/world/armor/Advanced Leather Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 3
+---
 # Advanced Leather Armor
 
 **_Tier 3_** _Armor_

--- a/world/armor/Bellamoi Fine Armor.md
+++ b/world/armor/Bellamoi Fine Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 3
+---
 # Bellamoi Fine Armor
 
 **_Tier 3_** _Armor_

--- a/world/armor/Bladefare Armor.md
+++ b/world/armor/Bladefare Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 3
+---
 # Bladefare Armor
 
 **_Tier 3_** _Armor_

--- a/world/armor/Chainmail Armor.md
+++ b/world/armor/Chainmail Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 1
+---
 # Chainmail Armor
 
 **_Tier 1_** _Armor_

--- a/world/armor/Channeling Armor.md
+++ b/world/armor/Channeling Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 4
+---
 # Channeling Armor
 
 **_Tier 4_** _Armor_

--- a/world/armor/Dragonscale Armor.md
+++ b/world/armor/Dragonscale Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 3
+---
 # Dragonscale Armor
 
 **_Tier 3_** _Armor_

--- a/world/armor/Dunamis Silkchain.md
+++ b/world/armor/Dunamis Silkchain.md
@@ -1,3 +1,6 @@
+---
+tier: 4
+---
 # Dunamis Silkchain
 
 **_Tier 4_** _Armor_

--- a/world/armor/Elundrian Chain Armor.md
+++ b/world/armor/Elundrian Chain Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 2
+---
 # Elundrian Chain Armor
 
 **_Tier 2_** _Armor_

--- a/world/armor/Emberwoven Armor.md
+++ b/world/armor/Emberwoven Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 4
+---
 # Emberwoven Armor
 
 **_Tier 4_** _Armor_

--- a/world/armor/Full Fortified Armor.md
+++ b/world/armor/Full Fortified Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 4
+---
 # Full Fortified Armor
 
 **_Tier 4_** _Armor_

--- a/world/armor/Full Plate Armor.md
+++ b/world/armor/Full Plate Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 1
+---
 # Full Plate Armor
 
 **_Tier 1_** _Armor_

--- a/world/armor/Gambeson Armor.md
+++ b/world/armor/Gambeson Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 1
+---
 # Gambeson Armor
 
 **_Tier 1_** _Armor_

--- a/world/armor/Harrowbone Armor.md
+++ b/world/armor/Harrowbone Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 2
+---
 # Harrowbone Armor
 
 **_Tier 2_** _Armor_

--- a/world/armor/Improved Chainmail Armor.md
+++ b/world/armor/Improved Chainmail Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 2
+---
 # Improved Chainmail Armor
 
 **_Tier 2_** _Armor_

--- a/world/armor/Improved Full Plate Armor.md
+++ b/world/armor/Improved Full Plate Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 2
+---
 # Improved Full Plate Armor
 
 **_Tier 2_** _Armor_

--- a/world/armor/Improved Gambeson Armor.md
+++ b/world/armor/Improved Gambeson Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 2
+---
 # Improved Gambeson Armor
 
 **_Tier 2_** _Armor_

--- a/world/armor/Improved Leather Armor.md
+++ b/world/armor/Improved Leather Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 2
+---
 # Improved Leather Armor
 
 **_Tier 2_** _Armor_

--- a/world/armor/Irontree Breastplate Armor.md
+++ b/world/armor/Irontree Breastplate Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 2
+---
 # IronTree Breastplate Armor
 
 **_Tier 2_** _Armor_

--- a/world/armor/Leather Armor.md
+++ b/world/armor/Leather Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 1
+---
 # Leather Armor
 
 **_Tier 1_** _Armor_

--- a/world/armor/Legendary Chainmail Armor.md
+++ b/world/armor/Legendary Chainmail Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 4
+---
 # Legendary Chainmail Armor
 
 **_Tier 4_** _Armor_

--- a/world/armor/Legendary Full Plate Armor.md
+++ b/world/armor/Legendary Full Plate Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 4
+---
 # Legendary Full Plate Armor
 
 **_Tier 4_** _Armor_

--- a/world/armor/Legendary Gambeson Armor.md
+++ b/world/armor/Legendary Gambeson Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 4
+---
 # Legendary Gambeson Armor
 
 **_Tier 4_** _Armor_

--- a/world/armor/Legendary Leather Armor.md
+++ b/world/armor/Legendary Leather Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 4
+---
 # Legendary Leather Armor
 
 **_Tier 4_** _Armor_

--- a/world/armor/Monetts Cloak.md
+++ b/world/armor/Monetts Cloak.md
@@ -1,3 +1,6 @@
+---
+tier: 3
+---
 # Monett's Cloak
 
 **_Tier 3_** _Armor_

--- a/world/armor/Rosewild Armor.md
+++ b/world/armor/Rosewild Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 2
+---
 # Rosewild Armor
 
 **_Tier 2_** _Armor_

--- a/world/armor/Runes of Fortification.md
+++ b/world/armor/Runes of Fortification.md
@@ -1,3 +1,6 @@
+---
+tier: 3
+---
 # Runes of Fortification
 
 **_Tier 3_** _Armor_

--- a/world/armor/Runetan Floating Armor.md
+++ b/world/armor/Runetan Floating Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 2
+---
 # Runetan Floating Armor
 
 **_Tier 2_** _Armor_

--- a/world/armor/Savior Chainmail.md
+++ b/world/armor/Savior Chainmail.md
@@ -1,3 +1,6 @@
+---
+tier: 4
+---
 # Savior Chainmail
 
 **_Tier 4_** _Armor_

--- a/world/armor/Spiked Plate Armor.md
+++ b/world/armor/Spiked Plate Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 3
+---
 # Spiked Plate Armor
 
 **_Tier 3_** _Armor_

--- a/world/armor/Tyris Soft Armor.md
+++ b/world/armor/Tyris Soft Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 2
+---
 # Tyris Soft Armor
 
 **_Tier 2_** _Armor_

--- a/world/armor/Veritas Opal Armor.md
+++ b/world/armor/Veritas Opal Armor.md
@@ -1,3 +1,6 @@
+---
+tier: 4
+---
 # Veritas Opal Armor
 
 **_Tier 4_** _Armor_

--- a/world/classes/subclasses/beastforms/Aquatic Scout.md
+++ b/world/classes/subclasses/beastforms/Aquatic Scout.md
@@ -12,6 +12,7 @@ tags:
   - daggerheart-srd
   - pc
   - reference
+tier: 1
 ---
 
 **_Tier 1_** _(Eel, Fish, Octopus, etc.)_

--- a/world/classes/subclasses/beastforms/Armored Sentry.md
+++ b/world/classes/subclasses/beastforms/Armored Sentry.md
@@ -12,6 +12,7 @@ tags:
   - daggerheart-srd
   - pc
   - reference
+tier: 2
 ---
 
 **_Tier 2_** _(Armadillo, Pangolin, Turtle, etc.)_

--- a/world/classes/subclasses/beastforms/Epic Aquatic Beast.md
+++ b/world/classes/subclasses/beastforms/Epic Aquatic Beast.md
@@ -12,6 +12,7 @@ tags:
   - daggerheart-srd
   - pc
   - reference
+tier: 4
 ---
 
 **_Tier 4_** _(Giant Squid, Whale, etc.)_

--- a/world/classes/subclasses/beastforms/Great Predator.md
+++ b/world/classes/subclasses/beastforms/Great Predator.md
@@ -12,6 +12,7 @@ tags:
   - daggerheart-srd
   - pc
   - reference
+tier: 3
 ---
 
 **_Tier 3_** _(Dire Wolf, Velociraptor, Sabertooth Tiger, etc.)_

--- a/world/classes/subclasses/beastforms/Great Winged Beast.md
+++ b/world/classes/subclasses/beastforms/Great Winged Beast.md
@@ -12,6 +12,7 @@ tags:
   - daggerheart-srd
   - pc
   - reference
+tier: 3
 ---
 
 **_Tier 3_** _(Giant Eagle, Falcon, etc.)_

--- a/world/classes/subclasses/beastforms/Household Friend.md
+++ b/world/classes/subclasses/beastforms/Household Friend.md
@@ -12,6 +12,7 @@ tags:
   - daggerheart-srd
   - pc
   - reference
+tier: 1
 ---
 
 **_Tier 1_** _(Cat, Dog, Rabbit, etc.)_

--- a/world/classes/subclasses/beastforms/Legendary Beast.md
+++ b/world/classes/subclasses/beastforms/Legendary Beast.md
@@ -12,6 +12,7 @@ tags:
   - daggerheart-srd
   - pc
   - reference
+tier: 3
 ---
 
 **_Tier 3_** _(Upgraded Tier 1 Options)_

--- a/world/classes/subclasses/beastforms/Legendary Hybrid.md
+++ b/world/classes/subclasses/beastforms/Legendary Hybrid.md
@@ -12,6 +12,7 @@ tags:
   - daggerheart-srd
   - pc
   - reference
+tier: 3
 ---
 
 **_Tier 3_** _(Griffon, Sphinx, etc.)_

--- a/world/classes/subclasses/beastforms/Massive Behemoth.md
+++ b/world/classes/subclasses/beastforms/Massive Behemoth.md
@@ -12,6 +12,7 @@ tags:
   - daggerheart-srd
   - pc
   - reference
+tier: 4
 ---
 
 **_Tier 4_** _(Elephant, Mammoth, Rhinoceros, etc.)_

--- a/world/classes/subclasses/beastforms/Mighty Lizard.md
+++ b/world/classes/subclasses/beastforms/Mighty Lizard.md
@@ -12,6 +12,7 @@ tags:
   - daggerheart-srd
   - pc
   - reference
+tier: 3
 ---
 
 **_Tier 3_** _(Alligator, Crocodile, Gila Monster, etc.)_

--- a/world/classes/subclasses/beastforms/Mighty Strider.md
+++ b/world/classes/subclasses/beastforms/Mighty Strider.md
@@ -12,6 +12,7 @@ tags:
   - daggerheart-srd
   - pc
   - reference
+tier: 2
 ---
 
 **_Tier 2_** _(Camel, Horse, Zebra, etc.)_

--- a/world/classes/subclasses/beastforms/Mythic Aerial Hunter.md
+++ b/world/classes/subclasses/beastforms/Mythic Aerial Hunter.md
@@ -12,6 +12,7 @@ tags:
   - daggerheart-srd
   - pc
   - reference
+tier: 4
 ---
 
 **_Tier 4_** _(Dragon, Pterodactyl, Roc, Wyvern, etc.)_

--- a/world/classes/subclasses/beastforms/Mythic Beast.md
+++ b/world/classes/subclasses/beastforms/Mythic Beast.md
@@ -12,6 +12,7 @@ tags:
   - daggerheart-srd
   - pc
   - reference
+tier: 4
 ---
 
 **_Tier 4_** _(Upgraded Tier 1 or Tier 2 Options)_

--- a/world/classes/subclasses/beastforms/Mythic Hybrid.md
+++ b/world/classes/subclasses/beastforms/Mythic Hybrid.md
@@ -12,6 +12,7 @@ tags:
   - daggerheart-srd
   - pc
   - reference
+tier: 4
 ---
 
 **_Tier 4_** _(Chimera, Cockatrice, Manticore, etc.)_

--- a/world/classes/subclasses/beastforms/Nimble Grazer.md
+++ b/world/classes/subclasses/beastforms/Nimble Grazer.md
@@ -12,6 +12,7 @@ tags:
   - daggerheart-srd
   - pc
   - reference
+tier: 1
 ---
 
 **_Tier 1_** _(Deer, Gazelle, Goat, etc.)_

--- a/world/classes/subclasses/beastforms/Pack Predator.md
+++ b/world/classes/subclasses/beastforms/Pack Predator.md
@@ -12,6 +12,7 @@ tags:
   - daggerheart-srd
   - pc
   - reference
+tier: 1
 ---
 
 **_Tier 1_** _(Coyote, Hyena, Wolf, etc.)_

--- a/world/classes/subclasses/beastforms/Pouncing Predator.md
+++ b/world/classes/subclasses/beastforms/Pouncing Predator.md
@@ -12,6 +12,7 @@ tags:
   - daggerheart-srd
   - pc
   - reference
+tier: 2
 ---
 
 **_Tier 2_** _(Cheetah, Lion, Panther, etc.)_

--- a/world/classes/subclasses/beastforms/Powerful Beast.md
+++ b/world/classes/subclasses/beastforms/Powerful Beast.md
@@ -12,6 +12,7 @@ tags:
   - daggerheart-srd
   - pc
   - reference
+tier: 2
 ---
 
 **_Tier 2_** _(Bear, Bull, Moose, etc.)_

--- a/world/classes/subclasses/beastforms/Stalking Arachnid.md
+++ b/world/classes/subclasses/beastforms/Stalking Arachnid.md
@@ -12,6 +12,7 @@ tags:
   - daggerheart-srd
   - pc
   - reference
+tier: 1
 ---
 
 **_Tier 1_** _(Tarantula, Wolf Spider, etc.)_

--- a/world/classes/subclasses/beastforms/Striking Serpent.md
+++ b/world/classes/subclasses/beastforms/Striking Serpent.md
@@ -12,6 +12,7 @@ tags:
   - daggerheart-srd
   - pc
   - reference
+tier: 2
 ---
 
 **_Tier 2_** _(Cobra, Rattlesnake, Viper, etc.)_

--- a/world/classes/subclasses/beastforms/Terrible Lizard.md
+++ b/world/classes/subclasses/beastforms/Terrible Lizard.md
@@ -12,6 +12,7 @@ tags:
   - daggerheart-srd
   - pc
   - reference
+tier: 4
 ---
 
 **_Tier 4_** _(Brachiosaurus, Tyrannosaurus, etc.)_

--- a/world/classes/subclasses/beastforms/Winged Beast.md
+++ b/world/classes/subclasses/beastforms/Winged Beast.md
@@ -12,6 +12,7 @@ tags:
   - daggerheart-srd
   - pc
   - reference
+tier: 2
 ---
 
 **_Tier 2_** _(Hawk, Owl, Raven, etc.)_


### PR DESCRIPTION
…ilities

Extends the numeric field migration pattern to three additional content domains using the generalized migrate_numeric_field.py script.

- world/classes/**/*.md (24 beastform files): tier: 1–4 added; 27 class/subclass files without tier correctly skipped
- world/armor/*.md (34 files): tier: 1–4 added
- world/abilities/*.md (189 files): level: 1–10 added; files had no prior frontmatter — minimal --- block created

utilities/world/migrate_numeric_field.py: generalized one-shot script
  supporting --field, --dir (multiple), --dry-run; handles both insert
  into existing frontmatter and creation of new frontmatter block —
  delete after merge

https://claude.ai/code/session_01KxUPGmLbF9VKhAXAR6uYWd