### PR TITLE
pipeline: add beastforms category page with back-nav to Druid

### DIFF
--- a/utilities/world/generate_all_world_html.py
+++ b/utilities/world/generate_all_world_html.py
@@ -955,21 +955,26 @@ def generate_category_page(
                            for d in sorted_docs]
 
     # Resolve parent label for back-nav and jump-nav
+    # back_href / back_label in _category.md override the auto-computed link
+    back_href_override  = str(cfg.get('back_href', '')).strip()
+    back_label_override = str(cfg.get('back_label', '')).strip()
     if parent_bucket:
         parent_cfg, _ = _read_category_config(vault, parent_bucket)
         parent_label  = parent_cfg.get('title') or _category_label(parent_bucket)
     else:
         parent_label = None
 
+    def _back_link_li(label: str, href: str) -> str:
+        return f'  <li style="list-style:none"><a href="{escape(href)}">&larr; {escape(label)}</a></li>'
+
     # Generate jump nav if enabled in frontmatter
     jump_nav_html = ''
     all_nav_items = subcat_nav_items + jump_nav_items
     if cfg.get('jump_nav') and len(all_nav_items) >= 2:
-        if parent_bucket:
-            back_link = (
-                f'  <li style="list-style:none">'
-                f'<a href="category-{escape(parent_bucket)}.html">&larr; {escape(parent_label)}</a></li>'
-            )
+        if back_href_override:
+            back_link = _back_link_li(back_label_override or 'Back', back_href_override)
+        elif parent_bucket:
+            back_link = _back_link_li(parent_label, f'category-{parent_bucket}.html')
         else:
             back_link = '  <li style="list-style:none"><a href="index.html">&larr; Campaign Documents</a></li>'
         nav_items = [back_link, '  <li class="nav-divider"></li>']
@@ -1002,7 +1007,13 @@ def generate_category_page(
     count = len(sorted_docs)
 
     # Back navigation
-    if parent_bucket:
+    if back_href_override:
+        back_nav_html = (
+            '<div class="back-nav">\n'
+            f'  <a href="{escape(back_href_override)}">← {escape(back_label_override or "Back")}</a>\n'
+            '</div>\n'
+        )
+    elif parent_bucket:
         back_nav_html = (
             '<div class="back-nav">\n'
             f'  <a href="category-{escape(parent_bucket)}.html">\u2190 {escape(parent_label)}</a>\n'

--- a/world/classes/subclasses/beastforms/_category.md
+++ b/world/classes/subclasses/beastforms/_category.md
@@ -1,0 +1,16 @@
+---
+title: Beastforms
+description: Wild shapes available to the Druid — twenty-four forms spanning tiers of power.
+project: TTRPG_Tarim_Shaiel
+type: lore
+visibility: gm_secrets
+published: true
+status: canon
+created: 2026-04-19
+last_updated: 2026-04-19
+banner_left: TARIM-SHAIEL * Character Creation
+banner_right: Beastforms
+jump_nav: true
+back_href: druid.html
+back_label: Druid
+---


### PR DESCRIPTION
Adds _category.md to world/classes/subclasses/beastforms/ so the generator produces category-beastforms.html with a jump-nav listing all 24 forms and a back-nav pointing directly to druid.html.

Extends generate_category_page() with back_href / back_label frontmatter overrides so any category page can target a document URL rather than being forced to link to category-{parent}.html.

https://claude.ai/code/session_01GXzrPAXKqLVueJAZ8KNWzX