### PR TITLE
pipeline: add parent: classes to beastforms _category.md

### DIFF
--- a/world/classes/subclasses/beastforms/_category.md
+++ b/world/classes/subclasses/beastforms/_category.md
@@ -7,9 +7,10 @@ visibility: gm_secrets
 published: true
 status: canon
 created: 2026-04-19
-last_updated: 2026-04-19
+last_updated: 2026-04-20
 banner_left: TARIM-SHAIEL * Character Creation
 banner_right: Beastforms
+parent: classes
 jump_nav: true
 back_href: druid.html
 back_label: Druid


### PR DESCRIPTION
Without parent: classes, beastforms was treated as a top-level folder and appeared as its own card on the home page index. Adding parent: classes puts it in subcategory_set, which excludes it from index top_level_folders. back_href override takes precedence so back-nav still links to druid.html.

https://claude.ai/code/session_01GXzrPAXKqLVueJAZ8KNWzX