### PR TITLE
pipeline+content: fix subclass/domain link rendering on class pages

### DIFF
--- a/utilities/shared/md_utils.py
+++ b/utilities/shared/md_utils.py
@@ -19,7 +19,7 @@ def _md_link_sub(m: 're.Match') -> str:
     href = m.group(2)
     if href.endswith('.md'):
         stem = href.rsplit('/', 1)[-1][:-3]          # filename without extension
-        href = stem.lower().replace(' ', '_') + '.html'
+        href = re.sub(r'[^\w\-]+', '-', stem.lower()).strip('-') + '.html'
     return f'<a href="{href}">{link_text}</a>'
 
 

--- a/world/classes/Bard.md
+++ b/world/classes/Bard.md
@@ -20,7 +20,7 @@ tags:
 ---
 Bards are the most charismatic people in all the realms. Members of this class are masters of captivation and specialize in a variety of performance types, including singing, playing musical instruments, weaving tales, or telling jokes. Whether performing for an audience or speaking to an individual, bards thrive in social situations. Members of this profession bond and train at schools or guilds, but a current of egotism runs through those of the bardic persuasion. While they may be the most likely class to bring people together, a bard of ill temper can just as easily tear a party apart.
 
-- **DOMAINS -** [Grace](references/daggerheart-srd/domains/Grace.md) & [Codex](references/daggerheart-srd/domains/Codex.md)
+- **DOMAINS -** [Grace](world/domains/Grace.md) & [Codex](world/domains/Codex.md)
 - **STARTING EVASION -** 10
 - **STARTING HIT POINTS -** 5
 - **CLASS ITEMS -** A romance novel or a letter never opened

--- a/world/classes/Druid.md
+++ b/world/classes/Druid.md
@@ -12,7 +12,7 @@ sub-classes:
   - beastforms
 status: canon
 created: 2026-04-14
-last_updated: 2026-04-14
+last_updated: 2026-04-20
 tags:
   - daggerheart
   - daggerheart-srd
@@ -21,7 +21,7 @@ tags:
 ---
 Becoming a druid is more than an occupation; it's a calling for those who wish to learn from and protect the magic of the wilderness. While one might underestimate a gentle druid who practices the often-quiet work of cultivating flora, druids who channel the untamed forces of nature are terrifying to behold. Druids cultivate their abilities in small groups, often connected by a specific ethos or locale, but some choose to work alone. Through years of study and dedication, druids can learn to transform into beasts and shape nature itself.
 
-- **DOMAINS -** [Sage](references/daggerheart-srd/domains/Sage.md) & [Arcana](references/daggerheart-srd/domains/Arcana.md)
+- **DOMAINS -** [Sage](world/domains/Sage.md) & [Arcana](world/domains/Arcana.md)
 - **STARTING EVASION -** 10
 - **STARTING HIT POINTS -** 6
 - **CLASS ITEMS -** A small bag of rocks and bones or a strange pendant found in the dirt
@@ -58,41 +58,7 @@ Beastform categories are divided by tier. Each entry includes the following deta
 
 ### BEASTFORMS
 
-#### TIER 1
-
-- [Agile Scout](world/classes/subclasses/beastforms/Agile Scout.md)
-- [Household Friend](world/classes/subclasses/beastforms/Household Friend.md)
-- [Nimble Grazer](world/classes/subclasses/beastforms/Nimble Grazer.md)
-- [Pack Predator](world/classes/subclasses/beastforms/Pack Predator.md)
-- [Aquatic Scout](world/classes/subclasses/beastforms/Aquatic Scout.md)
-- [Stalking Arachnid](world/classes/subclasses/beastforms/Stalking Arachnid.md)
-[[world/classes/subclasses/beastforms/Agile Scout]]
-#### TIER 2
-
-- [Armored Sentry](world/classes/subclasses/beastforms/Armored Sentry.md)
-- [Powerful Beast](world/classes/subclasses/beastforms/Powerful Beast.md)
-- [Mighty Strider](world/classes/subclasses/beastforms/Mighty Strider.md)
-- [Striking Serpent](world/classes/subclasses/beastforms/Striking Serpent.md)
-- [Pouncing Predator](world/classes/subclasses/beastforms/Pouncing Predator.md)
-- [Winged Beast](world/classes/subclasses/beastforms/Winged Beast.md)
-
-#### TIER 3
-
-- [Great Predator](world/classes/subclasses/beastforms/Great Predator.md)
-- [Mighty Lizard](world/classes/subclasses/beastforms/Mighty Lizard.md)
-- [Great Winged Beast](world/classes/subclasses/beastforms/Great Winged Beast.md)
-- [Aquatic Predator](world/classes/subclasses/beastforms/Aquatic Predator.md)
-- [Legendary Beast](world/classes/subclasses/beastforms/Legendary Beast.md)
-- [Legendary Hybrid](world/classes/subclasses/beastforms/Legendary Hybrid.md)
-
-#### TIER 4
-
-- [Massive Behemoth](world/classes/subclasses/beastforms/Massive Behemoth.md)
-- [Terrible Lizard](world/classes/subclasses/beastforms/Terrible Lizard.md)
-- [Mythic Aerial Hunter](world/classes/subclasses/beastforms/Mythic Aerial Hunter.md)
-- [Epic Aquatic Beast](world/classes/subclasses/beastforms/Epic Aquatic Beast.md)
-- [Mythic Beast](world/classes/subclasses/beastforms/Mythic Beast.md)
-- [Mythic Hybrid](world/classes/subclasses/beastforms/Mythic Hybrid.md)
+See **[Beastforms](category-beastforms.html)** for all twenty-four available forms, organized by tier.
 
 ### SUBCLASSES
 

--- a/world/classes/Guardian.md
+++ b/world/classes/Guardian.md
@@ -20,7 +20,7 @@ tags:
 ---
 The title of guardian represents an array of martial professions, speaking more to their moral compass and unshakeable fortitude than the means by which they fight. While many guardians join groups of militants for either a country or cause, they're more likely to follow those few they truly care for, majority be damned. Guardians are known for fighting with remarkable ferocity even against overwhelming odds, defending their cohort above all else. Woe betide those who harm the ally of a guardian, as the guardian will answer this injury in kind.
 
-- **DOMAINS -** [Valor](references/daggerheart-srd/domains/Valor.md) & [Blade](references/daggerheart-srd/domains/Blade.md)
+- **DOMAINS -** [Valor](world/domains/Valor.md) & [Blade](world/domains/Blade.md)
 - **STARTING EVASION -** 9
 - **STARTING HIT POINTS -** 7
 - **CLASS ITEMS -** A totem from your mentor or a secret key

--- a/world/classes/Ranger.md
+++ b/world/classes/Ranger.md
@@ -20,7 +20,7 @@ tags:
 ---
 Rangers are highly skilled hunters who, despite their martial abilities, rarely lend their skills to an army. Through mastery of the body and a deep understanding of the wilderness, rangers become sly tacticians, pursuing their quarry with cunning and patience. Many rangers track and fight alongside an animal companion with whom they've forged a powerful spiritual bond. By honing their skills in the wild, rangers become expert trackers, as likely to ensnare their foes in a trap as they are to assail them head-on.
 
-- **DOMAINS -** [Bone](references/daggerheart-srd/domains/Bone.md) & [Sage](references/daggerheart-srd/domains/Sage.md)
+- **DOMAINS -** [Bone](world/domains/Bone.md) & [Sage](world/domains/Sage.md)
 - **STARTING EVASION -** 12
 - **STARTING HIT POINTS -** 6
 - **CLASS ITEMS -** A trophy from your first kill or a seemingly broken compass

--- a/world/classes/Rogue.md
+++ b/world/classes/Rogue.md
@@ -20,7 +20,7 @@ tags:
 ---
 Rogues are scoundrels, often in both attitude and practice. Broadly known as liars and thieves, the best among this class move through the world anonymously. Utilizing their sharp wits and blades, rogues trick their foes through social manipulation as easily as breaking locks, climbing through windows, or dealing underhanded blows. These masters of magical craft manipulate shadow and movement, adding an array of useful and deadly tools to their repertoire. Rogues frequently establish guilds to meet future accomplices, hire out jobs, and hone secret skills, proving that there's honor among thieves for those who know where to look.
 
-- **DOMAINS -** [Midnight](references/daggerheart-srd/domains/Midnight.md) & [Grace](references/daggerheart-srd/domains/Grace.md)
+- **DOMAINS -** [Midnight](world/domains/Midnight.md) & [Grace](world/domains/Grace.md)
 - **STARTING EVASION -** 12
 - **STARTING HIT POINTS -** 6
 - **CLASS ITEMS -** A set of forgery tools or a grappling hook

--- a/world/classes/Seraph.md
+++ b/world/classes/Seraph.md
@@ -20,7 +20,7 @@ tags:
 ---
 Seraphs are divine fighters and healers imbued with sacred purpose. A wide array of deities exist within the realms, and thus numerous kinds of seraphs are appointed by these gods. Their ethos traditionally aligns with the domain or goals of their god, such as defending the weak, exacting vengeance, protecting a land or artifact, or upholding a particular faith. Some seraphs ally themselves with an army or locale, much to the satisfaction of their rulers, but other crusaders fight in opposition to the follies of the Mortal Realm. It is better to be a seraph's ally than their enemy, as they are terrifying foes to those who defy their purpose.
 
-- **DOMAINS -** [Splendor](references/daggerheart-srd/domains/Splendor.md) & [Valor](references/daggerheart-srd/domains/Valor.md)
+- **DOMAINS -** [Splendor](world/domains/Splendor.md) & [Valor](world/domains/Valor.md)
 - **STARTING EVASION -** 9
 - **STARTING HIT POINTS -** 7
 - **CLASS ITEMS -** A bundle of offerings or a sigil of your god

--- a/world/classes/Sorcerer.md
+++ b/world/classes/Sorcerer.md
@@ -20,7 +20,7 @@ tags:
 ---
 Not all innate magic users choose to hone their craft, but those who do can become powerful sorcerers. The gifts of these wielders are passed down through families, even if the family is unaware of or reluctant to practice them. A sorcerer's abilities can range from the elemental to the illusionary and beyond, and many practitioners band together into collectives based on their talents. The act of becoming a formidable sorcerer is not the practice of acquiring power, but learning to cultivate and control the power one already possesses. The magic of a misguided or undisciplined sorcerer is a dangerous force indeed.
 
-- **DOMAINS -** [Arcana](references/daggerheart-srd/domains/Arcana.md) & [Midnight](references/daggerheart-srd/domains/Midnight.md)
+- **DOMAINS -** [Arcana](world/domains/Arcana.md) & [Midnight](world/domains/Midnight.md)
 - **STARTING EVASION -** 10
 - **STARTING HIT POINTS -** 6
 - **CLASS ITEMS -** A whispering orb or a family heirloom

--- a/world/classes/Warrior.md
+++ b/world/classes/Warrior.md
@@ -20,7 +20,7 @@ tags:
 ---
 Becoming a warrior requires years, often a lifetime, of training and dedication to the mastery of weapons and violence. While many who seek to fight hone only their strength, warriors understand the importance of an agile body and mind, making them some of the most sought-after fighters across the realms. Frequently, warriors find employment within an army, a band of mercenaries, or even a royal guard, but their potential is wasted in any position where they cannot continue to improve and expand their skills. Warriors are known to have a favored weapon; to come between them and their blade would be a grievous mistake.
 
-- **DOMAINS -** [Blade](references/daggerheart-srd/domains/Blade.md) & [Bone](references/daggerheart-srd/domains/Bone.md)
+- **DOMAINS -** [Blade](world/domains/Blade.md) & [Bone](world/domains/Bone.md)
 - **STARTING EVASION -** 11
 - **STARTING HIT POINTS -** 6
 - **CLASS ITEMS -** The drawing of a lover or a sharpening stone

--- a/world/classes/Wizard.md
+++ b/world/classes/Wizard.md
@@ -20,7 +20,7 @@ tags:
 ---
 Whether through an institution or individual study, those known as wizards acquire and hone immense magical power over years of learning using a variety of tools, including books, stones, potions, and herbs. Some wizards dedicate their lives to mastering a particular school of magic, while others learn from a wide variety of disciplines. Many wizards become wise and powerful figures in their communities, advising rulers, providing medicines and healing, and even leading war councils. While these mages all work toward the common goal of collecting magical knowledge, wizards often have the most conflict within their own ranks, as the acquisition, keeping, and sharing of powerful secrets is a topic of intense debate that has resulted in innumerable deaths.
 
-- **DOMAINS -** [Codex](references/daggerheart-srd/domains/Codex.md) & [Splendor](references/daggerheart-srd/domains/Splendor.md)
+- **DOMAINS -** [Codex](world/domains/Codex.md) & [Splendor](world/domains/Splendor.md)
 - **STARTING EVASION -** 11
 - **STARTING HIT POINTS -** 5
 - **CLASS ITEMS -** A book you're trying to translate or a tiny, harmless elemental pet


### PR DESCRIPTION
md_utils.py: _md_link_sub was slugifying with underscores while the file generator uses hyphens — all multi-word subclass links produced 404s (warden_of_the_elements.html vs warden-of-the-elements.html). Align to the same re.sub hyphen pattern used by _slug().

Druid.md: collapse the 24-item inline beastform list to a single link to category-beastforms.html (the canonical list page), remove the stray wikilink on line 69.

All class files: correct domain link paths from
references/daggerheart-srd/domains/ to world/domains/ for Obsidian accuracy (output URL is the same either way, stem-only).

https://claude.ai/code/session_01GXzrPAXKqLVueJAZ8KNWzX