### PR TITLE
infra: create DASHBOARD.md; refactor generator to read structured schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,8 @@ Target register: Erikson-grade density. Session 0 Warrior Awakening (v2.0) is th
 
 | File | Purpose |
 |---|---|
-| `TODO.md` | Active work, blockers, project health — source of truth for session priorities |
+| `TODO.md` | Active checklist + session log — source of truth for task state |
+| `DASHBOARD.md` | Project health panel — critical path, player status, quick summary, blockers |
 | `narrative/sessions/00_session0/` | Session 0 awakening scenario files |
 | `templates/tarim-shaiel-campaign-frame-v2.md` | Primary player-facing campaign frame |
 | `utilities/dashboard/generate_dashboard.py` | Project health dashboard script |
@@ -127,7 +128,7 @@ Target register: Erikson-grade density. Session 0 Warrior Awakening (v2.0) is th
 ## Working Conventions
 
 - **Verify before claiming capability.** Before asserting that a tool, CLI command, or integration is available (e.g. `gh`, `netlify`, browser access), run a quick check (`which <cmd>` or equivalent). Do not claim a capability and then demonstrate its absence — that wastes cycles and erodes trust. If uncertain, say so first.
-- **TODO.md is the session anchor.** Start each session by reading it. Then check the Quick Navigation table above and read any `lat.md/` files relevant to the session's domain before beginning work.
+- **TODO.md + DASHBOARD.md are the session anchors.** Start each session by reading both. Then check the Quick Navigation table above and read any `lat.md/` files relevant to the session's domain before beginning work. Update `DASHBOARD.md` when overall project state changes (critical path, player status, quick summary, blockers); update `TODO.md` when tasks change.
 - **Update `last_updated` frontmatter** when editing any persistent file.
 - **Append an entry to `.meta/DECISION_LOG.md`** for any significant design choice — include date, decision, rationale, and lock status. (Write only; do not read the archive.)
 - **Batch minor inconsistencies** rather than interrupting mid-flow; surface them in a summary.

--- a/DASHBOARD.md
+++ b/DASHBOARD.md
@@ -1,0 +1,54 @@
+---
+title: Project Dashboard
+project: TTRPG_Tarim_Shaiel
+type: operational
+visibility: internal
+status: active
+last_updated: 2026-04-22
+
+critical_path:
+  - Resolve cosmological architecture
+  - Complete Session 0 scenarios
+  - Resolve Campaign Frame
+  - Playtest
+
+players:
+  committed: 1
+  total: 6
+  archetypes:
+    - {name: Warrior,    status: committed}
+    - {name: Breaker,    status: pending}
+    - {name: Bridge,     status: pending}
+    - {name: Seeker,     status: pending}
+    - {name: Sacrificer, status: pending}
+    - {name: Visionary,  status: pending}
+    - {name: Trickster,  status: pending}
+    - {name: Crafter,    status: pending}
+    - {name: Sentinel,   status: pending}
+    - {name: Healer,     status: pending}
+
+domain_overrides:
+  # Uncomment + set a value to manually pin a domain's percentage.
+  # Remove entry to let checkbox counts drive it.
+  # world: 42
+  # mechanics: 80
+
+blockers:
+  # - "⛔ Description of active blocker"
+---
+
+## Quick Summary
+
+- [x] **Core complete:** Campaign narrative, world geography, fantasy naming, charm architecture, Orc cultural framework, Silk Road weapons, Cosmological architecture (all 8 decisions locked 2026-03-17), World entity infrastructure (factions/events/concepts indexes + all location templates 2026-03-10), Preliminary world diagrams (2026-03-13), HTML publishing pipeline + Netlify deployment (2026-03-15), Visibility gating + Obsidian Shell Commands integration (2026-03-17)
+- 🔄 **Active work:** Session 0 scenarios (3/6 core done; expanded 4 have design framework only), STORY_ARC_SYNTHESIS.md needs update to reflect locked decisions, individual entity files to be created from indexes
+- ✅ **Resolved (2026-04-05):** liberation_aftermath.md rewrite — v2.0 complete; Warren disturbance framing + 1,000-year timeline. [#106](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/106)
+- ✅ **Completed (2026-04-11):** lat.md/ AI navigation layer — 6 dense, path-forward orientation files + CLAUDE.md Quick Navigation table. [#121](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/121)
+- ✅ **Completed (2026-04-11):** CLAUDE.md audit + subagent context block — created lat.md/subagent-context.md; CLAUDE.md slimmed 258→174 lines; stale Wizard constraint corrected. [#128](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/128)
+- ✅ **Completed (2026-04-22):** DASHBOARD.md schema + generator refactor — health panel separated from TODO.md; six regex extractors replaced with YAML readers; SECTION_DOMAIN_HEADERS expanded. [#166](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/166)
+- 🆕 **Filed (2026-04-14):** Faction file stubs — 16 P1–P3 faction files to create from _category.md registry; 3 deferred pending #42, #43, Decision #11. [#144](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/144)
+- 🗒️ **Backlog:** HTML generation pipeline refactor — consolidate shared utilities, eliminate _Generator boilerplate + CSS token drift across 6 scripts. [#138](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/138)
+- 🗒️ **Backlog:** docs/ output hierarchy restructure — move per-document HTML into subdirectories; fixes ~500-file flat directory. [#168](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/168)
+- 🗒️ **Backlog:** Nianhao D3 timeline phase 2 — content import, GM-tunable influence scores, cross-view interaction, mobile optimization. [#116](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/116)
+- 🗒️ **Backlog:** Dashboard completion % from GitHub Issues — tie domain percentages to issue open/closed state. [#40](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/40)
+- 🗒️ **Backlog:** Template frontmatter reconciliation — align templates/world-building/ files with CLAUDE.md spec
+- 🗃️ **Charm system deferred (2026-03-13):** Archived to archive/charms/; Daggerheart base used for now

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@ project: TTRPG_Tarim_Shaiel
 type: project_management
 status: active
 created: 2025-12-14
-last_updated: 2026-04-21
+last_updated: 2026-04-22
 backlog: BACKLOG.md
 banner: images/places/248420.jpg
 banner-x: 51
@@ -15,26 +15,7 @@ banner-y: 37
 
 ## PROJECT HEALTH
 
-**Last Updated:** 2026-04-21
-**Critical Path:** Resolve cosmological architecture → Complete Session 0 scenarios → Resolve Campaign Frame → Playtest
-
-**Quick Summary:**
-- [x] **Core complete:** Campaign narrative, world geography, fantasy naming, charm architecture, **Orc cultural framework**, **Silk Road weapons**, **Cosmological architecture (all 8 decisions locked 2026-03-17)**, **World entity infrastructure (factions/events/concepts indexes + all location templates 2026-03-10)**, **Preliminary world diagrams (2026-03-13)**, **HTML publishing pipeline + Netlify deployment (2026-03-15)**, **Visibility gating + Obsidian Shell Commands integration (2026-03-17)**
-- 🔄 **Active work:** Session 0 scenarios (3/6 core done; expanded 4 have design framework only), STORY_ARC_SYNTHESIS.md needs update to reflect locked decisions, individual entity files to be created from indexes
-- ~~⚠️ **Blockers:** liberation_aftermath.md rewrite (Warren disturbance framing — see DECISION_LOG 2026-03-08)~~ ✅ **Resolved 2026-04-05** — v2.0 complete; Warren disturbance framing + 1,000-year timeline. [#106](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/106)
-- ✅ **Completed (2026-04-11):** `lat.md/` AI navigation layer — 6 dense, path-forward orientation files (`cosmology`, `session0`, `characters`, `world`, `mechanics`, `decisions`) + CLAUDE.md Quick Navigation table. [#121](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/121)
-- ✅ **Completed (2026-04-11):** CLAUDE.md audit + subagent context block — created `lat.md/subagent-context.md` (portable 83-line constraint block for spawned agents); CLAUDE.md slimmed 258→174 lines; stale Wizard constraint corrected; `.meta/` consolidated as archive directory; subagent-context maintenance rule added to Working Conventions. [#128](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/128)
-- 🗒️ **Backlog added (2026-04-07):** Nianhao D3 timeline phase 2 — content import, GM-tunable influence scores, cross-view interaction, mobile optimization, LK sync docs, click-through to event pages. [#116](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/116)
-- 🆕 **Filed (2026-04-14):** Faction file stubs — 16 P1–P3 faction files to create from `_category.md` registry; 3 deferred pending #42, #43, Decision #11. [#144](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/144)
-- 🗒️ **Backlog added (2026-04-13):** HTML generation pipeline refactor — consolidate shared utilities, eliminate `_Generator` boilerplate + CSS token drift across 6 scripts (~5,300 lines). 5 stages, independently deployable. [#138](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/138)
-- 🗒️ **Backlog added (2026-04-21):** DASHBOARD.md schema + generator refactor — separate health panel (Quick Summary, Player Status, Critical Path, overrides) from TODO.md into a 40-line structured file; six regex extractors replaced with YAML readers; `SECTION_DOMAIN_HEADERS` expanded with Daggerheart + world keywords; TODO.md PROJECT HEALTH section removed. [#166](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/166)
-- 🗒️ **Backlog added (2026-03-26):** Dashboard completion % from GitHub Issues — explore tying domain/section completion percentages to GitHub issue open/closed state (in addition to TODO.md checkbox counts). Requires GitHub API call during dashboard generation. Low priority; investigate after hook infrastructure ([#40](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/40)) is live.
-- 🗒️ **Backlog added (2026-04-21):** `docs/` output hierarchy restructure — move per-document HTML into `/world`-matching subdirectories (`docs/mythology/`, `docs/timelines/`, etc.); fixes ~500-file flat directory; asset paths require root-relative switch. [#168](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/168)
-- 🗒️ **Backlog added (2026-03-21):** Template frontmatter reconciliation — `templates/world-building/` files use non-canonical fields (`type: concept`, `classification:` instead of `visibility:`, etc.); needs pass to align with CLAUDE.md spec
-- 🆕 **Infrastructure complete (2026-03-15–17):** LegendKeeper dual-path pipeline, HTML generator (timeline + myth), Calendar Era labels (HJ/HB), batch runner + auto-generated index, Netlify deploy, GitHub Actions, visibility gating (fails-closed `--public`), Obsidian Shell Commands setup, **LK ↔ Markdown round-trip complete (`.lk` import/export + reverse converter, 2026-03-17)**
-- 🗃️ **Charm system deferred (2026-03-13):** Archived to `archive/charms/`; Daggerheart base used for now; Charm reference audit + remaining cleanup moved to `BACKLOG.md`
-
-**Players:** 1/6 committed — Warrior ✅ | Breaker / Bridge / Seeker / Sacrificer / Visionary / Trickster / Crafter / Sentinel / Healer ⏳
+_Project health tracked in [DASHBOARD.md](DASHBOARD.md)_
 
 ---
 

--- a/lat.md/subagent-context.md
+++ b/lat.md/subagent-context.md
@@ -5,7 +5,7 @@ type: navigation
 visibility: internal
 status: canon
 created: 2026-04-11
-last_updated: 2026-04-11
+last_updated: 2026-04-22
 ---
 
 > _Derived from CLAUDE.md and `lat.md/` files — update in the same commit when those change. Inject into spawned agent prompts; this file is not automatically read by any session._
@@ -16,6 +16,10 @@ The following contain no canonical content. Do not open them under any circumsta
 - `.meta/` directory — human audit trail only; all canonical content is summarized in `lat.md/` files
 - `transcripts/` — 12 historical session logs; no design decisions
 - `world/Index.md`, `world/factions/Index.md`, `characters/Index.md` — Dataview queries, not Claude-readable
+
+## Session-Start Reads
+
+At session start, read in order: `TODO.md` (active checklist + session log), `DASHBOARD.md` (health panel — critical path, player status, quick summary, blockers). Then read relevant `lat.md/` files for the session's domain before beginning work.
 
 ## Navigation
 

--- a/utilities/dashboard/generate_dashboard.py
+++ b/utilities/dashboard/generate_dashboard.py
@@ -2,7 +2,7 @@
 """
 Tarim-Shaiel Dashboard Generator
 =================================
-Parses TODO.md and generates docs/dashboard.html
+Parses TODO.md (checkbox counts) and DASHBOARD.md (health panel) to generate docs/dashboard.html.
 
 Usage:
     python generate_dashboard.py
@@ -34,9 +34,10 @@ SCRIPT_DIR  = Path(__file__).parent
 sys.path.insert(0, str(SCRIPT_DIR.parent))
 from shared.config import ProjectConfig
 
-VAULT_ROOT  = ProjectConfig.vault_root
-TODO_PATH   = VAULT_ROOT / "TODO.md"
-OUTPUT_PATH = VAULT_ROOT / "docs" / "dashboard.html"
+VAULT_ROOT      = ProjectConfig.vault_root
+TODO_PATH       = VAULT_ROOT / "TODO.md"
+DASHBOARD_PATH  = VAULT_ROOT / "DASHBOARD.md"
+OUTPUT_PATH     = VAULT_ROOT / "docs" / "dashboard.html"
 
 # ---------------------------------------------------------------------------
 # Domain keyword detection
@@ -127,36 +128,113 @@ class DashboardData:
     player_status: dict = field(default_factory=dict)
 
 # ---------------------------------------------------------------------------
-# Progress Tracking override parser
-# Reads manually-curated percentages from the Progress Tracking section and
-# uses them to override checkbox-computed values for that domain.
+# DASHBOARD.md reader
+# Replaces six regex-based extractors. Reads YAML frontmatter + Quick Summary
+# body from DASHBOARD.md. Falls back to sensible defaults if file is missing.
 # ---------------------------------------------------------------------------
-PROGRESS_RE = re.compile(r"\*\*([^*]+):\*\*\s*(\d+)%", re.IGNORECASE)
-LABEL_TO_DOMAIN = {
-    "story": "narrative", "narrative": "narrative",
-    "world": "world", "world-building": "world",
-    "game mechanics": "mechanics", "mechanics": "mechanics",
-    "infrastructure": "infra", "infra": "infra",
-    "cosmolog": "cosmology",
-}
+_SUMMARY_STATUS_MAP = [
+    ("✅",  "done"),      # ✅
+    ("\U0001f504", "active"), # 🔄
+    ("⚠",  "blocked"),   # ⚠
+    ("\U0001f195", "info"),   # 🆕
+    ("\U0001f5c3", "info"),   # 🗃️
+    ("\U0001f5d2", "info"),   # 🗒️
+    ("- [x]",   "done"),
+    ("- [ ]",   "pending"),
+]
 
-def extract_manual_overrides(todo_text: str) -> dict[str, int]:
-    overrides: dict[str, int] = {}
-    in_progress = False
-    for line in todo_text.splitlines():
-        if re.search(r"##.*PROGRESS TRACKING", line, re.IGNORECASE):
-            in_progress = True
-        elif in_progress and line.startswith("## "):
+def parse_dashboard_md() -> dict:
+    """Parse DASHBOARD.md and return structured health-panel data.
+
+    Keys returned: last_updated, critical_path, players, domain_overrides,
+    blockers, quick_summary.
+    """
+    if not DASHBOARD_PATH.exists():
+        print(f"WARNING: {DASHBOARD_PATH} not found — health panel will use defaults. "
+              "Create DASHBOARD.md to resolve this.")
+        return {
+            "last_updated":     date.today().strftime("%B %d, %Y"),
+            "critical_path":    ["Complete Session 0 scenarios", "Resolve Campaign Frame", "Playtest"],
+            "players":          {"summary": "", "archetypes": []},
+            "domain_overrides": {},
+            "blockers":         ["No active blockers detected"],
+            "quick_summary":    [],
+        }
+
+    from shared.frontmatter import parse_frontmatter
+    text = DASHBOARD_PATH.read_text(encoding="utf-8")
+    fm, body = parse_frontmatter(text)
+
+    # last_updated
+    raw_date = fm.get("last_updated", "")
+    try:
+        parsed_date = datetime.strptime(str(raw_date), "%Y-%m-%d")
+        last_updated = parsed_date.strftime("%B %d, %Y")
+    except (ValueError, TypeError):
+        last_updated = date.today().strftime("%B %d, %Y")
+
+    # critical_path
+    critical_path = fm.get("critical_path") or []
+    if isinstance(critical_path, str):
+        critical_path = [s.strip() for s in re.split(r"→|->", critical_path) if s.strip()]
+
+    # players
+    players_fm = fm.get("players") or {}
+    committed  = players_fm.get("committed", 0)
+    total      = players_fm.get("total", 0)
+    archetypes = [
+        {"name": a["name"], "status": a.get("status", "pending")}
+        for a in (players_fm.get("archetypes") or [])
+        if isinstance(a, dict)
+    ]
+    player_status = {
+        "summary":    f"{committed}/{total} committed" if (committed or total) else "",
+        "archetypes": archetypes,
+    }
+
+    # domain_overrides
+    overrides_fm    = fm.get("domain_overrides") or {}
+    domain_overrides = {k: int(v) for k, v in overrides_fm.items() if v is not None}
+
+    # blockers
+    blockers_raw = fm.get("blockers") or []
+    blockers     = [str(b) for b in blockers_raw if b] if blockers_raw else ["No active blockers detected"]
+
+    # quick_summary — scan body for ## Quick Summary bullets
+    quick_summary: list[dict] = []
+    in_summary = False
+    for line in body.splitlines():
+        if re.match(r"^## Quick Summary", line, re.IGNORECASE):
+            in_summary = True
+            continue
+        if in_summary and line.startswith("## "):
             break
-        if in_progress:
-            for m in PROGRESS_RE.finditer(line):
-                label = m.group(1).strip().lower()
-                pct   = int(m.group(2))
-                for key, domain in LABEL_TO_DOMAIN.items():
-                    if key in label:
-                        overrides[domain] = pct
-                        break
-    return overrides
+        if in_summary:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if not stripped.startswith("-"):
+                break
+            item_text = stripped.lstrip("- ").strip()
+            item_text = re.sub(r"^\[[xX ]\]\s*", "", item_text)
+            item_text = re.sub(r"\*\*([^*]+)\*\*", r"\1", item_text)
+            item_text = re.sub(r"`[^`]+`", "", item_text).strip()
+            status = "info"
+            for marker, s in _SUMMARY_STATUS_MAP:
+                if marker in stripped:
+                    status = s
+                    break
+            display = item_text[:240] + ("…" if len(item_text) > 240 else "")
+            quick_summary.append({"text": display, "status": status})
+
+    return {
+        "last_updated":     last_updated,
+        "critical_path":    critical_path,
+        "players":          player_status,
+        "domain_overrides": domain_overrides,
+        "blockers":         blockers,
+        "quick_summary":    quick_summary,
+    }
 
 # ---------------------------------------------------------------------------
 # Checkbox counter per domain
@@ -168,9 +246,13 @@ SECTION_DOMAIN_HEADERS: dict[str, str] = {
     "awakening": "narrative", "lore": "narrative", "liberation": "narrative",
     "charm": "mechanics", "tool": "mechanics", "campaign frame": "mechanics",
     "mechanics": "mechanics", "archetype": "mechanics",
+    "domains":    "mechanics", "abilities":  "mechanics", "classes":    "mechanics",
+    "subclasses": "mechanics", "armor":      "mechanics",
     "world": "world", "geographic": "world", "ancestry": "world",
-    "location": "world", "orc": "world", "myth": "world", "silk road": "world",
-    "npc": "world", "culture": "world",
+    "location": "world", "locations": "world", "orc": "world", "myth": "world",
+    "silk road": "world", "npc": "world", "culture": "world",
+    "faction": "world", "factions": "world", "events": "world",
+    "regions": "world",
     "kanka": "infra", "obsidian": "infra", "infrastructure": "infra",
     "geojson": "infra", "documentation": "infra", "sync": "infra",
 }
@@ -230,20 +312,6 @@ def compute_readiness(domain_pcts: dict[str, int]) -> int:
     return round(sum(domain_pcts.get(d, 0) * w for d, w in DOMAIN_WEIGHTS.items()))
 
 # ---------------------------------------------------------------------------
-# Blocker extraction
-# ---------------------------------------------------------------------------
-BLOCKER_PATTERNS = [
-    (r"Campaign Frame.*?Archetypes|Classes vs",     "\u26d4 Campaign Frame: Classes vs. Archetypes decision required"),
-]
-
-def extract_blockers(todo_text: str) -> list[str]:
-    found = []
-    for pattern, label in BLOCKER_PATTERNS:
-        if re.search(pattern, todo_text, re.IGNORECASE):
-            found.append(label)
-    return found or ["No active blockers detected"]
-
-# ---------------------------------------------------------------------------
 # Recent sessions — reads from ## SESSION LOG, ### Session YYYY-MM-DD entries
 # ---------------------------------------------------------------------------
 SESSION_LOG_RE = re.compile(
@@ -277,121 +345,9 @@ def extract_recent_sessions(todo_text: str) -> list[dict]:
 # ---------------------------------------------------------------------------
 # Metadata
 # ---------------------------------------------------------------------------
-def extract_last_updated(todo_text: str) -> str:
-    m = re.search(r"last_updated:\s*(\d{4}-\d{2}-\d{2})", todo_text)
-    if m:
-        # Parse the date and format nicely
-        from datetime import datetime as dt
-        date_str = m.group(1)
-        try:
-            parsed = dt.strptime(date_str, "%Y-%m-%d")
-            return parsed.strftime("%B %d, %Y")
-        except ValueError:
-            return date_str  # fallback
-    m = re.search(r"\*\*Last Updated:\*\*\s*(\d{4}-\d{2}-\d{2})", todo_text)
-    if m:
-        date_str = m.group(1)
-        try:
-            parsed = dt.strptime(date_str, "%Y-%m-%d")
-            return parsed.strftime("%B %d, %Y")
-        except ValueError:
-            return date_str
-    return date.today().strftime("%B %d, %Y")
-
 def extract_generation_time() -> str:
     return datetime.now().strftime("%B %d, %Y at %I:%M %p")
 
-def extract_critical_path(todo_text: str) -> list[str]:
-    m = re.search(r"\*\*Critical Path:\*\*\s*(.+?)(?:\n|$)", todo_text)
-    if m:
-        return [s.strip() for s in re.split(r"\u2192|->", m.group(1)) if s.strip()]
-    return [
-        "Cosmological architecture decisions",
-        "Complete Session 0 scenarios",
-        "Resolve Campaign Frame",
-        "Build Charm library",
-        "Playtest",
-    ]
-
-# ---------------------------------------------------------------------------
-# Quick Summary extractor — parses **Quick Summary:** bullets from PROJECT HEALTH
-# ---------------------------------------------------------------------------
-QUICK_SUMMARY_STATUS_MAP = [
-    ("\u2705",  "done"),     # ✅
-    ("\U0001f504", "active"),  # 🔄
-    ("\u26a0",  "blocked"),  # ⚠ (also ⚠️)
-    ("\U0001f195", "info"),  # 🆕
-    ("\U0001f5c3", "info"),  # 🗃️
-    ("- [x]",   "done"),
-    ("- [ ]",   "pending"),
-]
-
-def extract_quick_summary(todo_text: str) -> list[dict]:
-    items: list[dict] = []
-    in_health = False
-    in_summary = False
-    for line in todo_text.splitlines():
-        if re.match(r"^## PROJECT HEALTH", line, re.IGNORECASE):
-            in_health = True
-            continue
-        if in_health and line.startswith("## "):
-            break
-        if in_health and "**Quick Summary:**" in line:
-            in_summary = True
-            continue
-        if in_summary:
-            stripped = line.strip()
-            if not stripped:
-                continue
-            # Stop when we hit a non-list line that isn't blank (e.g. **Players:**)
-            if not stripped.startswith("-"):
-                break
-            text = stripped.lstrip("- ").strip()
-            # Strip checkbox markers
-            text = re.sub(r"^\[[xX ]\]\s*", "", text)
-            # Clean markdown bold
-            text = re.sub(r"\*\*([^*]+)\*\*", r"\1", text)
-            # Strip backtick code spans and trailing link references
-            text = re.sub(r"`[^`]+`", "", text).strip()
-            status = "info"
-            for marker, s in QUICK_SUMMARY_STATUS_MAP:
-                if marker in stripped:
-                    status = s
-                    break
-            # Truncate long lines for display
-            display = text[:240] + ("…" if len(text) > 240 else "")
-            items.append({"text": display, "status": status})
-    return items
-
-# ---------------------------------------------------------------------------
-# Player Status extractor — parses **Players:** line from PROJECT HEALTH
-# ---------------------------------------------------------------------------
-def extract_player_status(todo_text: str) -> dict:
-    m = re.search(r"\*\*Players:\*\*\s*(.+?)(?:\n|$)", todo_text)
-    if not m:
-        return {"summary": "", "archetypes": []}
-    raw = m.group(1).strip()
-
-    # Count: "1/6 committed"
-    count_m = re.search(r"(\d+)/(\d+)\s+\w+", raw)
-    summary = f"{count_m.group(1)}/{count_m.group(2)} committed" if count_m else ""
-
-    # Archetype list — after the em-dash: "Warrior ✅ | Breaker / Bridge / Seeker / Sacrificer / Visionary ⏳"
-    archetypes: list[dict] = []
-    after_dash = re.search(r"[—\-]\s*(.+)$", raw)
-    if after_dash:
-        segment = after_dash.group(1)
-        for part in re.split(r"\s*/\s*|\s*\|\s*", segment):
-            part = part.strip()
-            if not part:
-                continue
-            if "\u2705" in part:   # ✅
-                archetypes.append({"name": part.replace("\u2705", "").strip(), "status": "committed"})
-            elif "\u23f3" in part: # ⏳
-                archetypes.append({"name": part.replace("\u23f3", "").strip(), "status": "pending"})
-            else:
-                archetypes.append({"name": part.strip(), "status": "pending"})
-    return {"summary": summary, "archetypes": archetypes}
 
 # ---------------------------------------------------------------------------
 # TODO section parser
@@ -830,7 +786,7 @@ def render_html(data: DashboardData) -> str:
         <div class="header-subtitle">State of the world as of {data.generation_time}</div>
       </div>
       <div class="header-meta">
-        <div class="last-updated">TODO.md last updated: {data.last_updated}</div>
+        <div class="last-updated">Dashboard last updated: {data.last_updated}</div>
         <div class="last-updated" style="margin-top:4px">Dun-Kharan caravan departs at dawn</div>
       </div>
     </div>
@@ -966,20 +922,21 @@ def main():
     print(f"Reading {todo_path.name} ...")
     txt = todo_path.read_text(encoding="utf-8")
 
-    overrides   = extract_manual_overrides(txt)
+    dashboard   = parse_dashboard_md()
+    overrides   = dashboard["domain_overrides"]
     domain_pcts = compute_domain_pcts(txt, overrides)
     readiness   = compute_readiness(domain_pcts)
     data = DashboardData(
-        last_updated    = extract_last_updated(txt),
+        last_updated    = dashboard["last_updated"],
         generation_time = extract_generation_time(),
         readiness       = readiness,
         domain_pcts     = domain_pcts,
-        critical_path   = extract_critical_path(txt),
-        blockers        = extract_blockers(txt),
+        critical_path   = dashboard["critical_path"],
+        blockers        = dashboard["blockers"],
         recent_sessions = extract_recent_sessions(txt),
         sections        = parse_todo_sections(txt),
-        quick_summary   = extract_quick_summary(txt),
-        player_status   = extract_player_status(txt),
+        quick_summary   = dashboard["quick_summary"],
+        player_status   = dashboard["players"],
     )
 
     if args.json:
@@ -994,7 +951,7 @@ def main():
     print(f"\nDashboard -> {out_path}")
     print(f"  Readiness : {readiness}%")
     for d, pct in domain_pcts.items():
-        src = " (override)" if d in overrides else ""
+        src = " (override)" if d in dashboard["domain_overrides"] else ""
         print(f"  {d:12s}: {pct}%{src}")
     print(f"  Sections  : {len(data.sections)}")
     print(f"  Blockers  : {len(data.blockers)}")


### PR DESCRIPTION
- Create DASHBOARD.md at vault root: YAML frontmatter for critical_path, players, domain_overrides, blockers; Markdown body for Quick Summary bullets
- Replace six regex-based extractors (extract_manual_overrides, extract_last_updated, extract_critical_path, extract_blockers, extract_quick_summary, extract_player_status) with parse_dashboard_md() — reads YAML + body from DASHBOARD.md; graceful fallback (console warning + sensible defaults) if file is missing
- Expand SECTION_DOMAIN_HEADERS: faction/factions/events/locations/regions → world; domains/abilities/classes/subclasses/armor → mechanics
- Trim TODO.md PROJECT HEALTH section to a single reference line
- Update CLAUDE.md Key Reference Files + Working Conventions for DASHBOARD.md
- Update lat.md/subagent-context.md: add DASHBOARD.md as session-start read target

Closes #166

https://claude.ai/code/session_01CmijDEQWqyM8BsD2g4qr4J