### PR TITLE
infra: implement account-based GM gatekeeping (#176)

### DIFF
--- a/.meta/DECISION_LOG.md
+++ b/.meta/DECISION_LOG.md
@@ -515,3 +515,35 @@ Post-implementation baseline test — 3 parallel Explore agents with `lat.md/sub
 | "What are the locked decisions?" | 908 lines / 9 inv | **59 lines / 1 file** | `.meta/` never opened ✅ |
 | "What happened in previous sessions?" | 1,307 lines / 6 inv | **282 lines / 4 files** | `transcripts/` never opened ✅ |
 | "Write a Warrior archetype description" | 1,423 lines / 9 inv | **198 lines / 2 files** | Routed via `lat.md/characters.md` first; constraints applied correctly ✅ |
+
+
+## Decision 15 — Account-Based GM Gatekeeping Architecture
+
+**Date:** 2026-04-22
+**Domain:** Publishing infrastructure
+**Status:** 🔒 LOCKED
+
+**Decision:** Two-deploy architecture (public unchanged; new GM deploy with Netlify Identity, invite-only) plus a three-tier component markdown system for intra-page GM content.
+
+**Architecture:**
+- Public deploy: `build.py all --public` — unchanged, no auth, `gm_secrets` files never generated
+- GM deploy: `build.py all --gm` — all content, Netlify Identity auth guard injected into every page, `TS_GM_MODE=1` env var set
+- Second Netlify site points at same repo; build command overridden to use `netlify-gm.toml`
+
+**Three-tier component system (all build-time, nothing in DOM):**
+- Tier 1 `{gm:text}`: inline — public → `██████` bar; GM → crimson underline span
+- Tier 2 `> [!gm-only]`: callout block — public → stripped; GM → crimson callout
+- Tier 3 `![[gm_secrets/filename]]`: .md transclusion — public → stripped; GM → rendered block
+
+**Key files:**
+- `netlify-gm.toml` — second deploy config
+- `docs/login.html` — Netlify Identity login page
+- `GM_AUTHORING.md` — authoring reference
+- `utilities/build.py` — `--gm` flag + `TS_GM_MODE=1`
+- `utilities/shared/md_utils.py` — Tier 1 in `inline_md()`
+- `utilities/shared/html_render.py` — Tier 2 in `render_body()`, Tier 3 in `render_wiki_embed()`
+- `utilities/world/generate_world_html.py` — `gm_mode` param, per-page banners, auth guard
+- `utilities/world/generate_all_world_html.py` — `--gm` flag, badge CSS, index call chain
+- `utilities/shared/page_shell.py` — auth guard + GM banner for lore/ancestry pages
+
+**GitHub Issue:** #176

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ last_updated: YYYY-MM-DD
 - `visibility: gm_secrets` = GM-only; `visibility: public` = player-facing; `visibility: internal` = operational/navigational infrastructure (never player-facing, never published; e.g. `lat.md/` files)
 - `status: canon` = locked/authoritative; do not change without explicit direction
 - Template filenames are prefixed `_TEMPLATE_`
+- GM markdown conventions (inline redaction `{gm:text}`, block callouts `> [!gm-only]`, file transclusion `![[gm_secrets/...]]`): see `GM_AUTHORING.md`
 
 ### File Persistence Rule
 Write to filesystem if: source-of-truth doc, referenced across conversations, Lore Keeper needs to track it, session artifact, decision log entry.

--- a/DASHBOARD.md
+++ b/DASHBOARD.md
@@ -48,6 +48,7 @@ blockers:
 - 🆕 **Filed (2026-04-14):** Faction file stubs — 16 P1–P3 faction files to create from _category.md registry; 3 deferred pending #42, #43, Decision #11. [#144](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/144)
 - 🗒️ **Backlog:** HTML generation pipeline refactor — consolidate shared utilities, eliminate _Generator boilerplate + CSS token drift across 6 scripts. [#138](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/138)
 - 🗒️ **Backlog:** docs/ output hierarchy restructure — move per-document HTML into subdirectories; fixes ~500-file flat directory. [#168](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/168)
+- ✅ **Completed (2026-04-22):** Account-based GM gatekeeping — `build.py all --gm`, Netlify Identity auth guard, three-tier markdown gating (Tier 1/2/3), `docs/login.html`, `GM_AUTHORING.md`. Remaining: manual Netlify second-site setup. [#176](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/176)
 - 🗒️ **Backlog:** Nianhao D3 timeline phase 2 — content import, GM-tunable influence scores, cross-view interaction, mobile optimization. [#116](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/116)
 - 🗒️ **Backlog:** Dashboard completion % from GitHub Issues — tie domain percentages to issue open/closed state. [#40](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/40)
 - 🗒️ **Backlog:** Template frontmatter reconciliation — align templates/world-building/ files with CLAUDE.md spec

--- a/GM_AUTHORING.md
+++ b/GM_AUTHORING.md
@@ -1,0 +1,159 @@
+---
+title: GM Content Authoring Guide
+project: TTRPG_Tarim_Shaiel
+type: operational
+visibility: internal
+status: canon
+created: 2026-04-22
+last_updated: 2026-04-22
+---
+
+# GM Content Authoring Guide
+
+Reference for all four content-gating levels in the Tarim-Shaiel publishing pipeline. All gating is **build-time** — nothing is hidden client-side. Players who visit the public site can never see GM content, even via DevTools.
+
+---
+
+## Gating Level Summary
+
+| Level | Syntax | Scope | Public output | GM output |
+|---|---|---|---|---|
+| Page-level | `visibility: gm_secrets` frontmatter | Entire file | File never generated | Full page with crimson top border + "GM EYES ONLY" banner |
+| Tier 1 | `{gm:text}` | Single word/phrase inline | `██████` redaction bar | Crimson underline span |
+| Tier 2 | `> [!gm-only]` callout block | Paragraph(s) in a public doc | Stripped entirely | Crimson left-border callout |
+| Tier 3 | `![[gm_secrets/filename]]` | Arbitrary-length content from a separate file | Stripped entirely | Rendered with crimson left border, "↓ GM CONTENT" label |
+
+---
+
+## Page-Level Gating
+
+Set `visibility: gm_secrets` in the file's frontmatter. The entire file is excluded from `--public` builds. No other changes needed.
+
+For mixed-visibility files (public doc with embedded GM notes), use Tier 1–3 instead.
+
+---
+
+## Tier 1 — Inline Redaction: `{gm:text}`
+
+For a single word, name, number, or short phrase that must stay hidden in a sentence.
+
+**Syntax:**
+```
+The Wizard's true name is {gm:Sylaveth Vorn}, bound to the Sixth Warren.
+The chest contains {gm:1,200 gp and a +2 dagger named Ashwhisper}.
+```
+
+**Public output:** `<span class="gm-redacted">██████</span>` — a black-on-black bar.  
+Players see a thematic redaction signal that information exists but is withheld.
+
+**GM output:** `<span class="gm-inline">Sylaveth Vorn</span>` — crimson underline.
+
+**Obsidian:** Renders as literal `{gm:...}` text — readable in vault, doesn't break other syntax.
+
+**When to use:** A name, a number, a single suppressed fact. Any longer GM note → Tier 2 or 3.
+
+---
+
+## Tier 2 — Block Callout: `> [!gm-only]`
+
+For paragraph-length GM notes (hidden motivations, trap details, spoiler annotations) embedded within a public document.
+
+**Syntax:**
+```markdown
+The ruin was abandoned before the empire fell.
+
+> [!gm-only]
+> That's the official story. Players will learn the tower was sealed after
+> a containment failure — the Held Breath "Dust of the Closed Eye" nearly
+> awakened here in 1209 CE.
+>
+> They can find the truth in the sealed lower chamber (Perception DC 16).
+
+The locals avoid it entirely.
+```
+
+**Public output:** The entire callout block is stripped. No trace in the DOM.
+
+**GM output:** Crimson left-border callout with "GM ONLY" label above the content.
+
+**Multi-paragraph:** Use `>` alone on blank lines to continue the callout. If you leave a truly blank line (no `>`), the block is split into two paragraphs — use `>` on every line including blanks.
+
+**Supports:** Multiple paragraphs, lists, inline markdown, Tier 1 `{gm:...}` markers within the block.
+
+**Does not support:** Nested headings inside the callout. Use Tier 3 for content with headers or tables.
+
+**Obsidian:** Renders as a styled callout in vault preview. Clearly visible during authoring.
+
+**When to use:** A GM annotation, hidden NPC motivation, encounter note. Anything up to a few paragraphs that lives inside a public document.
+
+---
+
+## Tier 3 — File Transclusion: `![[gm_secrets/filename]]`
+
+For arbitrary-length GM content: full scene descriptions, encounter tables, stat blocks, anything with headers, tables, or multiple sections.
+
+**Syntax:**
+```markdown
+## The Black Palace — Ground Floor
+
+The ground floor is accessible via the collapsed east wall.
+
+![[gm_secrets/black_palace_ground_floor_gm_notes]]
+
+The inner sanctum is locked with a puzzle lock (DC 18 Investigation).
+```
+
+**Public output:** The embed line is stripped entirely.
+
+**GM output:** The referenced `.md` file is located via vault search, its body rendered, and wrapped in a `<div class="gm-block">` with "↓ GM CONTENT" label and crimson border.
+
+**Path convention:** Always use `gm_secrets/` as a prefix in the `![[...]]` reference so the pipeline can detect it without a file lookup. The filename stem without extension is sufficient:
+- `![[gm_secrets/filename]]` → resolves `filename.md` anywhere in the vault
+
+**File creation workflow:**
+1. Create the file in the appropriate `gm_secrets/` subdirectory (e.g. `world/locations/gm_secrets/black_palace_gm.md`)
+2. Add `visibility: gm_secrets` to its frontmatter
+3. Reference it from the public parent doc with `![[gm_secrets/black_palace_gm]]`
+
+**Supports:** Full markdown — headings, tables, lists, audio embeds, Tier 1 `{gm:...}` and Tier 2 `> [!gm-only]` within the transcluded file.
+
+**Obsidian:** Renders as a full embedded document (native wikilink transclusion).
+
+**When to use:** A full scene description, stat block, encounter table, or any section with headers — anything too large or structured for a Tier 2 callout.
+
+---
+
+## Decision Guide: Which Tier?
+
+| Scenario | Use |
+|---|---|
+| A name, a number, a single fact | Tier 1 `{gm:...}` |
+| A GM note, hidden motivation, spoiler annotation (up to a few paragraphs) | Tier 2 `> [!gm-only]` |
+| A full scene, encounter table, stat block, anything with headers | Tier 3 `![[gm_secrets/...]]` |
+| An entire file is GM-only | Page-level `visibility: gm_secrets` frontmatter |
+
+---
+
+## Build Behavior Reference
+
+| Build command | Tier 1 | Tier 2 | Tier 3 | Page-level gm_secrets |
+|---|---|---|---|---|
+| `build.py all --public` | `██████` bars | Stripped | Stripped | File skipped |
+| `build.py all` (local) | `██████` bars | Stripped | Stripped | Rendered (no auth) |
+| `build.py all --gm` | Crimson spans | Crimson callouts | GM blocks | Rendered, crimson banner |
+
+**Note:** The local run (`build.py all` with no flag) generates `gm_secrets` pages for GM preview, but does NOT inject the Netlify Identity auth guard. Use `--gm` for the deployed GM site.
+
+---
+
+## Netlify Setup (manual, one-time)
+
+The GM deploy uses a second Netlify site pointing at this repo with `netlify-gm.toml` as the build config:
+
+1. In Netlify UI: Add new site → same GitHub repo
+2. Override build settings: build command `python utilities/build.py all --gm`, publish dir `docs`
+3. Site settings → Identity → Enable → set registration to **Invite only**
+4. Identity → Invite users → your email → follow invite link to set a password
+5. Keep the GM site URL private (Netlify subdomain URLs are not enumerable)
+
+After login, the JWT persists in `localStorage` (default 60-day expiry) — no re-login on each visit.

--- a/TODO.md
+++ b/TODO.md
@@ -24,11 +24,19 @@ _Project health tracked in [DASHBOARD.md](DASHBOARD.md)_
 _What happened this session. Newest first. Trim to last 3 sessions; older entries go to archive._
 
 ### 2026-04-22
-- Designed account-based GM gatekeeping system — filed [#176](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/176)
-  - Architecture: two Netlify deploys (public unchanged; new GM deploy with Netlify Identity, invite-only)
-  - Three-tier component markdown system: Tier 1 `{gm:text}` inline redaction, Tier 2 `> [!gm-only]` callout, Tier 3 `![[gm_secrets/file]]` `.md` transclusion — all build-time, nothing in DOM
-  - `GM_AUTHORING.md` authoring reference planned at repo root
-  - Branch: `claude/account-based-gatekeeping-0alHN`; implementation pending
+- Implemented account-based GM gatekeeping — [#176](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/176) ✅
+  - `netlify-gm.toml` — second deploy config (`build.py all --gm`)
+  - `docs/login.html` — parchment-styled Netlify Identity login page
+  - Tier 1: `{gm:text}` inline redaction in `md_utils.py::inline_md()`
+  - Tier 2: `> [!gm-only]` callout in `html_render.py::render_body()`
+  - Tier 3: `![[gm_secrets/...]]` transclusion in `html_render.py::render_wiki_embed()`
+  - Per-page GM/public banners + auth guard in `generate_world_html.py`
+  - `generate_all_world_html.py`: `--gm` flag, badge CSS, full call chain
+  - `build.py`: `--gm` flag sets `TS_GM_MODE=1` env var
+  - `page_shell.py`: auth guard injection for lore/ancestry pages
+  - `GM_AUTHORING.md` reference doc + `CLAUDE.md` pointer
+  - Decision 15 logged; world_base.css extended with GM component CSS
+  - **Remaining:** manual Netlify second-site setup (user action)
 
 ### 2026-04-11 (continued, session 2)
 - Implemented [#128](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/128): CLAUDE.md audit + subagent context block
@@ -449,22 +457,22 @@ _Manual one-time setup steps for Obsidian Shell Commands integration + Netlify._
 
 ---
 
-### 11. Account-Based GM Gatekeeping 🆕 NOT STARTED ([#176](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/176))
+### 11. Account-Based GM Gatekeeping ✅ COMPLETE ([#176](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/176))
 **Domain:** `utilities/` + `docs/`
 **Description:** Second Netlify deploy (`build.py all --gm`) gated by Netlify Identity (invite-only). GM sees all content including `gm_secrets` pages, each visually marked. Three-tier component markdown system for intra-page GM content (inline redaction, callout blocks, file transclusion) — all build-time, nothing in the DOM.
 
-- [ ] Create `netlify-gm.toml` — second deploy config
-- [ ] Create `docs/login.html` — parchment-styled Netlify Identity login page
-- [ ] `utilities/shared/md_utils.py` — Tier 1: `{gm:text}` inline redaction in `inline_md()`
-- [ ] `utilities/shared/html_render.py` — Tier 2: `> [!gm-only]` callout + Tier 3: `![[gm_secrets/file]]` `.md` transclusion
-- [ ] `utilities/world/generate_world_html.py` — `gm_mode` param, per-page banners, thread `vault`+`gm_mode` through render chain
-- [ ] `utilities/shared/page_shell.py` — auth guard injection via `TS_GM_MODE` env var
-- [ ] `utilities/world/generate_all_world_html.py` — `--gm` flag, gating logic, badge CSS, full call chain
-- [ ] `utilities/build.py` — `--gm` flag + set `TS_GM_MODE=1`
-- [ ] Create `GM_AUTHORING.md` (repo root) + one-line pointer in `CLAUDE.md`
-- [ ] Manual Netlify setup (user): create second site, enable Identity, invite-only, invite your email
+- [x] Create `netlify-gm.toml` — second deploy config
+- [x] Create `docs/login.html` — parchment-styled Netlify Identity login page
+- [x] `utilities/shared/md_utils.py` — Tier 1: `{gm:text}` inline redaction in `inline_md()`
+- [x] `utilities/shared/html_render.py` — Tier 2: `> [!gm-only]` callout + Tier 3: `![[gm_secrets/file]]` `.md` transclusion
+- [x] `utilities/world/generate_world_html.py` — `gm_mode` param, per-page banners, thread `vault`+`gm_mode` through render chain
+- [x] `utilities/shared/page_shell.py` — auth guard injection via `TS_GM_MODE` env var
+- [x] `utilities/world/generate_all_world_html.py` — `--gm` flag, gating logic, badge CSS, full call chain
+- [x] `utilities/build.py` — `--gm` flag + set `TS_GM_MODE=1`
+- [x] Create `GM_AUTHORING.md` (repo root) + one-line pointer in `CLAUDE.md`
+- [ ] **Manual Netlify setup (user):** create second site, enable Identity, invite-only, invite your email
 
-**Estimated effort:** ~1 session (pipeline) + manual Netlify setup
+**Completed:** 2026-04-22
 
 ---
 

--- a/netlify-gm.toml
+++ b/netlify-gm.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "python utilities/build.py all --gm"
+  publish = "docs"

--- a/utilities/build.py
+++ b/utilities/build.py
@@ -34,6 +34,7 @@ The LegendKeeper pipeline (generate_lk_json, generate_lk_markdown) is
 handled separately by utilities/legendkeeper-pipeline/publish.py.
 """
 
+import os
 import sys
 import argparse
 from pathlib import Path
@@ -90,6 +91,8 @@ def _run_one(name: str, generator, args: argparse.Namespace) -> int:
     elif name == "world-all":
         if args.public:
             argv = ["--public"]
+        elif args.gm:
+            argv = ["--gm"]
         if args.out:
             argv += ["--out", args.out]
 
@@ -109,6 +112,8 @@ def _cmd_list(registry: dict) -> int:
 
 
 def _cmd_run(names: list[str], registry: dict, args: argparse.Namespace) -> int:
+    if args.gm:
+        os.environ['TS_GM_MODE'] = '1'
     failed = []
     for name in names:
         if name not in registry:
@@ -153,6 +158,10 @@ def main() -> int:
     parser.add_argument(
         "--public", action="store_true",
         help="Pass --public to world-all (omit GM content)"
+    )
+    parser.add_argument(
+        "--gm", action="store_true",
+        help="GM mode: include all docs with GM markers + auth guard; sets TS_GM_MODE=1"
     )
 
     args = parser.parse_args()

--- a/utilities/shared/html_render.py
+++ b/utilities/shared/html_render.py
@@ -10,6 +10,7 @@ Depends on: shared.md_utils.inline_md
 import re
 from pathlib import Path
 from html import escape
+from typing import Optional
 
 from shared.md_utils import inline_md
 
@@ -18,21 +19,42 @@ AUDIO_MIME  = {'.mp3': 'audio/mpeg', '.ogg': 'audio/ogg', '.wav': 'audio/wav',
                '.m4a': 'audio/mp4',  '.flac': 'audio/flac', '.aac': 'audio/aac'}
 
 
-def render_wiki_embed(p: str) -> str:
+def render_wiki_embed(
+    p: str,
+    vault: Optional[Path] = None,
+    gm_mode: bool = False,
+) -> str:
     """Render a single Obsidian wiki-embed paragraph (![[...]]) to HTML.
 
-    Returns an audio player div for audio files, or a figure block for images.
-    Returns an empty string if `p` is not a wiki-embed pattern.
+    Returns an audio player div for audio files, a figure for images, or a GM
+    prose block for ![[gm_secrets/...]] embeds.  Returns '' if not a wiki-embed.
+
+    Tier 3 logic:
+      - path contains 'gm_secrets/': public → '' (stripped); GM → rendered block
+      - .md or extensionless with gm_secrets/ prefix → prose transclusion
     """
     obs_m = re.match(r'^!\[\[([^\]|]+)(?:\|([^\]]*))?\]\]$', p)
     if not obs_m:
         return ''
 
     path_part  = obs_m.group(1).strip()
-    # Obsidian allows multiple pipes: ![[file|alias|width]] — take first segment only
     alias_part = (obs_m.group(2) or '').split('|')[0].strip()
     fname = Path(path_part).name
     ext   = Path(fname).suffix.lower()
+
+    # Tier 3: gm_secrets/ prose transclusion
+    if 'gm_secrets/' in path_part.replace('\\', '/'):
+        if not gm_mode or vault is None:
+            return ''
+        fname_md = fname if ext == '.md' else fname + '.md'
+        matches  = list(vault.rglob(fname_md))
+        if not matches:
+            return f'<div class="gm-block"><em>⚠ GM embed not found: {escape(fname_md)}</em></div>\n'
+        raw = matches[0].read_text(encoding='utf-8')
+        # Strip frontmatter inline (avoid circular import with shared.frontmatter)
+        raw_body = re.sub(r'^---\n.*?\n---\n', '', raw, flags=re.DOTALL).strip()
+        body_html, _ = render_body(raw_body, vault, vault / 'docs', gm_mode=gm_mode)
+        return f'<div class="gm-block">{body_html}</div>\n'
 
     if ext in AUDIO_EXTS:
         src   = escape(f'/audio/{fname}')
@@ -162,21 +184,28 @@ def _slug_anchor(text: str) -> str:
     return re.sub(r'[^\w\-]+', '-', text.lower()).strip('-')
 
 
-def render_body(body: str, vault: 'Path', docs: 'Path') -> 'tuple[str, list[dict]]':
+def render_body(
+    body: str,
+    vault: 'Path',
+    docs: 'Path',
+    gm_mode: bool = False,
+) -> 'tuple[str, list[dict]]':
     """Render a full Markdown body to HTML with component support.
 
     Handles (in priority order):
-      ![[file|caption]]  → lore-figure or audio-player (via render_wiki_embed)
-      ![alt](path)       → lore-figure
-      **Name:** text     → feature-box (accumulated into feature-grid)
-      ## heading         → <h2 id=...>  (jump nav level 2)
-      ### heading        → <h3 id=...>  (jump nav level 3)
-      > text             → callout div
-      - item / * item    → <ul>
-      anything else      → <p>
+      ![[gm_secrets/f]] → GM prose block (Tier 3) or stripped (public)
+      ![[file|caption]] → lore-figure or audio-player (via render_wiki_embed)
+      ![alt](path)      → lore-figure
+      > [!gm-only]      → GM callout block (Tier 2) or stripped (public)
+      **Name:** text    → feature-box (accumulated into feature-grid)
+      ## heading        → <h2 id=...>  (jump nav level 2)
+      ### heading       → <h3 id=...>  (jump nav level 3)
+      > text            → callout div
+      - item / * item   → <ul>
+      anything else     → <p>
 
     Strips: frontmatter, Obsidian %% comments, wikilinks (preserving ![[]] embeds),
-    Obsidian callout markers.
+    Obsidian callout markers (except [!gm-only] which is handled by Tier 2).
 
     Returns: (html_string, jump_nav_items)
       jump_nav_items = [{'text': str, 'anchor': str, 'level': int}, ...]
@@ -218,8 +247,21 @@ def render_body(body: str, vault: 'Path', docs: 'Path') -> 'tuple[str, list[dict
         feature_buffer = []
 
     for para in paragraphs:
-        # Wiki-embed: ![[file|caption|width]] → figure or audio
-        wiki_html = render_wiki_embed(para)
+        # Tier 2: GM-only callout block > [!gm-only]
+        # The preprocessing regex (^>\s*\[!\w+\]\s*$) leaves [!gm-only] intact because
+        # \w+ does not match across hyphens, so the marker survives to here.
+        if re.match(r'^>\s*\[!gm-only\]', para):
+            _flush_features()
+            lines = para.splitlines()
+            inner_lines = [re.sub(r'^>\s?', '', ln) for ln in lines[1:]]
+            inner = '\n'.join(inner_lines).strip()
+            if gm_mode:
+                html_parts.append(f'<div class="gm-callout">{inline_md(inner)}</div>\n')
+            # public: strip entirely — GM content never reaches the DOM
+            continue
+
+        # Wiki-embed: ![[file|caption|width]] → figure, audio, or GM prose block
+        wiki_html = render_wiki_embed(para, vault=vault, gm_mode=gm_mode)
         if wiki_html:
             _flush_features()
             html_parts.append(wiki_html)

--- a/utilities/shared/md_utils.py
+++ b/utilities/shared/md_utils.py
@@ -5,6 +5,7 @@ Inline markdown conversion plus Obsidian-specific sanitizers.
 Used by all generators that process Obsidian .md source files.
 """
 
+import os
 import re
 from html import escape as html_escape
 
@@ -27,9 +28,17 @@ def inline_md(text: str) -> str:
     """Convert inline markdown to HTML (bold, italic, bold-italic, links).
 
     HTML-escapes the input first so caller does not need to pre-escape.
-    Handles (in order): bold-italic, bold, italic, markdown links [t](url).
+    Handles (in order): {gm:text} redaction, bold-italic, bold, italic, markdown links.
     """
     text = html_escape(text)
+    # Tier 1 GM inline redaction: {gm:text} → crimson span (GM) or black bar (public)
+    _gm = os.environ.get('TS_GM_MODE') == '1'
+    text = re.sub(
+        r'\{gm:([^}]+)\}',
+        lambda m: (f'<span class="gm-inline">{m.group(1)}</span>'
+                   if _gm else '<span class="gm-redacted">██████</span>'),
+        text,
+    )
     text = re.sub(r'\*{3}(.+?)\*{3}', r'<strong><em>\1</em></strong>', text)
     text = re.sub(r'\*\*(.+?)\*\*', r'<strong>\1</strong>', text)
     text = re.sub(r'\*(.+?)\*', r'<em>\1</em>', text)

--- a/utilities/shared/page_shell.py
+++ b/utilities/shared/page_shell.py
@@ -18,6 +18,7 @@ Each generator supplies:
   - generator_name : appears in the <!-- AUTO-GENERATED --> comment
 """
 
+import os
 from html import escape as html_escape
 
 FAVICON_SVG = (
@@ -305,6 +306,31 @@ CSS_BASE = """\
 
 
 # ---------------------------------------------------------------------------
+# Auth guard script (injected into GM-build pages via TS_GM_MODE env var)
+# ---------------------------------------------------------------------------
+
+_GM_GUARD_SCRIPT = """\
+<script src="https://cdn.jsdelivr.net/npm/netlify-identity-widget@1/build/netlify-identity-widget.js"></script>
+<script>
+(function () {
+  netlifyIdentity.init();
+  netlifyIdentity.on('init', function (user) {
+    if (!user) { window.location.replace('login.html'); }
+  });
+})();
+</script>
+"""
+
+_GM_BANNER_CSS = """\
+    .gm-mode-top-banner {
+      background: var(--crimson); color: #f5edd8;
+      font-family: 'Cinzel', serif; font-size: 10px;
+      letter-spacing: 0.22em; text-transform: uppercase;
+      text-align: center; padding: 6px 1rem;
+    }
+"""
+
+# ---------------------------------------------------------------------------
 # Page shell
 # ---------------------------------------------------------------------------
 
@@ -340,7 +366,10 @@ def build_page(
     banner_right_esc = html_escape(banner_right)
     cover_url_esc = html_escape(cover_image_url, quote=True)
 
-    css = CSS_BASE + css_extra
+    _gm = os.environ.get('TS_GM_MODE') == '1'
+    guard_html   = _GM_GUARD_SCRIPT if _gm else ''
+    gm_banner_html = '<div class="gm-mode-top-banner">GM VIEW — PRIVILEGED ARCHIVE</div>\n' if _gm else ''
+    css = CSS_BASE + (_GM_BANNER_CSS if _gm else '') + css_extra
 
     return f"""<!DOCTYPE html>
 <html lang="en">
@@ -354,7 +383,8 @@ def build_page(
 </head>
 <body>
 
-{jump_nav_html}<div class="page-wrap">
+{guard_html}{jump_nav_html}<div class="page-wrap">
+{gm_banner_html}
 
   <!-- BACK NAV -->
   <div class="back-nav">

--- a/utilities/world/generate_all_world_html.py
+++ b/utilities/world/generate_all_world_html.py
@@ -335,7 +335,13 @@ def _hero_html(config: dict, vault: Path, docs: Path) -> str:
     )
 
 
-def _category_section_html(folder: str, folder_docs: list[dict], vault: Path, public_only: bool) -> str:
+def _category_section_html(
+    folder: str,
+    folder_docs: list[dict],
+    vault: Path,
+    public_only: bool,
+    gm_mode: bool = False,
+) -> str:
     cfg, _ = _read_category_config(vault, folder)  # body not needed for inline preview
     label = cfg.get('title') or _category_label(folder)
     desc = cfg.get('description') or CATEGORY_DESCRIPTIONS.get(folder, '')
@@ -349,10 +355,12 @@ def _category_section_html(folder: str, folder_docs: list[dict], vault: Path, pu
 
     items_html = ''
     for d in inline_docs:
-        badge = ' <span class="gm-badge">GM</span>' if d['visibility'] == 'gm_secrets' else ''
-        extra = ' gm-secrets' if d['visibility'] == 'gm_secrets' else ''
+        is_gm = d['visibility'] == 'gm_secrets'
+        gm_badge  = ' <span class="gm-badge">GM ONLY</span>'  if (gm_mode and is_gm)  else (' <span class="gm-badge">GM</span>' if is_gm else '')
+        pub_badge = ' <span class="pub-badge">PUBLIC</span>'  if (gm_mode and not is_gm) else ''
+        extra = ' gm-secrets' if is_gm else (' public-doc' if gm_mode else '')
         items_html += (
-            f"      <a class=\"inline-doc-item{extra}\" href=\"{escape(d['filename'])}\">{escape(d['title'])}{badge}</a>\n"
+            f"      <a class=\"inline-doc-item{extra}\" href=\"{escape(d['filename'])}\">{escape(d['title'])}{gm_badge}{pub_badge}</a>\n"
         )
 
     remainder_html = ''
@@ -466,15 +474,15 @@ def generate_all(
     vault: Path, docs: Path,
     dry_run: bool = False,
     public_only: bool = False,
+    gm_mode: bool = False,
     grouped_sources: dict[str, list[Path]] | None = None,
 ) -> dict[str, list[dict]]:
     """Generate HTML for every discovered source. Returns docs grouped by folder.
 
     Args:
-        public_only: When True, only generate docs explicitly tagged
-                     visibility: public (fails closed — missing/other → skipped).
-        grouped_sources: Pre-computed discover_sources() result. If None, calls
-                         discover_sources() internally (preserves backward compat).
+        public_only:     When True, only generate visibility: public docs (fails closed).
+        gm_mode:         When True, include all docs with visual GM markers.
+        grouped_sources: Pre-computed discover_sources() result; calls internally if None.
     """
     if grouped_sources is None:
         grouped_sources = discover_sources(vault)
@@ -516,9 +524,11 @@ def generate_all(
 
             if not dry_run:
                 if doc_type == 'timeline':
-                    html = render_timeline_html(fm, body, folder=folder, back_prefix=back_prefix)
+                    html = render_timeline_html(fm, body, folder=folder,
+                                                back_prefix=back_prefix, gm_mode=gm_mode)
                 else:
-                    html = build_myth_html(fm, body, folder=folder, back_prefix=back_prefix)
+                    html = build_myth_html(fm, body, folder=folder,
+                                           back_prefix=back_prefix, gm_mode=gm_mode)
                 (docs / subfolder).mkdir(parents=True, exist_ok=True)
                 out_path.write_text(html, encoding='utf-8')
 
@@ -551,6 +561,42 @@ _INDEX_CSS = (
     (_CSS_DIR / "world_base.css").read_text(encoding="utf-8") +
     (_CSS_DIR / "world_category.css").read_text(encoding="utf-8")
 )
+
+# GM-mode additions: banner, enhanced card/badge styles, public-doc tint
+_GM_INDEX_CSS = """
+    .gm-mode-banner {
+      background: var(--crimson); color: #f5edd8;
+      font-family: 'Inconsolata', monospace; font-size: 11px;
+      letter-spacing: 0.22em; text-transform: uppercase;
+      text-align: center; padding: 6px 1rem;
+    }
+    .doc-card.gm-secrets {
+      background: rgba(122,31,31,0.06) !important;
+      border-left: 4px solid var(--crimson) !important;
+    }
+    .doc-card.gm-secrets:hover { background: rgba(122,31,31,0.10) !important; }
+    .doc-card.public-doc { border-left: 4px solid rgba(184,146,44,0.5); }
+    .pub-badge {
+      background: rgba(184,146,44,0.15); color: var(--gold);
+      border: 1px solid rgba(184,146,44,0.4);
+      font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase;
+      padding: 2px 7px; border-radius: 100px; margin-left: 6px;
+      font-family: 'Inconsolata', monospace; vertical-align: middle;
+    }
+    .inline-doc-item.public-doc { border-color: rgba(184,146,44,0.3); }
+"""
+
+_GM_GUARD_SCRIPT_INDEX = """\
+<script src="https://cdn.jsdelivr.net/npm/netlify-identity-widget@1/build/netlify-identity-widget.js"></script>
+<script>
+(function () {
+  netlifyIdentity.init();
+  netlifyIdentity.on('init', function (user) {
+    if (!user) { window.location.replace('login.html'); }
+  });
+})();
+</script>
+"""
 
 # ── Legacy inline CSS kept as dead reference only — DO NOT USE ────────────────
 _INDEX_CSS_LEGACY_UNUSED = """
@@ -875,13 +921,21 @@ _INDEX_CSS_LEGACY_UNUSED = """
 """  # end _INDEX_CSS_LEGACY_UNUSED
 
 
-def _card_html(filename: str, title: str, meta: str, desc: str, gm: bool = False) -> str:
-    gm_badge = '<span class="gm-badge">GM</span>' if gm else ''
-    extra    = ' gm-secrets' if gm else ''
-    anchor   = _slug(title)
+def _card_html(
+    filename: str,
+    title: str,
+    meta: str,
+    desc: str,
+    gm: bool = False,
+    gm_mode: bool = False,
+) -> str:
+    gm_badge  = f'<span class="gm-badge">{"GM ONLY" if gm_mode else "GM"}</span>' if gm else ''
+    pub_badge = '<span class="pub-badge">PUBLIC</span>' if (gm_mode and not gm) else ''
+    extra     = ' gm-secrets' if gm else (' public-doc' if gm_mode else '')
+    anchor    = _slug(title)
     return (
         f'    <a id="{anchor}" class="doc-card{extra}" href="{escape(filename)}">\n'
-        f'      <div class="doc-title">{escape(title)}{gm_badge}</div>\n'
+        f'      <div class="doc-title">{escape(title)}{gm_badge}{pub_badge}</div>\n'
         f'      <div class="doc-meta">{escape(meta)}</div>\n'
         f'      <div class="doc-desc">{escape(desc)}</div>\n'
         f'      <div class="doc-card-arrow">&#8594;</div>\n'
@@ -1191,11 +1245,15 @@ def generate_category_page(
 def generate_index(
     docs: Path, grouped_docs: dict[str, list[dict]], vault: Path | None = None,
     public_only: bool = False,
+    gm_mode: bool = False,
     subcategory_set: set[str] | None = None,
 ) -> None:
     """Write docs/index.html listing core docs with hero and category sections."""
     config = _read_site_config(vault) if vault else {}
     hero_html = _hero_html(config, vault, docs) if config else ''
+
+    gm_mode_banner = ('<div class="gm-mode-banner">GM VIEW — PRIVILEGED ARCHIVE</div>\n'
+                      if gm_mode else '')
 
     # Banner for index page
     banner_html = (
@@ -1206,9 +1264,14 @@ def generate_index(
         '<div class="banner-rule"></div>\n'
     )
 
-    visible_core = [d for d in _CORE_DOCS if not public_only or 'public' in d.get('visibility', 'gm_secrets')]
+    # In GM mode show all core docs (including gm_secrets); otherwise filter by public_only
+    visible_core = [
+        d for d in _CORE_DOCS
+        if gm_mode or (not public_only or 'public' in d.get('visibility', 'gm_secrets'))
+    ]
     core_html = ''.join(
-        _card_html(d['filename'], d['title'], d['meta'], d['desc'])
+        _card_html(d['filename'], d['title'], d['meta'], d['desc'],
+                   gm=(d.get('visibility') == 'gm_secrets'), gm_mode=gm_mode)
         for d in visible_core
     )
 
@@ -1217,12 +1280,16 @@ def generate_index(
     if grouped_docs:
         sorted_folders = sorted(top_level_folders, key=_category_label)
         categories_html = ''.join(
-            _category_section_html(folder, grouped_docs[folder], vault, public_only)
+            _category_section_html(folder, grouped_docs[folder], vault, public_only,
+                                   gm_mode=gm_mode)
             for folder in sorted_folders
         )
 
     top_level_docs = {f: v for f, v in grouped_docs.items() if f in top_level_folders}
     total = len(visible_core) + sum(len(v) for v in top_level_docs.values())
+
+    gm_css = _GM_INDEX_CSS if gm_mode else ''
+    gm_guard = (_GM_GUARD_SCRIPT_INDEX if gm_mode else '')
 
     html = f"""<!DOCTYPE html>
 <html lang="en">
@@ -1232,13 +1299,13 @@ def generate_index(
   <title>Tarim Shaiel - Campaign Lore</title>
   <!-- AUTO-GENERATED by utilities/world/generate_all_world_html.py - do not hand-edit -->
   <link rel="icon" href="{_FAVICON}">
-  <style>{_INDEX_CSS}  </style>
+  <style>{_INDEX_CSS}{gm_css}  </style>
 </head>
 <body>
 
-<div class="page-wrap">
+{gm_guard}<div class="page-wrap">
 
-{hero_html}
+{gm_mode_banner}{hero_html}
 {banner_html}
 
   <div class="content">
@@ -1313,14 +1380,24 @@ def main() -> None:
         help='Public-only mode: only generate/index docs with explicit visibility: public. '
              'Use for Netlify/CI deployments. Fails closed — missing or gm_secrets → skipped.',
     )
+    parser.add_argument(
+        '--gm', action='store_true',
+        help='GM mode: include all docs with visual GM markers and Netlify Identity auth guard.',
+    )
     args = parser.parse_args()
 
-    vault = Path(args.vault) if args.vault else Path(__file__).parent.parent.parent
-    docs  = vault / 'docs'
+    if args.public and args.gm:
+        sys.exit('ERROR: --public and --gm are mutually exclusive.')
+
+    gm_mode = args.gm
+    vault   = Path(args.vault) if args.vault else Path(__file__).parent.parent.parent
+    docs    = vault / 'docs'
 
     print(f'Vault: {vault}')
     if args.public:
         print('Mode: PUBLIC (visibility: public only — fails closed)')
+    elif gm_mode:
+        print('Mode: GM (all docs, GM markers + auth guard injected)')
     else:
         print('Mode: LOCAL (all docs including gm_secrets)')
     print('Scanning for pipeline sources...')
@@ -1328,7 +1405,8 @@ def main() -> None:
     grouped_sources = discover_sources(vault)
     subcategory_map, subcategory_set = _build_subcategory_map(vault, grouped_sources)
     grouped_docs    = generate_all(vault, docs, grouped_sources=grouped_sources,
-                                   dry_run=args.dry_run, public_only=args.public)
+                                   dry_run=args.dry_run, public_only=args.public,
+                                   gm_mode=gm_mode)
     total = sum(len(v) for v in grouped_docs.values())
     print(f'Generated {total} world document(s) across {len(grouped_docs)} categories.')
 
@@ -1346,8 +1424,9 @@ def main() -> None:
             )
             print(f'  Category: {folder} ({count} doc(s)) → docs/category-{folder}.html')
         generate_index(docs, grouped_docs, vault=vault, public_only=args.public,
-                       subcategory_set=subcategory_set)
-        visible_core_count = len([d for d in _CORE_DOCS if not args.public or 'public' in d.get('visibility', 'gm_secrets')])
+                       gm_mode=gm_mode, subcategory_set=subcategory_set)
+        visible_core_count = len([d for d in _CORE_DOCS
+                                   if gm_mode or (not args.public or 'public' in d.get('visibility', 'gm_secrets'))])
         top_level_count = len(grouped_docs) - len(subcategory_set)
         print(f'Index: docs/index.html ({visible_core_count} core + {top_level_count} categories, {len(subcategory_set)} subcategories suppressed)')
         generate_404(docs)

--- a/utilities/world/generate_world_html.py
+++ b/utilities/world/generate_world_html.py
@@ -16,6 +16,7 @@ Usage:
     python generate_world_html.py source.md --open     # open in browser after generating
 """
 
+import os
 import re
 import json
 import argparse
@@ -226,7 +227,13 @@ def render_myth_section(title: str, content: str) -> str:
     )
 
 
-def build_myth_html(fm: dict, body: str, folder: str | None = None, back_prefix: str = '../') -> str:
+def build_myth_html(
+    fm: dict,
+    body: str,
+    folder: str | None = None,
+    back_prefix: str = '../',
+    gm_mode: bool = False,
+) -> str:
     """Build a styled HTML page for a lore/myth document.
 
     Args:
@@ -236,6 +243,7 @@ def build_myth_html(fm: dict, body: str, folder: str | None = None, back_prefix:
                      and category page link. Pass None to omit back-nav.
         back_prefix: Path prefix to reach docs/ root from the output file's
                      directory (e.g. '../' for one level, '../../' for two).
+        gm_mode:     When True, render GM banners and pass gm_mode to render_body.
     """
     from shared.html_render import render_body as _render_body
 
@@ -279,7 +287,7 @@ def build_myth_html(fm: dict, body: str, folder: str | None = None, back_prefix:
         body = body.replace(non_empty_pre[0], '', 1).strip()
 
     # Render full body with component support (images, features, jump nav, headers)
-    content_html, jump_nav_items = _render_body(body, VAULT_ROOT, DOCS_DIR)
+    content_html, jump_nav_items = _render_body(body, VAULT_ROOT, DOCS_DIR, gm_mode=gm_mode)
     if epigraph_html:
         content_html = epigraph_html + content_html
 
@@ -349,6 +357,20 @@ def build_myth_html(fm: dict, body: str, folder: str | None = None, back_prefix:
         f'<div class="banner-rule"></div>\n'
     )
 
+    # Per-page GM/public indicator banner (GM build only)
+    gm_banner_html = ''
+    page_extra_class = ''
+    if gm_mode:
+        vis_raw = fm.get('visibility', 'gm_secrets')
+        is_gm_secret = 'gm_secrets' in (str(vis_raw) if not isinstance(vis_raw, list)
+                                         else ' '.join(str(v) for v in vis_raw))
+        if is_gm_secret:
+            gm_banner_html = '<div class="gm-page-banner">✦ GM EYES ONLY · RESTRICTED ✦</div>\n'
+            page_extra_class = ' gm-secret-page'
+        else:
+            gm_banner_html = '<div class="public-page-banner">PLAYER-VISIBLE · PUBLIC DOCUMENT</div>\n'
+            page_extra_class = ' public-page'
+
     return _html_wrapper(
         title=title,
         css=CSS_BASE + CSS_MYTH,
@@ -357,6 +379,9 @@ def build_myth_html(fm: dict, body: str, folder: str | None = None, back_prefix:
         banner_html=banner_html,
         content_html=content_html,
         jump_nav_html=jump_nav_html,
+        gm_banner_html=gm_banner_html,
+        page_extra_class=page_extra_class,
+        gm_mode=gm_mode,
     )
 
 
@@ -1080,7 +1105,13 @@ drawTLStemTimeline('all');
     return container_html + script_html
 
 
-def render_timeline_html(fm: dict, body: str, folder: str | None = None, back_prefix: str = '../') -> str:
+def render_timeline_html(
+    fm: dict,
+    body: str,
+    folder: str | None = None,
+    back_prefix: str = '../',
+    gm_mode: bool = False,
+) -> str:
     title    = fm.get('title', 'Timeline')
     calendar = fm.get('calendar', '')
 
@@ -1326,6 +1357,20 @@ def render_timeline_html(fm: dict, body: str, folder: str | None = None, back_pr
             f'</div>\n'
         )
 
+    # Per-page GM banner (GM build only — timelines are always public for now)
+    gm_banner_html = ''
+    page_extra_class = ''
+    if gm_mode:
+        vis_raw = fm.get('visibility', 'gm_secrets')
+        is_gm_secret = 'gm_secrets' in (str(vis_raw) if not isinstance(vis_raw, list)
+                                         else ' '.join(str(v) for v in vis_raw))
+        if is_gm_secret:
+            gm_banner_html = '<div class="gm-page-banner">✦ GM EYES ONLY · RESTRICTED ✦</div>\n'
+            page_extra_class = ' gm-secret-page'
+        else:
+            gm_banner_html = '<div class="public-page-banner">PLAYER-VISIBLE · PUBLIC DOCUMENT</div>\n'
+            page_extra_class = ' public-page'
+
     return _html_wrapper(
         title=title,
         css=CSS_BASE + CSS_TIMELINE,
@@ -1334,12 +1379,46 @@ def render_timeline_html(fm: dict, body: str, folder: str | None = None, back_pr
         content_html=content_html,
         extra_head='<script src="https://cdn.jsdelivr.net/npm/d3@7"></script>\n',
         back_nav_html=back_nav_html,
+        gm_banner_html=gm_banner_html,
+        page_extra_class=page_extra_class,
+        gm_mode=gm_mode,
     )
 
 
 # ---------------------------------------------------------------------------
 # HTML wrapper
 # ---------------------------------------------------------------------------
+
+_GM_GUARD_SCRIPT = """\
+<script src="https://cdn.jsdelivr.net/npm/netlify-identity-widget@1/build/netlify-identity-widget.js"></script>
+<script>
+(function () {
+  netlifyIdentity.init();
+  netlifyIdentity.on('init', function (user) {
+    if (!user) { window.location.replace('login.html'); }
+  });
+})();
+</script>
+"""
+
+_GM_PAGE_CSS = """\
+    .gm-page-banner {
+      background: var(--crimson); color: #f5edd8;
+      font-family: 'Inconsolata', monospace; font-size: 11px;
+      letter-spacing: 0.22em; text-transform: uppercase;
+      text-align: center; padding: 8px 1rem;
+    }
+    .public-page-banner {
+      background: rgba(184,146,44,0.18); color: var(--gold);
+      border: 1px solid rgba(184,146,44,0.35);
+      font-family: 'Inconsolata', monospace; font-size: 11px;
+      letter-spacing: 0.22em; text-transform: uppercase;
+      text-align: center; padding: 6px 1rem;
+    }
+    .page-wrap.gm-secret-page { border-top: 4px solid var(--crimson); }
+    .page-wrap.public-page     { border-top: 4px solid rgba(184,146,44,0.5); }
+"""
+
 
 def _html_wrapper(
     title: str,
@@ -1350,7 +1429,12 @@ def _html_wrapper(
     extra_head: str = '',
     back_nav_html: str = '',
     jump_nav_html: str = '',
+    gm_banner_html: str = '',
+    page_extra_class: str = '',
+    gm_mode: bool = False,
 ) -> str:
+    guard = _GM_GUARD_SCRIPT if gm_mode else ''
+    page_css = (css + _GM_PAGE_CSS) if gm_mode else css
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -1359,13 +1443,13 @@ def _html_wrapper(
   <title>{escape(title)} &mdash; Tarim-Shaiel</title>
   <link rel="icon" href="{FAVICON}">
   <!-- AUTO-GENERATED by utilities/world/generate_world_html.py — do not hand-edit -->
-  {extra_head}<style>{css}  </style>
+  {extra_head}<style>{page_css}  </style>
 </head>
 <body>
 
-{jump_nav_html}<div class="page-wrap">
+{guard}{jump_nav_html}<div class="page-wrap{page_extra_class}">
 
-{back_nav_html}{header_html}
+{gm_banner_html}{back_nav_html}{header_html}
 {banner_html}
 
   <div class="content">

--- a/utilities/world/world_base.css
+++ b/utilities/world/world_base.css
@@ -418,3 +418,46 @@
         break-inside: avoid;
       }
     }
+
+    /* ── GM component styles (Tier 1 / 2 / 3) ─────────────────────────────── */
+    /* Tier 1: inline redaction */
+    .gm-redacted {
+      background: var(--ink); color: var(--ink);
+      user-select: none; border-radius: 2px;
+      padding: 0 4px; letter-spacing: -0.05em;
+    }
+    .gm-inline {
+      background: rgba(122,31,31,0.12); color: var(--crimson);
+      border-bottom: 1px solid rgba(122,31,31,0.4);
+      padding: 0 2px; border-radius: 2px;
+    }
+
+    /* Tier 2: GM-only callout block */
+    .gm-callout {
+      border-left: 3px solid var(--crimson);
+      background: rgba(122,31,31,0.06);
+      padding: 0.8rem 1rem 0.8rem 1.2rem;
+      margin: 1.2rem 0;
+    }
+    .gm-callout::before {
+      content: "GM ONLY";
+      display: block;
+      font-family: 'Inconsolata', monospace;
+      font-size: 0.65rem; letter-spacing: 0.2em;
+      color: var(--crimson); margin-bottom: 0.5rem;
+    }
+
+    /* Tier 3: GM prose block (file transclusion) */
+    .gm-block {
+      border: 1px solid rgba(122,31,31,0.3);
+      border-left: 4px solid var(--crimson);
+      background: rgba(122,31,31,0.04);
+      padding: 1rem 1.2rem; margin: 1.5rem 0;
+    }
+    .gm-block::before {
+      content: "↓ GM CONTENT";
+      display: block;
+      font-family: 'Inconsolata', monospace;
+      font-size: 0.6rem; letter-spacing: 0.2em;
+      color: rgba(122,31,31,0.5); margin-bottom: 0.8rem;
+    }


### PR DESCRIPTION
- netlify-gm.toml: second deploy config (build.py all --gm)
- docs/login.html: Netlify Identity login page (parchment-styled)
- Tier 1: {gm:text} inline redaction in md_utils.py::inline_md()
- Tier 2: > [!gm-only] callout in html_render.py::render_body()
- Tier 3: ![[gm_secrets/...]] transclusion in render_wiki_embed()
- generate_world_html.py: gm_mode param, per-page banners, auth guard
- generate_all_world_html.py: --gm flag, badge CSS, call chain
- build.py: --gm flag sets TS_GM_MODE=1
- page_shell.py: auth guard + GM banner (lore/ancestry pages)
- world_base.css: GM component CSS (Tier 1/2/3 classes)
- GM_AUTHORING.md: authoring reference at repo root
- CLAUDE.md: pointer to GM_AUTHORING.md
- Decision 15 logged

https://claude.ai/code/session_01Boque3nEG2nRarkaYzbb61