### PR TITLE
fix: preserve URL hash on auth guard redirect to login.html

### DIFF
--- a/utilities/shared/page_shell.py
+++ b/utilities/shared/page_shell.py
@@ -315,7 +315,7 @@ _GM_GUARD_SCRIPT = """\
 (function () {
   netlifyIdentity.init();
   netlifyIdentity.on('init', function (user) {
-    if (!user) { window.location.replace('login.html'); }
+    if (!user) { window.location.replace('login.html' + window.location.hash); }
   });
 })();
 </script>

--- a/utilities/world/generate_all_world_html.py
+++ b/utilities/world/generate_all_world_html.py
@@ -592,7 +592,7 @@ _GM_GUARD_SCRIPT_INDEX = """\
 (function () {
   netlifyIdentity.init();
   netlifyIdentity.on('init', function (user) {
-    if (!user) { window.location.replace('login.html'); }
+    if (!user) { window.location.replace('login.html' + window.location.hash); }
   });
 })();
 </script>

--- a/utilities/world/generate_world_html.py
+++ b/utilities/world/generate_world_html.py
@@ -1395,7 +1395,7 @@ _GM_GUARD_SCRIPT = """\
 (function () {
   netlifyIdentity.init();
   netlifyIdentity.on('init', function (user) {
-    if (!user) { window.location.replace('login.html'); }
+    if (!user) { window.location.replace('login.html' + window.location.hash); }
   });
 })();
 </script>


### PR DESCRIPTION
Invite and recovery tokens arrive as #invite_token= / #recovery_token= in the URL hash. The guard was stripping the hash on redirect, losing the token before login.html could process it. Now passes hash through.

https://claude.ai/code/session_01Boque3nEG2nRarkaYzbb61