### PR TITLE
ci: opt into Node.js 24 + fix pip install to use requirements.txt

### DIFF
--- a/.github/workflows/generate-html.yml
+++ b/.github/workflows/generate-html.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout repository
@@ -28,7 +30,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install dependencies
-        run: pip install pyyaml
+        run: pip install -r requirements.txt
 
       - name: Generate TODO dashboard
         run: python utilities/dashboard/generate_dashboard.py --out docs/dashboard.html


### PR DESCRIPTION
Two fixes for the GitHub Actions workflow:

1. **Node.js 24 opt-in** — adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to the job env, silencing the Node 20 deprecation warning ahead of the June 2026 forced cutover.

2. **Fix pip install** — changes `pip install pyyaml` → `pip install -r requirements.txt`. The Phase 0 work on #183 added `jinja2>=3.1.6` to `requirements.txt` but the CI step was never updated. Any generator run in CI would have failed with a missing `jinja2` import since that merge.

https://claude.ai/code/session_015CaVXuRopxYWBfgxMYE7z1

---
_Generated by [Claude Code](https://claude.ai/code/session_015CaVXuRopxYWBfgxMYE7z1)_