### PR TITLE
infra: Phase 2c Jinja2 — world generator migration (#183)

### DIFF
--- a/DASHBOARD.md
+++ b/DASHBOARD.md
@@ -4,7 +4,7 @@ project: TTRPG_Tarim_Shaiel
 type: operational
 visibility: internal
 status: active
-last_updated: 2026-05-01
+last_updated: 2026-05-01  # session 2
 
 critical_path:
   - Resolve cosmological architecture
@@ -49,6 +49,7 @@ blockers:
 - 🗒️ **Backlog:** HTML generation pipeline refactor — consolidate shared utilities, eliminate _Generator boilerplate + CSS token drift across 6 scripts. [#138](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/138)
 - 🗒️ **Backlog:** docs/ output hierarchy restructure — move per-document HTML into subdirectories; fixes ~500-file flat directory. [#168](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/168)
 - ✅ **Completed (2026-05-01):** Faction stubs — 16 P1–P3 files created; 3 deferred pending #42, #43, Decision #11. [#144](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/144)
+- ✅ **Completed (2026-05-01):** Phase 2c Jinja2 — world generators migrated; `base.html` extended with extra_head/page_gm_banner/back_nav/cover blocks; `pages/world.html` + `pages/world-timeline.html` created; `_html_wrapper()` removed. [#183](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/183)
 - ✅ **Completed (2026-05-01):** Phase 2b Jinja2 — campaign frame generator migrated; `base.html` extended with cover_extra + conditional base.css hooks. [#183](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/183) (PR #189)
 - ✅ **Completed (2026-04-30):** CSS extraction + Jinja2 template layer Phase 0–2a — tokens.css + linked CSS files (PR #187); renderer.py + base/ancestry/lore templates; ancestry + lore generators are now pure data-extraction. [#183](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/183)
 - ✅ **Completed (2026-04-22):** Account-based GM gatekeeping — `build.py all --gm`, Netlify Identity auth guard, three-tier markdown gating (Tier 1/2/3), `docs/login.html`, `GM_AUTHORING.md`. Remaining: manual Netlify second-site setup. [#176](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/176)

--- a/TODO.md
+++ b/TODO.md
@@ -23,6 +23,13 @@ _Project health tracked in [DASHBOARD.md](DASHBOARD.md)_
 ## SESSION LOG
 _What happened this session. Newest first. Trim to last 3 sessions; older entries go to archive._
 
+### 2026-05-01 (session 2)
+- #183 Phase 2c: world generators migrated to Jinja2 ✅
+  - `base.html` extended with `{% block extra_head %}`, `{% block page_gm_banner %}`, `{% block back_nav %}`, `{% block cover %}`; `page_class` variable on page-wrap
+  - `pages/world.html` created — myth/lore template with dynamic cover (or no-cover fallback), jump-nav, back-nav, per-page GM banner
+  - `pages/world-timeline.html` created — extends world.html; overrides `extra_head` with D3 script, `cover` block with `tl-header`
+  - `generate_world_html.py`: `build_myth_html()` and `render_timeline_html()` now call `render_page()` instead of `_html_wrapper()`; `_html_wrapper()` removed; full build verified
+
 ### 2026-05-01
 - Faction stubs: 16 P1–P3 faction files created in `world/factions/` — [#144](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/144) ✅ (PR #191)
   - P1 rich stubs: `lich-cadre.md`, `the-wizard.md`, `chain-breakers-order.md`
@@ -39,7 +46,7 @@ _What happened this session. Newest first. Trim to last 3 sessions; older entrie
   - **Phase 0:** Decision 16 CSS token map locked; `jinja2>=3.1.6` added to `requirements.txt`; `utilities/shared/css/tokens.css` created with canonical 15-token map
   - **Phase 1 (PR #187):** All CSS extracted from Python string constants to `utilities/shared/css/*.css` files; generators switch from `<style>` inlining to `<link>` tags; `_copy_css()` step added to `build.py`; `.gitignore` updated for `docs/assets/`
   - **Phase 2a (PR #188):** Jinja2 environment + `render_page()` in `utilities/shared/renderer.py`; template tree: `base.html`, `pages/ancestry.html`, `pages/lore.html`, `partials/ancestry-card.html`; ancestry and lore generators stripped of all HTML-building functions; both generators verified producing correct output
-  - **Remaining on #183:** Phase 2b (campaign frame), Phase 2c (world generators — needs `render_body_structured()`), Phase 2d (dashboard), Phase 3 (theme variants)
+  - **Remaining on #183:** Phase 2d (dashboard), Phase 3 (theme variants)
 
 ### 2026-04-22
 - Implemented account-based GM gatekeeping — [#176](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/176) ✅

--- a/utilities/templates/base.html
+++ b/utilities/templates/base.html
@@ -18,20 +18,25 @@
   {% if gm_mode %}
   <link rel="stylesheet" href="/assets/css/gm.css">
   {% endif %}
+  {% block extra_head %}{% endblock %}
 </head>
 <body>
 
 {% if gm_mode %}{{ gm_guard_script | safe }}{% endif %}
 {% block jump_nav %}{% endblock %}
-<div class="page-wrap">
+<div class="page-wrap{{ page_class | default('') }}">
 {% if gm_mode %}<div class="gm-mode-top-banner">GM VIEW — PRIVILEGED ARCHIVE</div>{% endif %}
+{% block page_gm_banner %}{% endblock %}
 
   <!-- BACK NAV -->
+  {% block back_nav %}
   <div class="back-nav">
     <a href="index.html">&#8592; Campaign Documents</a>
   </div>
+  {% endblock %}
 
   <!-- COVER -->
+  {% block cover %}
   <div class="cover">
     <div class="cover-image" style="background-image: url('{{ cover_image_url | e }}');"></div>
     <div class="cover-gradient"></div>
@@ -47,6 +52,7 @@
     <span>{{ banner_right }}</span>
   </div>
   <div class="banner-rule"></div>
+  {% endblock %}
 
   <!-- MAIN CONTENT -->
   <div class="content">

--- a/utilities/templates/pages/world-timeline.html
+++ b/utilities/templates/pages/world-timeline.html
@@ -1,0 +1,14 @@
+{% extends "pages/world.html" %}
+
+{% block extra_head %}
+<script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
+{% endblock %}
+
+{% block cover %}
+{{ header_html | safe }}
+<div class="banner">
+  <span>{{ banner_left }}</span>
+  <span>{{ banner_right }}</span>
+</div>
+<div class="banner-rule"></div>
+{% endblock %}

--- a/utilities/templates/pages/world.html
+++ b/utilities/templates/pages/world.html
@@ -1,0 +1,65 @@
+{% extends "base.html" %}
+
+{% block extra_head %}{% endblock %}
+
+{% block jump_nav %}
+{% if jump_nav_items and jump_nav_items | length >= 2 %}
+<div class="jump-nav">
+<ul>
+  {% if back_href %}
+  <li style="list-style:none"><a href="{{ back_href | e }}">&larr; Back</a></li>
+  <li class="nav-divider"></li>
+  {% endif %}
+  {% for item in jump_nav_items %}
+  <li><a href="#{{ item.anchor }}">{{ item.text }}</a></li>
+  {% endfor %}
+  <li class="nav-divider"></li>
+  <li style="list-style:none"><a href="#">&#8593; Top</a></li>
+</ul>
+</div>
+{% endif %}
+{% endblock %}
+
+{% block page_gm_banner %}
+{% if gm_page_banner_html %}{{ gm_page_banner_html | safe }}{% endif %}
+{% endblock %}
+
+{% block back_nav %}
+{% if back_href %}
+<div class="back-nav">
+  <a href="{{ back_href | e }}">&larr; {{ back_label }}</a>
+</div>
+{% endif %}
+{% endblock %}
+
+{% block cover %}
+{% if cover_image_url %}
+<div class="cover">
+  <div class="cover-image" style="background-image: url('{{ cover_image_url | e }}'); background-position: {{ banner_x | default(50) }}% {{ banner_y | default(50) }}%"></div>
+  <div class="cover-gradient"></div>
+  <div class="cover-content">
+    <div class="cover-title">{{ title }}</div>
+    {% if tag_label %}<div class="cover-tag">{{ tag_label }}</div>{% endif %}
+  </div>
+</div>
+{% else %}
+<div class="no-cover-header">
+  <div class="cover-title">{{ title }}</div>
+  {% if tag_label %}<div class="cover-tag">{{ tag_label }}</div>{% endif %}
+</div>
+{% endif %}
+
+<div class="banner">
+  <span>{{ banner_left }}</span>
+  <span>{{ banner_right }}</span>
+</div>
+<div class="banner-rule"></div>
+{% endblock %}
+
+{% block content %}
+{{ content_html | safe }}
+{% endblock %}
+
+{% block credits %}
+    Tarim-Shaiel &middot; Daggerheart Campaign &middot; 2026
+{% endblock %}

--- a/utilities/world/generate_world_html.py
+++ b/utilities/world/generate_world_html.py
@@ -243,6 +243,7 @@ def build_myth_html(
         gm_mode:     When True, render GM banners and pass gm_mode to render_body.
     """
     from shared.html_render import render_body as _render_body
+    from shared.renderer import render_page as _render_page
 
     title = fm.get('title', 'Untitled')
     tags = fm.get('tags', [])
@@ -290,7 +291,6 @@ def build_myth_html(
 
     # --- Back navigation ---
     # If frontmatter has parent-class, link to parent page; otherwise link to category.
-    back_nav_html = ''
     back_href = ''
     back_label = ''
     parent_class = str(fm.get('parent-page', '') or fm.get('parent-class', '')).strip()
@@ -303,82 +303,50 @@ def build_myth_html(
         cat_label  = folder.replace('-', ' ').replace('_', ' ').title()
         back_href  = f'{back_prefix}category-{escape(folder)}.html'
         back_label = cat_label
-    if back_href:
-        back_nav_html = (
-            f'<div class="back-nav">'
-            f'<a href="{back_href}">&larr; Back</a>'
-            f'</div>\n'
-        )
 
     # --- Jump navigation (shown when 2+ sections exist, opt-out with jump_nav: false) ---
-    jump_nav_html = ''
+    nav_items = []
     if len(jump_nav_items) >= 2 and (fm.get('jump_nav', True) is not False):
-        nav_items = []
-        if back_href:
-            nav_items.append(f'  <li style="list-style:none"><a href="{back_href}">&larr; Back</a></li>')
-            nav_items.append('  <li class="nav-divider"></li>')
-        for item in jump_nav_items:
-            nav_items.append(f'  <li><a href="#{item["anchor"]}">{escape(item["text"])}</a></li>')
-        nav_items.append('  <li class="nav-divider"></li>')
-        nav_items.append('  <li style="list-style:none"><a href="#">&#8593; Top</a></li>')
-        jump_nav_html = '<div class="jump-nav">\n<ul>\n' + '\n'.join(nav_items) + '\n</ul>\n</div>\n'
+        nav_items = jump_nav_items
 
-    # --- Cover / header ---
-    if cover_image:
-        header_html = (
-            f'<div class="cover">\n'
-            f'  <div class="cover-image" style="background-image: url(\'{escape(cover_image)}\'); background-position: {banner_x}% {banner_y}%"></div>\n'
-            f'  <div class="cover-gradient"></div>\n'
-            f'  <div class="cover-content">\n'
-            f'    <div class="cover-title">{escape(title)}</div>\n'
-            + (f'    <div class="cover-tag">{escape(tag_label)}</div>\n' if tag_label else '')
-            + f'  </div>\n</div>\n'
-        )
-    else:
-        header_html = (
-            f'<div class="no-cover-header">\n'
-            f'  <div class="cover-title">{escape(title)}</div>\n'
-            + (f'  <div class="cover-tag">{escape(tag_label)}</div>\n' if tag_label else '')
-            + f'</div>\n'
-        )
-
-    # --- Banner (frontmatter-overridable) ---
+    # --- Banner labels (frontmatter-overridable) ---
     doc_type_label = str(fm.get('type', 'lore')).replace('_', ' ').title()
     banner_left  = fm.get('banner_left',  'Tarim-Shaiel')
     banner_right = fm.get('banner_right', doc_type_label)
-    banner_html = (
-        f'<div class="banner">'
-        f'<span>{escape(str(banner_left))}</span>'
-        f'<span>{escape(str(banner_right))}</span>'
-        f'</div>\n'
-        f'<div class="banner-rule"></div>\n'
-    )
 
-    # Per-page GM/public indicator banner (GM build only)
-    gm_banner_html = ''
-    page_extra_class = ''
+    # --- Per-page GM/public indicator banner (GM build only) ---
+    gm_page_banner_html = ''
+    page_class = ''
     if gm_mode:
         vis_raw = fm.get('visibility', 'gm_secrets')
         is_gm_secret = 'gm_secrets' in (str(vis_raw) if not isinstance(vis_raw, list)
                                          else ' '.join(str(v) for v in vis_raw))
         if is_gm_secret:
-            gm_banner_html = '<div class="gm-page-banner">✦ GM EYES ONLY · RESTRICTED ✦</div>\n'
-            page_extra_class = ' gm-secret-page'
+            gm_page_banner_html = '<div class="gm-page-banner">✦ GM EYES ONLY · RESTRICTED ✦</div>\n'
+            page_class = ' gm-secret-page'
         else:
-            gm_banner_html = '<div class="public-page-banner">PLAYER-VISIBLE · PUBLIC DOCUMENT</div>\n'
-            page_extra_class = ' public-page'
+            gm_page_banner_html = '<div class="public-page-banner">PLAYER-VISIBLE · PUBLIC DOCUMENT</div>\n'
+            page_class = ' public-page'
 
-    return _html_wrapper(
+    return _render_page(
+        'pages/world.html',
         title=title,
-        css_files=('world-myth',),
-        back_nav_html=back_nav_html,
-        header_html=header_html,
-        banner_html=banner_html,
+        generator_name='utilities/world/generate_world_html.py',
+        extra_css=['world-base', 'world-myth'],
+        use_base_css=False,
+        cover_image_url=cover_image,
+        banner_x=banner_x,
+        banner_y=banner_y,
+        tag_label=tag_label,
+        banner_left=str(banner_left),
+        banner_right=str(banner_right),
+        back_href=back_href,
+        back_label=back_label,
+        jump_nav_items=nav_items,
         content_html=content_html,
-        jump_nav_html=jump_nav_html,
-        gm_banner_html=gm_banner_html,
-        page_extra_class=page_extra_class,
         gm_mode=gm_mode,
+        gm_page_banner_html=gm_page_banner_html,
+        page_class=page_class,
     )
 
 
@@ -1344,128 +1312,45 @@ def render_timeline_html(
         + f'<div class="tl-list-wrap">\n{rows_html}\n</div>\n'
     )
 
-    back_nav_html = ''
+    back_href = ''
+    back_label = ''
     if folder:
         cat_label = folder.replace('-', ' ').replace('_', ' ').title()
-        back_href = f'{back_prefix}category-{escape(folder)}.html'
-        back_nav_html = (
-            f'<div class="back-nav">'
-            f'<a href="{back_href}">&larr; Back</a>'
-            f'</div>\n'
-        )
+        back_href  = f'{back_prefix}category-{escape(folder)}.html'
+        back_label = cat_label
 
     # Per-page GM banner (GM build only — timelines are always public for now)
-    gm_banner_html = ''
-    page_extra_class = ''
+    gm_page_banner_html = ''
+    page_class = ''
     if gm_mode:
         vis_raw = fm.get('visibility', 'gm_secrets')
         is_gm_secret = 'gm_secrets' in (str(vis_raw) if not isinstance(vis_raw, list)
                                          else ' '.join(str(v) for v in vis_raw))
         if is_gm_secret:
-            gm_banner_html = '<div class="gm-page-banner">✦ GM EYES ONLY · RESTRICTED ✦</div>\n'
-            page_extra_class = ' gm-secret-page'
+            gm_page_banner_html = '<div class="gm-page-banner">✦ GM EYES ONLY · RESTRICTED ✦</div>\n'
+            page_class = ' gm-secret-page'
         else:
-            gm_banner_html = '<div class="public-page-banner">PLAYER-VISIBLE · PUBLIC DOCUMENT</div>\n'
-            page_extra_class = ' public-page'
+            gm_page_banner_html = '<div class="public-page-banner">PLAYER-VISIBLE · PUBLIC DOCUMENT</div>\n'
+            page_class = ' public-page'
 
-    return _html_wrapper(
+    from shared.renderer import render_page as _render_page
+    return _render_page(
+        'pages/world-timeline.html',
         title=title,
-        css_files=('world-timeline',),
+        generator_name='utilities/world/generate_world_html.py',
+        extra_css=['world-base', 'world-timeline'],
+        use_base_css=False,
         header_html=header_html,
-        banner_html=banner_html,
+        banner_left='Tarim-Shaiel',
+        banner_right='Timeline',
         content_html=content_html,
-        extra_head='<script src="https://cdn.jsdelivr.net/npm/d3@7"></script>\n',
-        back_nav_html=back_nav_html,
-        gm_banner_html=gm_banner_html,
-        page_extra_class=page_extra_class,
+        back_href=back_href,
+        back_label=back_label,
         gm_mode=gm_mode,
+        gm_page_banner_html=gm_page_banner_html,
+        page_class=page_class,
     )
 
-
-# ---------------------------------------------------------------------------
-# HTML wrapper
-# ---------------------------------------------------------------------------
-
-_GM_GUARD_SCRIPT = """\
-<script src="https://cdn.jsdelivr.net/npm/netlify-identity-widget@1/build/netlify-identity-widget.js"></script>
-<script>
-(function () {
-  netlifyIdentity.init();
-  netlifyIdentity.on('init', function (user) {
-    if (!user) { window.location.replace('login.html' + window.location.hash); }
-  });
-})();
-</script>
-"""
-
-# GM page CSS is now in utilities/shared/css/gm.css (linked externally when gm_mode=True)
-
-
-def _html_wrapper(
-    title: str,
-    css_files: tuple = (),
-    header_html: str = '',
-    banner_html: str = '',
-    content_html: str = '',
-    extra_head: str = '',
-    back_nav_html: str = '',
-    jump_nav_html: str = '',
-    gm_banner_html: str = '',
-    page_extra_class: str = '',
-    gm_mode: bool = False,
-) -> str:
-    guard = _GM_GUARD_SCRIPT if gm_mode else ''
-    extra_css_links = ''.join(
-        f'  <link rel="stylesheet" href="/assets/css/{stem}.css">\n'
-        for stem in css_files
-    )
-    gm_link = '  <link rel="stylesheet" href="/assets/css/gm.css">\n' if gm_mode else ''
-    return f"""<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>{escape(title)} &mdash; Tarim-Shaiel</title>
-  <link rel="icon" href="{FAVICON}">
-  <!-- AUTO-GENERATED by utilities/world/generate_world_html.py — do not hand-edit -->
-  {extra_head}
-  <script>(function(){{var t=localStorage.getItem('ts-theme');if(t)document.documentElement.setAttribute('data-theme',t);}})()</script>
-  <link rel="stylesheet" href="/assets/css/tokens.css">
-  <link rel="stylesheet" href="/assets/css/world-base.css">
-{extra_css_links}{gm_link}</head>
-<body>
-
-{guard}{jump_nav_html}<div class="page-wrap{page_extra_class}">
-
-{gm_banner_html}{back_nav_html}{header_html}
-{banner_html}
-
-  <div class="content">
-{content_html}
-  </div>
-
-  <div class="credits">Tarim-Shaiel &middot; Daggerheart Campaign &middot; 2026</div>
-
-</div>
-
-<script>
-(function () {{
-  var a = document.querySelector('.back-nav a');
-  if (!a) return;
-  a.addEventListener('click', function (e) {{
-    e.preventDefault();
-    if (history.length > 1 && document.referrer &&
-        document.referrer.indexOf(location.hostname) !== -1) {{
-      history.back();
-    }} else {{
-      location.replace(a.href);
-    }}
-  }});
-}})();
-</script>
-</body>
-</html>
-"""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- base.html: add {% block extra_head %}, {% block page_gm_banner %}, {% block back_nav %}, {% block cover %}; page_class variable on page-wrap
- pages/world.html: myth/lore template — dynamic cover (with banner-x/y positioning or no-cover fallback), jump-nav, per-page GM banner
- pages/world-timeline.html: extends world.html; D3 script in extra_head, tl-header in cover block
- generate_world_html.py: build_myth_html() + render_timeline_html() now call render_page() instead of _html_wrapper(); _html_wrapper() removed

Full build verified — 479 world docs, ancestry, lore, campaign frame all pass. Remaining on #183: Phase 2d (dashboard), Phase 3 (theme variants).

https://claude.ai/code/session_01KnCArXoy9M32Z4tsExfSMT