### PR TITLE
infra: Phase 3 Jinja2 — dark/light theme layer (#183)

### DIFF
--- a/utilities/shared/css/base.css
+++ b/utilities/shared/css/base.css
@@ -9,7 +9,7 @@
     .page-wrap {
       max-width: 860px;
       margin: 0;
-      background: var(--paper);
+      background: var(--bg);
       box-shadow: 0 0 80px rgba(0,0,0,0.75);
       position: relative;
       overflow: hidden;

--- a/utilities/shared/css/page-ancestry.css
+++ b/utilities/shared/css/page-ancestry.css
@@ -7,7 +7,7 @@
       font-family: 'EB Garamond', Georgia, serif;
       font-size: 17px;
       line-height: 1.72;
-      color: var(--ink);
+      color: var(--fg);
     }
 
     .cover { min-height: 280px; }
@@ -60,7 +60,7 @@
     }
 
     .feature-box {
-      background: var(--cream);
+      background: var(--surface);
       border: 1px solid var(--rule);
       border-radius: 2px;
       padding: 0.95rem 1.1rem 1rem;

--- a/utilities/shared/css/page-campaign.css
+++ b/utilities/shared/css/page-campaign.css
@@ -11,13 +11,13 @@
       font-family: 'EB Garamond', Georgia, serif;
       font-size: 17px;
       line-height: 1.72;
-      color: var(--ink);
+      color: var(--fg);
     }
 
     .page-wrap {
       max-width: 860px;
       margin: 0 auto;
-      background: var(--paper);
+      background: var(--bg);
       box-shadow: 0 0 80px rgba(0,0,0,0.75);
       position: relative;
       overflow: hidden;
@@ -212,7 +212,7 @@
     .theme p { margin-bottom: 0; font-size: 0.97rem; }
 
     .callout {
-      background: var(--cream);
+      background: var(--surface);
       border-left: 3px solid var(--gold);
       border-radius: 2px;
       padding: 0.9rem 1.1rem;

--- a/utilities/shared/css/page-dashboard.css
+++ b/utilities/shared/css/page-dashboard.css
@@ -166,6 +166,57 @@ body { background:#111008; background-image: url('/images/paper-texture-top-view
 }
 
 /* =====================================================
+   DARK THEME
+   Activated via [data-theme="dark"] or prefers-color-scheme.
+   ===================================================== */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ink: #e8dcc8; --parchment: #0e0b08; --parchment2: #1c1710;
+    --parchment3: #2a2218; --rule: rgba(184,146,44,0.25); --shadow: rgba(0,0,0,0.4);
+  }
+}
+[data-theme="dark"] {
+  --ink: #e8dcc8; --parchment: #0e0b08; --parchment2: #1c1710;
+  --parchment3: #2a2218; --rule: rgba(184,146,44,0.25); --shadow: rgba(0,0,0,0.4);
+}
+[data-theme="light"] {
+  --ink: #1a1208; --parchment: #f5edd8; --parchment2: #ede0c4;
+  --parchment3: #e4d5b0; --rule: rgba(184,146,44,0.35); --shadow: rgba(26,18,8,0.12);
+}
+/* Elements with hardcoded rgba(26,18,8,...) — remap for dark mode */
+[data-theme="dark"] .domain-gauge-label,
+[data-theme="dark"] .domain-gauge-pct,
+[data-theme="dark"] .health-note,
+[data-theme="dark"] .filter-label,
+[data-theme="dark"] .critical-path,
+[data-theme="dark"] .session-summary,
+[data-theme="dark"] .summary-item,
+[data-theme="dark"] .section-count,
+[data-theme="dark"] .section-chevron,
+[data-theme="dark"] .todo-note,
+[data-theme="dark"] .todo-effort,
+[data-theme="dark"] .last-updated { color: rgba(232,220,200,0.55); }
+[data-theme="dark"] .filter-btn { color: rgba(232,220,200,0.6); background: var(--parchment2); }
+[data-theme="dark"] .filter-btn.active { background: var(--gold-lt, #d4a94a); color: #0e0b08; border-color: var(--gold-lt, #d4a94a); }
+[data-theme="dark"] .todo-checkbox { background: var(--parchment); }
+[data-theme="dark"] .todo-text.done-text { color: rgba(232,220,200,0.35); }
+[data-theme="dark"] .progress-bar-wrap { background: rgba(232,220,200,0.12); }
+[data-theme="dark"] .section-header:hover { background: rgba(184,146,44,0.08); }
+[data-theme="dark"] .todo-item:hover { background: rgba(184,146,44,0.06); }
+[data-theme="dark"] .obs-link { color: rgba(232,220,200,0.6); background: rgba(232,220,200,0.06); border-color: rgba(232,220,200,0.15); }
+[data-theme="dark"] .obs-link:hover { color: var(--parchment); background: rgba(232,220,200,0.12); }
+@media (prefers-color-scheme: dark) {
+  .domain-gauge-label, .domain-gauge-pct, .health-note, .filter-label,
+  .critical-path, .session-summary, .summary-item, .section-count,
+  .section-chevron, .todo-note, .todo-effort, .last-updated { color: rgba(232,220,200,0.55); }
+  .filter-btn { color: rgba(232,220,200,0.6); background: var(--parchment2); }
+  .filter-btn.active { background: var(--gold-lt, #d4a94a); color: #0e0b08; border-color: var(--gold-lt, #d4a94a); }
+  .todo-checkbox { background: var(--parchment); }
+  .todo-text.done-text { color: rgba(232,220,200,0.35); }
+  .progress-bar-wrap { background: rgba(232,220,200,0.12); }
+}
+
+/* =====================================================
    STYLE_OVERRIDES
    Add your CSS overrides here. Document in SKILL.md.
    ===================================================== */

--- a/utilities/shared/css/page-lore.css
+++ b/utilities/shared/css/page-lore.css
@@ -5,7 +5,7 @@
       font-family: 'EB Garamond', Georgia, serif;
       font-size: 18px;
       line-height: 1.85;
-      color: var(--ink);
+      color: var(--fg);
     }
 
     .cover { min-height: 300px; }
@@ -61,7 +61,7 @@
     .audio-player {
       margin: 2.4rem 0;
       padding: 1.1rem 1.4rem 1.2rem;
-      background: var(--cream);
+      background: var(--surface);
       border: 1px solid var(--rule);
       border-radius: 2px;
       box-shadow: inset 0 1px 4px rgba(26,18,8,0.06);

--- a/utilities/shared/css/tokens.css
+++ b/utilities/shared/css/tokens.css
@@ -13,4 +13,37 @@
   --dark-mid: #1c1710;
   --dark-sur: #2a2218;
   --dark-brd: #3a3020;
+
+  /* Semantic theme layer — use these in page CSS */
+  --bg:      var(--paper);
+  --fg:      var(--ink);
+  --surface: var(--cream);
 }
+@media (prefers-color-scheme: dark) {
+  :root { --bg: var(--dark-bg); --fg: var(--cream); --surface: var(--dark-sur); }
+}
+[data-theme="dark"]  { --bg: var(--dark-bg); --fg: var(--cream); --surface: var(--dark-sur); }
+[data-theme="light"] { --bg: var(--paper);   --fg: var(--ink);   --surface: var(--cream); }
+
+/* Theme toggle button (all pages) */
+.theme-toggle {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  z-index: 9999;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid var(--rule);
+  background: var(--bg);
+  color: var(--fg);
+  font-size: 1rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 8px var(--shadow);
+  transition: background 0.2s, color 0.2s, border-color 0.2s;
+  opacity: 0.7;
+}
+.theme-toggle:hover { opacity: 1; }

--- a/utilities/shared/css/world-base.css
+++ b/utilities/shared/css/world-base.css
@@ -10,7 +10,7 @@
       font-family: 'EB Garamond', Georgia, serif;
       font-size: 17px;
       line-height: 1.72;
-      color: var(--ink);
+      color: var(--fg);
       display: flex;
       align-items: flex-start;
       justify-content: center;
@@ -19,7 +19,7 @@
     .page-wrap {
       max-width: 860px;
       margin: 0;
-      background: var(--paper);
+      background: var(--bg);
       box-shadow: 0 0 80px rgba(0,0,0,0.75);
       position: relative;
       overflow: hidden;
@@ -57,7 +57,7 @@
     p:last-child { margin-bottom: 0; }
 
     .callout {
-      background: var(--cream);
+      background: var(--surface);
       border-left: 3px solid var(--gold);
       border-radius: 2px;
       padding: 0.9rem 1.1rem;
@@ -292,7 +292,7 @@
       letter-spacing: 0.07em;
       text-transform: uppercase;
       color: var(--steel);
-      background: var(--cream);
+      background: var(--surface);
       padding: 0.55rem 0.7rem;
       border-bottom: 2px solid var(--rule);
       text-align: left;
@@ -331,7 +331,7 @@
       gap: 0.9rem; margin-top: 1.3rem;
     }
     .feature-box {
-      background: var(--cream); border: 1px solid var(--rule);
+      background: var(--surface); border: 1px solid var(--rule);
       border-radius: 2px; padding: 0.95rem 1.1rem 1rem;
       box-shadow: inset 0 1px 4px rgba(26,18,8,0.06);
     }

--- a/utilities/templates/base.html
+++ b/utilities/templates/base.html
@@ -66,5 +66,7 @@
 
 </div><!-- /page-wrap -->
 
+<button class="theme-toggle" onclick="(function(){var h=document.documentElement;var cur=h.getAttribute('data-theme')||(window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');h.setAttribute('data-theme',cur==='dark'?'light':'dark');localStorage.setItem('ts-theme',h.getAttribute('data-theme'));})()" title="Toggle light/dark theme">◑</button>
+
 </body>
 </html>

--- a/utilities/templates/pages/dashboard.html
+++ b/utilities/templates/pages/dashboard.html
@@ -134,5 +134,7 @@
   }
   applyFilters();
 </script>
+<button class="theme-toggle" onclick="(function(){var h=document.documentElement;var cur=h.getAttribute('data-theme')||(window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');h.setAttribute('data-theme',cur==='dark'?'light':'dark');localStorage.setItem('ts-theme',h.getAttribute('data-theme'));})()" title="Toggle light/dark theme">◑</button>
+
 </body>
 </html>


### PR DESCRIPTION
- tokens.css: add --bg/--fg/--surface semantic vars + @media dark + [data-theme] overrides + .theme-toggle button CSS
- base.css, page-campaign.css, world-base.css: .page-wrap background → var(--bg)
- page-ancestry.css, page-lore.css, page-campaign.css, world-base.css: body color → var(--fg); cream backgrounds → var(--surface)
- page-dashboard.css: [data-theme="dark"] + @media dark block for parchment vars and rgba text overrides
- base.html, pages/dashboard.html: floating theme toggle button

https://claude.ai/code/session_01KnCArXoy9M32Z4tsExfSMT