### PR TITLE
infra: Schema C on diagrams + concepts index (#77 gap)

### DIFF
--- a/world/concepts/Index.md
+++ b/world/concepts/Index.md
@@ -1,9 +1,11 @@
 ---
 title: Concepts & Forces Index
 project: TTRPG_Tarim_Shaiel
-type: entity_index
-entity_type: concept
-status: active
+domain: world
+doc_type: operational
+content_type: index
+visibility: internal
+status: draft
 created: 2026-03-10
 last_updated: 2026-03-10
 ---

--- a/world/diagrams/cosmological-architecture.md
+++ b/world/diagrams/cosmological-architecture.md
@@ -1,7 +1,10 @@
 ---
 title: Cosmological Architecture Diagram
 project: TTRPG_Tarim_Shaiel
-type: diagram
+domain: world
+doc_type: substrate
+content_type: reference
+visibility: gm_secrets
 diagram_type: cosmological-layers
 status: draft
 created: 2026-03-10

--- a/world/diagrams/faction-web.md
+++ b/world/diagrams/faction-web.md
@@ -1,7 +1,10 @@
 ---
 title: Faction Relationship Web
 project: TTRPG_Tarim_Shaiel
-type: diagram
+domain: world
+doc_type: substrate
+content_type: reference
+visibility: gm_secrets
 diagram_type: faction-web
 status: draft
 created: 2026-03-10

--- a/world/diagrams/historical-causal-chain.md
+++ b/world/diagrams/historical-causal-chain.md
@@ -1,7 +1,10 @@
 ---
 title: Historical Causal Chain
 project: TTRPG_Tarim_Shaiel
-type: diagram
+domain: world
+doc_type: substrate
+content_type: reference
+visibility: gm_secrets
 diagram_type: causal-timeline
 status: draft
 created: 2026-03-10


### PR DESCRIPTION
4 files missed between phases — fixed now.

world/diagrams/: cosmological-architecture.md, faction-web.md,
historical-causal-chain.md — type: diagram removed; domain: world /
doc_type: substrate / content_type: reference / visibility: gm_secrets added.
diagram_type: extension field preserved.

world/concepts/Index.md — type: entity_index + entity_type: removed;
domain: world / doc_type: operational / content_type: index /
visibility: internal added; status: active → draft.

https://claude.ai/code/session_01TAs9kdJZ1Ceq8xoCd54Cmm