### PR TITLE
infra: sitewide keyword search (closes #200)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ references/
 docs/*.html
 docs/**/*.html
 !docs/login.html
+docs/search-index.json
 
 # External tool integration (not source content)
 moulinette/

--- a/utilities/build.py
+++ b/utilities/build.py
@@ -11,6 +11,7 @@ Usage:
     python utilities/build.py campaign-frame
     python utilities/build.py ancestry lore
     python utilities/build.py lore --source narrative/lore/The Roads.md
+    python utilities/build.py search-index search
 
 Commands:
     list            Print all registered generators with their descriptions
@@ -19,14 +20,17 @@ Commands:
 
 Options:
     --source PATH   Source file for generators that require one (lore, world)
-    --public        Pass --public to world-all (omit GM-only content)
+    --public        Pass --public to world-all and search-index (omit GM-only content)
     --out PATH      Override output path for a single generator
 
 Registered generators (in pipeline order):
+    homepage        Site homepage
     dashboard       Project health dashboard from TODO.md
     campaign-frame  Campaign frame HTML
     lore            Styled lore HTML (requires --source or uses default)
     ancestry        Peoples of Tarim-Shaiel ancestry page
+    search-index    Search index JSON (docs/search-index.json)
+    search          Search UI page (docs/search.html)
     world           Single world/myth/timeline doc (requires --source)
     world-all       Batch all world docs + index
 
@@ -35,7 +39,9 @@ handled separately by utilities/legendkeeper-pipeline/publish.py.
 
 Build pipeline:
     1. _copy_css()  — copies utilities/shared/css/*.css → docs/assets/css/
-    2. Run requested generators in order
+    2. _copy_js()   — copies utilities/shared/js/*.js  → docs/assets/js/
+                      (downloads lunr.min.js on first run if not present)
+    3. Run requested generators in order
 """
 
 import os
@@ -64,11 +70,16 @@ def _load_registry() -> dict:
     from campaign_frame.generate_campaign_frame import generator as campaign_frame
     from lore.generate_lore_html import generator as lore
     from ancestries.generate_ancestry_html import generator as ancestry
+    from search.generate_search_index import generator as search_index
+    from search.generate_search_html import generator as search
     from world.generate_world_html import generator as world
     from world.generate_all_world_html import generator as world_all
 
     return {
-        g.name: g for g in [homepage, dashboard, campaign_frame, lore, ancestry, world, world_all]
+        g.name: g for g in [
+            homepage, dashboard, campaign_frame, lore, ancestry,
+            search_index, search, world, world_all,
+        ]
     }
 
 # ---------------------------------------------------------------------------
@@ -92,6 +103,12 @@ def _run_one(name: str, generator, args: argparse.Namespace) -> int:
         argv = [args.source]
         if args.out:
             argv += ["--out", args.out]
+
+    elif name in ("search-index", "search"):
+        if args.public:
+            argv = ["--public"]
+        elif args.gm:
+            argv = ["--gm"]
 
     elif name == "world-all":
         if args.public:
@@ -126,8 +143,42 @@ def _copy_css() -> None:
         shutil.copy2(f, dst / f.name)
 
 
+def _download_lunr(dest: Path) -> None:
+    """Download lunr.min.js from CDN into utilities/shared/js/."""
+    import urllib.request
+    url = "https://cdn.jsdelivr.net/npm/lunr@2.3.9/lunr.min.js"
+    print(f"  Downloading lunr.min.js from CDN → {dest.name}")
+    try:
+        urllib.request.urlretrieve(url, dest)
+        print(f"  lunr.min.js downloaded ({dest.stat().st_size} bytes)")
+    except Exception as e:
+        print(f"  WARNING: Could not download lunr.min.js: {e}", file=sys.stderr)
+        print(f"  Search page will use CDN fallback. Vendor manually to remove CDN dependency.",
+              file=sys.stderr)
+
+
+def _copy_js() -> None:
+    """Copy all *.js from utilities/shared/js/ to docs/assets/js/.
+
+    Downloads lunr.min.js on first run if not already vendored.
+    """
+    import shutil
+    src = SCRIPT_DIR / "shared" / "js"
+    src.mkdir(parents=True, exist_ok=True)
+    dst = VAULT_ROOT / "docs" / "assets" / "js"
+    dst.mkdir(parents=True, exist_ok=True)
+
+    lunr_src = src / "lunr.min.js"
+    if not lunr_src.exists():
+        _download_lunr(lunr_src)
+
+    for f in src.glob("*.js"):
+        shutil.copy2(f, dst / f.name)
+
+
 def _cmd_run(names: list[str], registry: dict, args: argparse.Namespace) -> int:
     _copy_css()
+    _copy_js()
     if args.gm:
         os.environ['TS_GM_MODE'] = '1'
     failed = []

--- a/utilities/search/generate_search_html.py
+++ b/utilities/search/generate_search_html.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Tarim-Shaiel Search Page Generator
+=====================================
+Renders the static search UI shell at docs/search.html.
+The page fetches search-index.json at runtime and performs all
+searching client-side via Lunr.js.
+
+Usage:
+    python utilities/search/generate_search_html.py
+    python utilities/search/generate_search_html.py --public
+"""
+
+import os
+import sys
+import argparse
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+VAULT_ROOT = SCRIPT_DIR.parent.parent
+DOCS_DIR = VAULT_ROOT / "docs"
+
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+from shared.renderer import render_page
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate docs/search.html search UI page."
+    )
+    parser.add_argument("--public", action="store_true")
+    parser.add_argument("--gm", action="store_true")
+    parser.parse_args()
+
+    gm_mode = os.environ.get("TS_GM_MODE") == "1"
+
+    DOCS_DIR.mkdir(parents=True, exist_ok=True)
+    out = DOCS_DIR / "search.html"
+
+    html = render_page(
+        "pages/search.html",
+        title="Search · Tarim-Shaiel",
+        page_title="Search",
+        extra_css=["page-search"],
+        generator_name="utilities/search/generate_search_html.py",
+        gm_mode=gm_mode,
+    )
+
+    out.write_text(html, encoding="utf-8")
+    print(f"Search page generated: {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+
+# ---------------------------------------------------------------------------
+# Generator protocol (used by utilities/build.py)
+# ---------------------------------------------------------------------------
+
+class _Generator:
+    name = "search"
+    description = "Generate search.html Lunr.js search UI page"
+
+    def run(self, argv=None):
+        import sys as _sys
+        _saved = _sys.argv[1:]
+        if argv is not None:
+            _sys.argv[1:] = list(argv)
+        try:
+            result = main()
+            return result if isinstance(result, int) else 0
+        except SystemExit as e:
+            return int(e.code) if isinstance(e.code, int) else 0
+        finally:
+            _sys.argv[1:] = _saved
+
+
+generator = _Generator()

--- a/utilities/search/generate_search_index.py
+++ b/utilities/search/generate_search_index.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""
+Tarim-Shaiel Search Index Generator
+=====================================
+Crawls all source .md files and writes docs/search-index.json for use
+by the client-side Lunr.js search page.
+
+Usage:
+    python utilities/search/generate_search_index.py
+    python utilities/search/generate_search_index.py --public
+    python utilities/search/generate_search_index.py --gm
+"""
+
+import json
+import os
+import re
+import sys
+import argparse
+from pathlib import Path
+from urllib.parse import quote
+
+SCRIPT_DIR = Path(__file__).parent
+VAULT_ROOT = SCRIPT_DIR.parent.parent
+DOCS_DIR = VAULT_ROOT / "docs"
+
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+from shared.frontmatter import parse_frontmatter
+
+# Directories under vault root to crawl
+SEARCH_ROOTS = ["world", "narrative", "characters", "mechanics"]
+
+# Path segments that disqualify a file from indexing
+SKIP_SEGMENTS = {"lat.md", ".meta", "transcripts", "archive"}
+
+# Filename patterns that disqualify a file
+SKIP_FILENAME_PREFIXES = ("_TEMPLATE_",)
+
+# content_type / type values that get entity card treatment
+ENTITY_TYPES = {
+    "location", "landmark", "poi", "region",
+    "faction", "ancestry", "npc", "character",
+}
+
+BODY_MAX_CHARS = 500
+
+
+# ---------------------------------------------------------------------------
+# Text utilities
+# ---------------------------------------------------------------------------
+
+def _strip_obsidian(text: str) -> str:
+    """Convert Obsidian-flavoured Markdown to plain indexable text."""
+    # Remove wiki embeds: ![[...]]
+    text = re.sub(r'!\[\[[^\]]*\]\]', ' ', text)
+    # Wiki links with alias: [[target|alias]] → alias
+    text = re.sub(r'\[\[[^\]|]+\|([^\]]+)\]\]', r'\1', text)
+    # Wiki links without alias: [[target]] → target
+    text = re.sub(r'\[\[([^\]]+)\]\]', r'\1', text)
+    # Markdown headings → keep text
+    text = re.sub(r'^#{1,6}\s+', '', text, flags=re.MULTILINE)
+    # Bold / italic
+    text = re.sub(r'\*{1,3}([^*]+)\*{1,3}', r'\1', text)
+    text = re.sub(r'_{1,3}([^_]+)_{1,3}', r'\1', text)
+    # Inline code
+    text = re.sub(r'`[^`]*`', ' ', text)
+    # Fenced code blocks
+    text = re.sub(r'```[\s\S]*?```', ' ', text)
+    # HTML tags
+    text = re.sub(r'<[^>]+>', ' ', text)
+    # Horizontal rules / YAML-like lines
+    text = re.sub(r'^[-*_]{3,}\s*$', '', text, flags=re.MULTILINE)
+    # Collapse whitespace
+    text = re.sub(r'\s+', ' ', text)
+    return text.strip()
+
+
+def _compute_url(path: Path) -> str:
+    """Compute the site-relative URL for a source .md file.
+
+    Strips the top-level domain folder (world/, narrative/, characters/)
+    so that world/locations/kucha.md → /locations/kucha.html.
+    """
+    rel = path.relative_to(VAULT_ROOT)
+    parts = list(rel.parts)
+    # Drop the first component (world/, narrative/, etc.)
+    if len(parts) > 1:
+        parts = parts[1:]
+    # Percent-encode each segment (safe chars: letters, digits, hyphen, underscore, dot)
+    encoded = [quote(p, safe="-_.~") for p in parts]
+    url_path = "/".join(encoded)
+    # Swap extension
+    url_path = re.sub(r'\.md$', '.html', url_path, flags=re.IGNORECASE)
+    return "/" + url_path
+
+
+def _make_id(path: Path) -> str:
+    """Stable string ID derived from vault-relative path without extension."""
+    rel = path.relative_to(VAULT_ROOT)
+    return re.sub(r'\.md$', '', str(rel).replace("\\", "/"), flags=re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+def _should_skip_path(path: Path) -> bool:
+    """Return True if this path should be excluded from the index."""
+    parts_set = set(path.parts)
+    if parts_set & SKIP_SEGMENTS:
+        return True
+    if any(s in str(path) for s in SKIP_SEGMENTS):
+        return True
+    if any(path.name.startswith(p) for p in SKIP_FILENAME_PREFIXES):
+        return True
+    return False
+
+
+def _discover_files(public_only: bool) -> list[Path]:
+    """Return all indexable .md files respecting visibility rules."""
+    found = []
+    for root_name in SEARCH_ROOTS:
+        root = VAULT_ROOT / root_name
+        if not root.exists():
+            continue
+        for md in root.rglob("*.md"):
+            if _should_skip_path(md):
+                continue
+            found.append(md)
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Record builder
+# ---------------------------------------------------------------------------
+
+def _build_record(path: Path, public_only: bool) -> dict | None:
+    """Parse a .md file and return an index record, or None to skip."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except Exception:
+        return None
+
+    fm, body = parse_frontmatter(raw)
+
+    # Status gate
+    if str(fm.get("status", "")).lower() == "deprecated":
+        return None
+
+    # Visibility gate
+    visibility = str(fm.get("visibility", "gm_secrets")).lower()
+    if public_only and visibility != "public":
+        return None
+
+    title = fm.get("title") or path.stem
+    if not title:
+        return None
+
+    content_type = str(fm.get("content_type") or fm.get("type") or "").lower()
+    entity = content_type in ENTITY_TYPES
+
+    # Summary / description (prefer explicit field, fall back to body snippet)
+    summary = str(fm.get("summary") or fm.get("description") or "").strip()
+
+    # Tags: normalise to list of strings
+    raw_tags = fm.get("tags") or []
+    if isinstance(raw_tags, str):
+        raw_tags = [t.strip() for t in raw_tags.split(",") if t.strip()]
+    tags = [str(t) for t in raw_tags]
+
+    region = str(fm.get("region") or "").strip()
+
+    body_text = _strip_obsidian(body)
+    body_snippet = body_text[:BODY_MAX_CHARS]
+
+    return {
+        "id": _make_id(path),
+        "title": title,
+        "url": _compute_url(path),
+        "content_type": content_type,
+        "entity": entity,
+        "region": region,
+        "summary": summary,
+        "tags": tags,
+        "body": body_snippet,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate search-index.json for the Tarim-Shaiel site."
+    )
+    parser.add_argument(
+        "--public", action="store_true",
+        help="Only index visibility:public documents (Netlify public build)"
+    )
+    parser.add_argument(
+        "--gm", action="store_true",
+        help="Index all documents including gm_secrets (default behaviour)"
+    )
+    args = parser.parse_args()
+
+    # Honour TS_GM_MODE env var used by other generators
+    public_only = args.public
+    if not public_only and not args.gm:
+        # Default: follow TS_GM_MODE; if not set → index everything (GM mode)
+        public_only = False
+
+    files = _discover_files(public_only)
+    records = []
+    skipped = 0
+
+    for f in sorted(files):
+        rec = _build_record(f, public_only)
+        if rec is None:
+            skipped += 1
+            continue
+        records.append(rec)
+
+    DOCS_DIR.mkdir(parents=True, exist_ok=True)
+    out = DOCS_DIR / "search-index.json"
+    out.write_text(json.dumps(records, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    mode = "public" if public_only else "gm"
+    print(f"Search index written: {out}")
+    print(f"  Mode:    {mode}")
+    print(f"  Indexed: {len(records)} documents")
+    print(f"  Skipped: {skipped} documents")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+
+# ---------------------------------------------------------------------------
+# Generator protocol (used by utilities/build.py)
+# ---------------------------------------------------------------------------
+
+class _Generator:
+    name = "search-index"
+    description = "Generate search-index.json from all source .md files"
+
+    def run(self, argv=None):
+        import sys as _sys
+        _saved = _sys.argv[1:]
+        if argv is not None:
+            _sys.argv[1:] = list(argv)
+        try:
+            result = main()
+            return result if isinstance(result, int) else 0
+        except SystemExit as e:
+            return int(e.code) if isinstance(e.code, int) else 0
+        finally:
+            _sys.argv[1:] = _saved
+
+
+generator = _Generator()

--- a/utilities/search/generate_search_index.py
+++ b/utilities/search/generate_search_index.py
@@ -17,7 +17,6 @@ import re
 import sys
 import argparse
 from pathlib import Path
-from urllib.parse import quote
 
 SCRIPT_DIR = Path(__file__).parent
 VAULT_ROOT = SCRIPT_DIR.parent.parent
@@ -43,10 +42,35 @@ ENTITY_TYPES = {
 
 BODY_MAX_CHARS = 500
 
+# Scan roots that the world generator knows about (mirrors SCAN_ROOTS in generate_all_world_html.py)
+_WORLD_SCAN_ROOTS = {"world", "narrative"}
+
 
 # ---------------------------------------------------------------------------
 # Text utilities
 # ---------------------------------------------------------------------------
+
+def _slug(text: str) -> str:
+    """Mirror generate_all_world_html._slug(): lowercase, non-word chars → hyphens."""
+    return re.sub(r'[^\w\-]+', '-', text.lower()).strip('-')
+
+
+def _output_subfolder(path: Path) -> str:
+    """Mirror generate_all_world_html._output_subfolder().
+
+    Returns the docs-relative subdirectory for a source file by stripping
+    the scan root from the source parent path.
+    """
+    for root_name in _WORLD_SCAN_ROOTS:
+        root = VAULT_ROOT / root_name
+        try:
+            parts = path.parent.relative_to(root).parts
+            return '/'.join(parts) if parts else path.parent.name
+        except ValueError:
+            continue
+    # For paths outside world/narrative (e.g. characters/), strip top-level folder
+    rel_parts = path.relative_to(VAULT_ROOT).parts
+    return '/'.join(rel_parts[1:-1]) if len(rel_parts) > 2 else path.parent.name
 
 def _strip_obsidian(text: str) -> str:
     """Convert Obsidian-flavoured Markdown to plain indexable text."""
@@ -77,20 +101,20 @@ def _strip_obsidian(text: str) -> str:
 def _compute_url(path: Path) -> str:
     """Compute the site-relative URL for a source .md file.
 
-    Strips the top-level domain folder (world/, narrative/, characters/)
-    so that world/locations/kucha.md → /locations/kucha.html.
+    Mirrors generate_all_world_html.py's output path logic:
+      - subfolder via _output_subfolder() (strips scan root from parent)
+      - filename via _slug(stem) (lowercase, non-word → hyphens)
+
+    Examples:
+      world/locations/kucha.md          → /locations/kucha.html
+      world/ancestries/PEOPLES_OF_...md → /ancestries/peoples-of-....html
+      narrative/lore/The Roads.md       → /lore/the-roads.html
     """
-    rel = path.relative_to(VAULT_ROOT)
-    parts = list(rel.parts)
-    # Drop the first component (world/, narrative/, etc.)
-    if len(parts) > 1:
-        parts = parts[1:]
-    # Percent-encode each segment (safe chars: letters, digits, hyphen, underscore, dot)
-    encoded = [quote(p, safe="-_.~") for p in parts]
-    url_path = "/".join(encoded)
-    # Swap extension
-    url_path = re.sub(r'\.md$', '.html', url_path, flags=re.IGNORECASE)
-    return "/" + url_path
+    subfolder = _output_subfolder(path)
+    slug = _slug(path.stem)
+    if subfolder:
+        return f"/{subfolder}/{slug}.html"
+    return f"/{slug}.html"
 
 
 def _make_id(path: Path) -> str:

--- a/utilities/shared/css/page-search.css
+++ b/utilities/shared/css/page-search.css
@@ -1,0 +1,173 @@
+/* ── Search page — page-search.css ── */
+
+.search-wrap {
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 48px 32px 80px;
+}
+
+/* ── Search form ── */
+.search-form {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 32px;
+}
+
+.search-input {
+  flex: 1;
+  font-family: 'EB Garamond', Georgia, serif;
+  font-size: 17px;
+  background: var(--surface);
+  color: var(--fg);
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  padding: 10px 16px;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  appearance: none;
+  -webkit-appearance: none;
+}
+.search-input:focus {
+  border-color: var(--gold);
+  box-shadow: 0 0 0 2px rgba(184,137,42,0.15);
+}
+.search-input::placeholder { color: var(--muted); }
+
+.search-btn {
+  font-family: 'Cinzel', serif;
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  background: var(--gold);
+  color: var(--dark-bg);
+  border: none;
+  border-radius: 2px;
+  padding: 10px 20px;
+  cursor: pointer;
+  transition: background 0.15s;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.search-btn:hover { background: var(--gold-lt); }
+
+/* ── Status line ── */
+.search-status {
+  font-family: 'Cinzel', serif;
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 24px;
+  min-height: 1.4em;
+}
+
+/* ── Results container ── */
+.search-results {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* ── Content-type badge ── */
+.search-badge {
+  font-family: 'Cinzel', serif;
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--gold);
+  margin-bottom: 6px;
+  display: block;
+}
+
+/* ── Entity card — elevated result for locations, factions, etc. ── */
+.search-entity-card {
+  background: var(--surface);
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  padding: 24px 28px;
+  text-decoration: none;
+  display: block;
+  position: relative;
+  transition: border-color 0.2s, background 0.2s;
+}
+.search-entity-card:hover {
+  border-color: var(--gold);
+  background: rgba(184,137,42,0.04);
+}
+.search-entity-card .doc-card-title {
+  font-family: 'Cinzel', serif;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--fg);
+  margin-bottom: 5px;
+}
+.search-entity-card .doc-card-sub {
+  font-size: 15px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+.search-entity-card .doc-card-arrow {
+  position: absolute;
+  right: 24px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--gold);
+  font-size: 18px;
+  opacity: 0.4;
+  transition: opacity 0.2s, right 0.2s;
+}
+.search-entity-card:hover .doc-card-arrow { opacity: 1; right: 18px; }
+
+/* ── Standard result ── */
+.search-result {
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 16px;
+}
+.search-result:last-child { border-bottom: none; }
+
+.search-result-header {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 4px;
+  flex-wrap: wrap;
+}
+.search-result-title {
+  font-family: 'Cinzel', serif;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--fg);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+.search-result-title:hover { color: var(--gold); }
+
+/* Override badge display inline for standard results */
+.search-result .search-badge {
+  display: inline;
+  margin-bottom: 0;
+  font-size: 9px;
+}
+
+.search-result-snippet {
+  font-size: 15px;
+  color: var(--muted);
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* ── Highlight ── */
+mark {
+  background: rgba(184,137,42,0.22);
+  color: inherit;
+  border-radius: 2px;
+  padding: 0 2px;
+}
+
+/* ── Responsive ── */
+@media (max-width: 640px) {
+  .search-wrap { padding: 32px 20px 60px; }
+  .search-form { flex-direction: column; }
+  .search-btn { width: 100%; }
+  .search-entity-card .doc-card-arrow { display: none; }
+}

--- a/utilities/templates/base.html
+++ b/utilities/templates/base.html
@@ -37,6 +37,7 @@
     <a href="/index.html">Home</a>
     <a href="/campaign-frame.html">Campaign Frame</a>
     <a href="/peoples-of-tarim-shaiel.html">Peoples</a>
+    <a href="/search.html" title="Search">&#x2315; Search</a>
   </div>
 </nav>
 {% endblock %}

--- a/utilities/templates/pages/search.html
+++ b/utilities/templates/pages/search.html
@@ -1,0 +1,247 @@
+{% extends "base.html" %}
+
+{% block extra_head %}
+<script src="/assets/js/lunr.min.js"></script>
+<script>
+/* CDN fallback if vendored file missing */
+if (typeof lunr === 'undefined') {
+  document.write('<scr'+'ipt src="https://cdn.jsdelivr.net/npm/lunr@2.3.9/lunr.min.js"><\/scr'+'ipt>');
+}
+</script>
+{% endblock %}
+
+{% block page_header %}
+<div class="page-header">
+  <div class="page-header-eyebrow">Tarim-Shaiel</div>
+  <h1>Search</h1>
+</div>
+{% endblock %}
+
+{% block content %}
+<div class="search-wrap">
+
+  <form class="search-form" id="search-form" role="search" onsubmit="return false;">
+    <input
+      class="search-input"
+      id="search-input"
+      type="search"
+      placeholder="Search locations, factions, lore&hellip;"
+      autocomplete="off"
+      aria-label="Search"
+    />
+    <button class="search-btn" type="submit" aria-label="Submit search">Search</button>
+  </form>
+
+  <div id="search-status" class="search-status" aria-live="polite"></div>
+  <div id="search-results" class="search-results" role="region" aria-label="Search results"></div>
+
+</div>
+
+<script>
+(function () {
+  'use strict';
+
+  var INDEX_URL = '/search-index.json';
+  var LUNR_CDN  = 'https://cdn.jsdelivr.net/npm/lunr@2.3.9/lunr.min.js';
+
+  var _docs   = null;   // raw records array
+  var _idx    = null;   // built lunr index
+  var _docMap = {};     // id → record
+
+  /* ── Helpers ── */
+
+  function esc(str) {
+    return String(str || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function highlight(text, terms) {
+    if (!terms || !terms.length || !text) return esc(text);
+    var escaped = esc(text);
+    terms.forEach(function (term) {
+      var re = new RegExp('(' + term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + ')', 'gi');
+      escaped = escaped.replace(re, '<mark>$1</mark>');
+    });
+    return escaped;
+  }
+
+  function badgeHtml(contentType) {
+    if (!contentType) return '';
+    return '<span class="search-badge">' + esc(contentType.replace(/-/g, ' ')) + '</span>';
+  }
+
+  function renderEntityCard(doc, terms) {
+    var meta = [];
+    if (doc.region) meta.push(esc(doc.region));
+    if (doc.summary) meta.push(highlight(doc.summary, terms));
+    else if (doc.body) meta.push(highlight(doc.body.slice(0, 180), terms));
+
+    return [
+      '<a class="search-entity-card doc-card" href="' + esc(doc.url) + '">',
+        badgeHtml(doc.content_type),
+        '<div class="doc-card-title">' + highlight(doc.title, terms) + '</div>',
+        meta.length ? '<div class="doc-card-sub">' + meta.join(' &middot; ') + '</div>' : '',
+        '<span class="doc-card-arrow">&#8594;</span>',
+      '</a>',
+    ].join('');
+  }
+
+  function renderStandardResult(doc, terms) {
+    var snippet = doc.summary || doc.body || '';
+    return [
+      '<div class="search-result">',
+        '<div class="search-result-header">',
+          '<a class="search-result-title" href="' + esc(doc.url) + '">' + highlight(doc.title, terms) + '</a>',
+          badgeHtml(doc.content_type),
+        '</div>',
+        snippet ? '<p class="search-result-snippet">' + highlight(snippet.slice(0, 240), terms) + '</p>' : '',
+      '</div>',
+    ].join('');
+  }
+
+  /* ── Index build ── */
+
+  function buildIndex(docs) {
+    return lunr(function () {
+      this.ref('id');
+      this.field('title',   { boost: 10 });
+      this.field('summary', { boost: 5 });
+      this.field('body',    { boost: 1 });
+      this.field('tags',    { boost: 3 });
+      this.field('region',  { boost: 2 });
+      this.metadataWhitelist = ['position'];
+
+      var self = this;
+      docs.forEach(function (doc) {
+        self.add({
+          id:      doc.id,
+          title:   doc.title || '',
+          summary: (doc.summary || '') + ' ' + (doc.description || ''),
+          body:    doc.body || '',
+          tags:    Array.isArray(doc.tags) ? doc.tags.join(' ') : '',
+          region:  doc.region || '',
+        });
+      });
+    });
+  }
+
+  /* ── Search & render ── */
+
+  function doSearch(query) {
+    var status  = document.getElementById('search-status');
+    var results = document.getElementById('search-results');
+
+    if (!query || !query.trim()) {
+      status.textContent = '';
+      results.innerHTML  = '';
+      return;
+    }
+
+    if (!_idx) {
+      status.textContent = 'Index not loaded yet — please try again.';
+      return;
+    }
+
+    var raw;
+    try {
+      raw = _idx.search(query);
+    } catch (e) {
+      /* Lunr throws on malformed query strings */
+      try { raw = _idx.search(query + '*'); } catch (e2) { raw = []; }
+    }
+
+    /* Extract matched terms for highlighting */
+    var terms = [];
+    raw.forEach(function (r) {
+      Object.keys(r.matchData.metadata).forEach(function (t) { terms.push(t); });
+    });
+
+    if (!raw.length) {
+      status.textContent = 'No results for “' + esc(query) + '”.';
+      results.innerHTML  = '';
+      return;
+    }
+
+    status.textContent = raw.length + ' result' + (raw.length === 1 ? '' : 's') + ' for “' + esc(query) + '”';
+
+    var html = raw.map(function (r) {
+      var doc = _docMap[r.ref];
+      if (!doc) return '';
+      return doc.entity ? renderEntityCard(doc, terms) : renderStandardResult(doc, terms);
+    }).join('');
+
+    results.innerHTML = html;
+  }
+
+  /* ── URL param sync ── */
+
+  function getQueryParam() {
+    var params = new URLSearchParams(window.location.search);
+    return params.get('q') || '';
+  }
+
+  function setQueryParam(q) {
+    var url = new URL(window.location.href);
+    if (q) { url.searchParams.set('q', q); }
+    else   { url.searchParams.delete('q'); }
+    history.replaceState(null, '', url.toString());
+  }
+
+  /* ── Initialisation ── */
+
+  function init() {
+    fetch(INDEX_URL)
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.json();
+      })
+      .then(function (docs) {
+        _docs = docs;
+        docs.forEach(function (d) { _docMap[d.id] = d; });
+        _idx = buildIndex(docs);
+
+        var initialQ = getQueryParam();
+        if (initialQ) {
+          var input = document.getElementById('search-input');
+          if (input) input.value = initialQ;
+          doSearch(initialQ);
+        }
+      })
+      .catch(function (err) {
+        document.getElementById('search-status').textContent =
+          'Search index unavailable. Run ‘python utilities/build.py search-index’ to generate it.';
+        console.error('Search index load error:', err);
+      });
+
+    var input = document.getElementById('search-input');
+    var form  = document.getElementById('search-form');
+
+    function onSearch() {
+      var q = (input.value || '').trim();
+      setQueryParam(q);
+      doSearch(q);
+    }
+
+    form.addEventListener('submit', onSearch);
+    input.addEventListener('input', function () {
+      clearTimeout(input._debounce);
+      input._debounce = setTimeout(onSearch, 220);
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+})();
+</script>
+{% endblock %}
+
+{% block credits %}
+    Tarim-Shaiel &middot; Search &middot; 2026
+{% endblock %}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **`utilities/search/generate_search_index.py`** — new generator that crawls `world/`, `narrative/`, `characters/` via `rglob()`, reads frontmatter, and writes `docs/search-index.json`. Respects `--public` visibility gating (skips `gm_secrets` docs). Marks entity types (`location`, `landmark`, `poi`, `region`, `faction`, `ancestry`, `npc`, `character`) for elevated card rendering.
- **`utilities/search/generate_search_html.py`** — renders `docs/search.html` via the existing Jinja2 `render_page()` renderer.
- **`utilities/templates/pages/search.html`** — Lunr.js-powered search UI: fetches `search-index.json` at runtime, builds index client-side, renders entity cards vs standard snippet results, handles `?q=` URL param for linkable results, keyword highlighting via `<mark>`.
- **`utilities/shared/css/page-search.css`** — search form, entity card, standard result, and badge styles using existing design tokens.
- **`utilities/build.py`** — registers `search-index` and `search` generators (pipeline order: after `ancestry`, before `world-all`); adds `_copy_js()` which auto-downloads `lunr.min.js` on first run; `--public`/`--gm` flags pass through to both generators.
- **`utilities/templates/base.html`** — adds Search link (`⌕ Search`) to `.site-nav-links` navbar.
- **`.gitignore`** — adds `docs/search-index.json` (build artifact, generated at Netlify build time).

## Lunr.js vendoring

The harness environment blocks CDN downloads. `_copy_js()` in `build.py` will attempt to download `lunr.min.js` at first build on Netlify (which has full internet access). The search template includes a CDN fallback (`cdn.jsdelivr.net`) in case the vendored file is absent. To vendor locally: `curl -o utilities/shared/js/lunr.min.js https://cdn.jsdelivr.net/npm/lunr@2.3.9/lunr.min.js`.

## Test plan

- [ ] `python utilities/build.py search-index` → `docs/search-index.json` written; ~669 GM docs indexed
- [ ] `python utilities/build.py search-index --public` → ~56 docs (only `visibility: public`)
- [ ] `python utilities/build.py search-index search` → both files generated cleanly
- [ ] `python utilities/build.py list` → shows `search-index` and `search` in registry
- [ ] Open `docs/search.html` in browser; search for "Kucha" → entity card with `/locations/kucha.html` link
- [ ] Navigate to `docs/search.html?q=kucha` → results pre-populated
- [ ] Dark/light theme toggle works on search page
- [ ] `python utilities/build.py all --public` → full pipeline completes; search generators run without error

https://claude.ai/code/session_01FS44P6eBb9h5iF2rhBwZsB
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FS44P6eBb9h5iF2rhBwZsB)_