### PR TITLE
search: exclude gm_secrets directories from public search index

### DIFF
--- a/utilities/search/generate_search_index.py
+++ b/utilities/search/generate_search_index.py
@@ -29,7 +29,7 @@ from shared.frontmatter import parse_frontmatter
 SEARCH_ROOTS = ["world", "narrative", "characters", "mechanics"]
 
 # Path segments that disqualify a file from indexing
-SKIP_SEGMENTS = {"lat.md", ".meta", "transcripts", "archive"}
+SKIP_SEGMENTS = {"lat.md", ".meta", "transcripts", "archive", "gm_secrets"}
 
 # Filename patterns that disqualify a file
 SKIP_FILENAME_PREFIXES = ("_TEMPLATE_",)


### PR DESCRIPTION
## Summary

- `gm_secrets` was not in `SKIP_SEGMENTS` in `generate_search_index.py`, so files under any `gm_secrets/` subdirectory were crawled and included in the public search index if their `visibility:` frontmatter said anything other than `gm_secrets`
- Adding `"gm_secrets"` to `SKIP_SEGMENTS` makes directory-based exclusion a hard guarantee — no file under a `gm_secrets/` path can ever appear in the public index, regardless of its frontmatter

## Test plan

- [ ] Run `python utilities/build.py search-index --public` and confirm no records in `docs/search-index.json` have a path containing `gm_secrets`
- [ ] Run `python utilities/build.py search-index --gm` and confirm gm_secrets content is also excluded (GM build uses the full HTML generator's auth gate, not search)
- [ ] Verify public site search returns no GM-only content

https://claude.ai/code/session_01EaiGm24efvk2HqMpQrQbTN

---
_Generated by [Claude Code](https://claude.ai/code/session_01EaiGm24efvk2HqMpQrQbTN)_