### PR TITLE
pipeline: stub /locations HTML build (issue #201)

### DIFF
--- a/.meta/DECISION_LOG.md
+++ b/.meta/DECISION_LOG.md
@@ -653,3 +653,19 @@ Third visibility value for operational/navigational infrastructure files that ar
 - Single `visibility:` field replaces four competing signals
 - Extension field pattern (established by location files) applied consistently to ancestries, factions, and weapons
 - `published:` retained as a distinct generator-layer concern rather than conflated with content visibility
+
+---
+
+## Decision 18 — Locations HTML Generator Architecture
+Date: 2026-05-04
+Domain: Pipeline
+Status: locked after first successful build
+
+Dedicated `utilities/locations/` module separate from `generate_all_world_html.py`. Output: 33 location detail pages, 7 region index pages, `docs/world.html` world home. Full Leaflet maps (ESRI satellite + Carto labels, no API key).
+
+`gm_revealed` mechanic: optional `id=` attribute on `[!gm-only]` callout blocks; list of revealed IDs in location frontmatter; build-time promotion to `.revealed-content.gm-callout--revealed` — no JS toggle, no re-deploy.
+
+7 region source files created in `world/regions/`. 3 of 7 have GeoJSON polygon backing (tarim-basin, eastern-gateway, central-asia); 4 are content-only stubs.
+
+Normalization script (`utilities/world/normalize_locations.py`) applied to all 37 location files: added `parent_region`, `visibility`, `status`; renamed `factions → factions_visible`.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Read the relevant `lat.md/` file before diving into domain content — one read 
 | Session 0 design, awakenings, flashbacks, memory events | [[lat.md/session0]] | Session 0 work, pacing, scenario status |
 | Archetypes, tools system, surrendered-layer, identity | [[lat.md/characters]] | Archetype description constraints, tools-as-divine-marks, identity mechanics |
 | Locations, regions, factions, geography | [[lat.md/world]] | Any world / location / faction question |
+| Locations HTML generator, GM reveal mechanic, slug→region map | [[lat.md/locations]] | Any locations build / generator / gm_revealed question |
 | Daggerheart integration, current mechanics, Wrongness | [[lat.md/mechanics]] | Rules questions, mechanical identity |
 | All locked decisions + hard constraints (summary) | [[lat.md/decisions]] | Verifying lock status before any design work |
 

--- a/lat.md/locations.md
+++ b/lat.md/locations.md
@@ -1,0 +1,106 @@
+---
+title: Locations — AI Navigation
+project: TTRPG_Tarim_Shaiel
+type: navigation
+visibility: internal
+status: canon
+created: 2026-05-04
+last_updated: 2026-05-04
+---
+
+> _Navigation layer — stop here if the summary answers your question. Do not read individual location files unless you need specific detail._
+
+# Locations
+
+## Generator Architecture
+
+| Component | Path | Purpose |
+|---|---|---|
+| Main generator | `utilities/locations/generate_locations_html.py` | Full generation loop; CLI + build.py entry point |
+| Location parser | `utilities/locations/location_parser.py` | Parses `world/locations/*.md` → `LocationData` dicts |
+| Region parser | `utilities/locations/region_parser.py` | Parses `world/regions/*.md` → `RegionData` dicts |
+| HTML components | `utilities/locations/location_components.py` | Mini-map, faction table, danger pips, stats row, xref stub |
+| Normalization script | `utilities/world/normalize_locations.py` | One-time migration; adds `parent_region`, `visibility`, `status`, renames `factions→factions_visible` |
+
+## Output Paths
+
+| Output | Description |
+|---|---|
+| `docs/world.html` | World home page — full Leaflet map + region cards + A-Z location index |
+| `docs/locations/<slug>.html` | ~35 individual location detail pages |
+| `docs/locations/regions/<slug>.html` | 7 regional index pages |
+
+## Slug → Region Mapping
+
+| Region slug | GeoJSON ID | Locations | Notes |
+|---|---|---|---|
+| `tarim-basin` | `region_tarim_basin` | ~20 | Core Silk Road oases |
+| `eastern-gateway` | `region_eastern_gateway` | 4 | Gansu Corridor; Elven sacred sites |
+| `central-asian-hubs` | `region_central_asia` | ~5 | Transoxiana/Sogdiana cities |
+| `eastern-terminus` | _(no polygon)_ | 1 | Chang'an only |
+| `mountain-passes` | _(no polygon)_ | 3 | Dwarven pass infrastructure |
+| `transoxiana` | _(no polygon)_ | 0 | Stub; future development |
+| `steppe-confederations` | _(no polygon)_ | 2+ | Nomadic; Alak-Mor, Balkh-Kamen |
+
+## Type Classification (from location frontmatter)
+
+Priority: `type:` field → `mapmarker:` → `content_type:` → tags (type-city etc.)
+
+| Type slug | Display label | Default danger pips |
+|---|---|---|
+| city | City | 1 |
+| route-node | Route Node | 2 |
+| oasis | Oasis | 2 |
+| sacred-site | Sacred Site | 3 |
+| dungeon | Dungeon | 4 |
+| landmark | Landmark | 3 |
+| fortress | Fortress | 3 |
+| poi | Point of Interest | 1 |
+
+## GM Reveal Mechanic
+
+**Syntax in location .md files:**
+```markdown
+> [!gm-only id=some-unique-id]
+> This block is normally GM-only but can be promoted to player-visible.
+```
+
+**Promotion in frontmatter:**
+```yaml
+gm_revealed:
+  - some-unique-id
+```
+
+At build time, any block whose `id=` value appears in `gm_revealed` is rendered as `.revealed-content.gm-callout--revealed` — promoted to the player DOM regardless of `gm_mode`. Blocks without a matching revealed ID are stripped in public builds.
+
+## GeoJSON Structure
+
+- `world/data/tarim-shaiel-locations.geojson` — 32 features; IDs: `location_{slug}`
+- `world/data/tarim-shaiel-routes.geojson` — trade route linestrings
+- `world/data/tarim-shaiel-regions.geojson` — 3 polygon features; IDs: `region_tarim_basin`, `region_eastern_gateway`, `region_central_asia`
+
+Leaflet maps use ESRI satellite tile layer + Carto label overlay (no API key required).
+
+## Build Commands
+
+```bash
+# Default (public-only, no GM content)
+python utilities/build.py locations
+
+# GM build
+python utilities/build.py locations --gm
+
+# Dry run
+python utilities/locations/generate_locations_html.py --dry-run
+
+# Full pipeline (locations runs before search-index to avoid broken links)
+python utilities/build.py all
+```
+
+## Known Gaps
+
+- `dun-kharan.md` — no coordinates (complex frontmatter; parent_region: null)
+- `tarim-shaiel.md` — overview doc, not a specific location; parent_region: null
+- 4 of 7 regions have no GeoJSON polygon — region boundary layer shows only 3 polygons
+- `docs/locations/` cross-links not yet populated (xref-stub placeholder)
+- `zzkashkar.md` — duplicate stub file; excluded by `zz` prefix filter

--- a/lat.md/subagent-context.md
+++ b/lat.md/subagent-context.md
@@ -5,7 +5,7 @@ type: navigation
 visibility: internal
 status: canon
 created: 2026-04-11
-last_updated: 2026-05-02
+last_updated: 2026-05-04
 ---
 
 > _Derived from CLAUDE.md and `lat.md/` files — update in the same commit when those change. Inject into spawned agent prompts; this file is not automatically read by any session._
@@ -31,6 +31,7 @@ Read the relevant `lat.md/` file before diving into domain content — one read 
 | Session 0 design, awakenings, flashbacks, memory events | [[lat.md/session0]] | Session 0 work, pacing, scenario status |
 | Archetypes, tools system, surrendered-layer, identity | [[lat.md/characters]] | Archetype description constraints, tools-as-divine-marks, identity mechanics |
 | Locations, regions, factions, geography | [[lat.md/world]] | Any world / location / faction question |
+| Locations HTML generator, GM reveal mechanic, slug→region map | [[lat.md/locations]] | Any locations build / generator / gm_revealed question |
 | Daggerheart integration, current mechanics, Wrongness | [[lat.md/mechanics]] | Rules questions, mechanical identity |
 | All locked decisions + hard constraints (summary) | [[lat.md/decisions]] | Verifying lock status before any design work |
 

--- a/utilities/build.py
+++ b/utilities/build.py
@@ -33,6 +33,7 @@ Registered generators (in pipeline order):
     search          Search UI page (docs/search.html)
     world           Single world/myth/timeline doc (requires --source)
     world-all       Batch all world docs + index
+    locations       Location detail pages, region indexes, and world home map
 
 The LegendKeeper pipeline (generate_lk_json, generate_lk_markdown) is
 handled separately by utilities/legendkeeper-pipeline/publish.py.
@@ -74,11 +75,12 @@ def _load_registry() -> dict:
     from search.generate_search_html import generator as search
     from world.generate_world_html import generator as world
     from world.generate_all_world_html import generator as world_all
+    from locations.generate_locations_html import generator as locations
 
     return {
         g.name: g for g in [
             homepage, dashboard, campaign_frame, lore, ancestry,
-            search_index, search, world, world_all,
+            search_index, search, world, world_all, locations,
         ]
     }
 
@@ -117,6 +119,12 @@ def _run_one(name: str, generator, args: argparse.Namespace) -> int:
             argv = ["--gm"]
         if args.out:
             argv += ["--out", args.out]
+
+    elif name == "locations":
+        if args.public:
+            argv = ["--public"]
+        elif args.gm:
+            argv = ["--gm"]
 
     else:
         if args.out:

--- a/utilities/homepage/generate_homepage.py
+++ b/utilities/homepage/generate_homepage.py
@@ -35,6 +35,12 @@ FEATURED_DOCS = [
         "sub": "History, factions, and the shape of the known world.",
         "href": "/lore/the-roads.html",
     },
+    {
+        "tag": "Interactive Map · 6 Regions",
+        "title": "World Map",
+        "sub": "Locations, regions, and the Silk Road trade network.",
+        "href": "/world.html",
+    },
 ]
 
 # Categories suppressed from the homepage (subcategories, GM-only, or low-value index noise)

--- a/utilities/locations/__init__.py
+++ b/utilities/locations/__init__.py
@@ -1,0 +1,1 @@
+"Locations HTML generator package."

--- a/utilities/locations/generate_locations_html.py
+++ b/utilities/locations/generate_locations_html.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+"""
+Locations HTML Generator
+=========================
+Generates player-facing and GM location pages for the Tarim-Shaiel campaign.
+
+Output structure:
+  docs/world.html                         — world home page (full Leaflet map + region/location index)
+  docs/locations/<slug>.html              — individual location detail pages
+  docs/locations/regions/<slug>.html      — regional index pages
+
+Usage:
+    python utilities/locations/generate_locations_html.py
+    python utilities/locations/generate_locations_html.py --public
+    python utilities/locations/generate_locations_html.py --gm
+    python utilities/locations/generate_locations_html.py --dry-run
+
+Visibility gating (fails closed):
+  --public: only `visibility: public` locations and all regions
+  --gm    : all locations with GM callouts rendered; sets TS_GM_MODE=1
+  default : same as --public (safe default)
+"""
+
+import json
+import os
+import sys
+import argparse
+from pathlib import Path
+from html import escape
+
+SCRIPT_DIR = Path(__file__).parent
+VAULT_ROOT = SCRIPT_DIR.parent.parent
+DOCS_DIR   = VAULT_ROOT / "docs"
+
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+
+from locations.location_parser import load_all_locations, LocationData
+from locations.region_parser import load_all_regions, RegionData
+from locations.location_components import (
+    render_danger_pips,
+    render_stats_row,
+    render_faction_table,
+    render_resources,
+    render_mini_map,
+    render_xref_stub,
+    _TYPE_LABELS,
+)
+from shared.renderer import render_page
+from shared.html_render import render_body
+
+_LOCATIONS_DIR = VAULT_ROOT / "world" / "locations"
+_REGIONS_DIR   = VAULT_ROOT / "world" / "regions"
+_DATA_DIR      = VAULT_ROOT / "world" / "data"
+
+_LOCATIONS_GEOJSON = _DATA_DIR / "tarim-shaiel-locations.geojson"
+_ROUTES_GEOJSON    = _DATA_DIR / "tarim-shaiel-routes.geojson"
+_REGIONS_GEOJSON   = _DATA_DIR / "tarim-shaiel-regions.geojson"
+
+_GM_PAGE_BANNER = (
+    '<div class="gm-page-banner">'
+    'GM ARCHIVE — NOT FOR PLAYER DISTRIBUTION'
+    '</div>\n'
+)
+
+# ---------------------------------------------------------------------------
+# GeoJSON loading
+# ---------------------------------------------------------------------------
+
+def _load_geojson(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding='utf-8'))
+    except Exception as e:
+        print(f"  WARNING: could not load {path.name}: {e}", file=sys.stderr)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# World home map
+# ---------------------------------------------------------------------------
+
+_LEAFLET_TILE_SATELLITE = (
+    "https://server.arcgisonline.com/ArcGIS/rest/services/"
+    "World_Imagery/MapServer/tile/{z}/{y}/{x}"
+)
+_LEAFLET_TILE_LABELS = (
+    "https://{s}.basemaps.cartocdn.com/rastertiles/voyager_only_labels/{z}/{x}/{y}{r}.png"
+)
+
+
+def _build_world_map_html(
+    locations: list[LocationData],
+    locations_geojson: dict | None,
+    routes_geojson: dict | None,
+    regions_geojson: dict | None,
+) -> str:
+    """Build the full-page Leaflet map for world.html."""
+
+    layers_js = ''
+    if locations_geojson:
+        layers_js += f'var _locGJ = {json.dumps(locations_geojson)};\n'
+    if routes_geojson:
+        layers_js += f'var _routeGJ = {json.dumps(routes_geojson)};\n'
+    if regions_geojson:
+        layers_js += f'var _regionGJ = {json.dumps(regions_geojson)};\n'
+
+    # Build location popup data from parsed location list
+    popup_map: dict[str, dict] = {}
+    for loc in locations:
+        popup_map[loc['slug']] = {
+            'title': loc['title'],
+            'type':  _TYPE_LABELS.get(loc['location_type'], loc['location_type']),
+            'url':   f'/locations/{loc["slug"]}.html',
+        }
+    popup_js = f'var _locPopups = {json.dumps(popup_map)};\n'
+
+    geojson_layers = ''
+    if regions_geojson:
+        geojson_layers += (
+            'L.geoJSON(_regionGJ, {'
+            'style: function(f){return {color: f.properties.stroke || "#b8892a", weight: 2, fillOpacity: 0.08};}'
+            '}).addTo(map);\n'
+        )
+    if routes_geojson:
+        geojson_layers += (
+            'L.geoJSON(_routeGJ, {style:{color:"#b8892a",weight:1.5,opacity:0.5,dashArray:"4 4"}}).addTo(map);\n'
+        )
+    if locations_geojson:
+        geojson_layers += """\
+L.geoJSON(_locGJ, {
+  pointToLayer: function(f, ll) {
+    return L.circleMarker(ll, {radius:6, color:"#7a1f1f", weight:2, fillColor:"#f5edd8", fillOpacity:0.9});
+  },
+  onEachFeature: function(f, layer) {
+    var slug = (f.id || '').replace(/^location_/, '');
+    var info = _locPopups[slug] || {title: f.id, type: '', url: '#'};
+    layer.bindPopup('<strong>' + info.title + '</strong><br>' + info.type + '<br><a href="' + info.url + '">View &rarr;</a>');
+  }
+}).addTo(map);
+"""
+
+    return f"""<div id="world-map"></div>
+<script>
+(function() {{
+  {layers_js}{popup_js}
+  var map = L.map('world-map', {{
+    center: [40.0, 75.0],
+    zoom: 5,
+    zoomControl: true,
+    attributionControl: false
+  }});
+  L.tileLayer('{_LEAFLET_TILE_SATELLITE}', {{maxZoom: 18}}).addTo(map);
+  L.tileLayer('{_LEAFLET_TILE_LABELS}', {{maxZoom: 18, subdomains: 'abcd'}}).addTo(map);
+  {geojson_layers}
+}})();
+</script>
+"""
+
+
+# ---------------------------------------------------------------------------
+# Location detail page
+# ---------------------------------------------------------------------------
+
+def _build_location_page(
+    loc: LocationData,
+    regions: dict[str, RegionData],
+    locations_geojson: dict | None,
+    routes_geojson: dict | None,
+    gm_mode: bool,
+) -> str:
+    region = regions.get(loc['parent_region']) if loc['parent_region'] else None
+    revealed = set(loc['gm_revealed'])
+
+    body_html, _ = render_body(
+        loc['body'],
+        vault=VAULT_ROOT,
+        docs=DOCS_DIR,
+        gm_mode=gm_mode,
+        revealed_ids=revealed,
+    )
+
+    mini_map_html = render_mini_map(loc, locations_geojson, routes_geojson, zoom=6)
+    stats_row_html = render_stats_row(loc, region)
+    danger_html = render_danger_pips(loc['location_type'])
+    faction_html = render_faction_table(loc['factions_visible'])
+    resources_html = render_resources(loc['resources'])
+    xref_html = render_xref_stub()
+
+    gm_banner = _GM_PAGE_BANNER if gm_mode else ''
+
+    return render_page(
+        'pages/location-detail.html',
+        title=loc['title'],
+        fantasy_name=loc['fantasy_name'],
+        description=loc['description'],
+        location_type=loc['location_type'],
+        location_type_label=_TYPE_LABELS.get(loc['location_type'], loc['location_type'].replace('-', ' ').title()),
+        visibility=loc['visibility'],
+        stats_row_html=stats_row_html,
+        danger_pips_html=danger_html,
+        mini_map_html=mini_map_html,
+        content_html=body_html,
+        faction_table_html=faction_html,
+        resources_html=resources_html,
+        xref_html=xref_html,
+        region_title=region['title'] if region else None,
+        region_slug=loc['parent_region'] if loc['parent_region'] else '',
+        gm_page_banner_html=gm_banner,
+        gm_mode=gm_mode,
+        extra_css=['world-location'],
+        generator_name='generate_locations_html.py',
+    )
+
+
+# ---------------------------------------------------------------------------
+# Region index page
+# ---------------------------------------------------------------------------
+
+def _build_region_page(
+    region: RegionData,
+    region_locations: list[LocationData],
+    locations_geojson: dict | None,
+    routes_geojson: dict | None,
+    gm_mode: bool,
+) -> str:
+    from shared.html_render import render_body as _rb
+    body_html, _ = _rb(region['body'], vault=VAULT_ROOT, docs=DOCS_DIR, gm_mode=gm_mode)
+
+    # Region mini-map centred on the first location with coords
+    region_map_html = ''
+    anchor = next((l for l in region_locations if l['lat'] is not None), None)
+    if anchor:
+        from locations.location_components import render_mini_map
+        region_map_html = render_mini_map(anchor, locations_geojson, routes_geojson, zoom=5)
+
+    # Location cards
+    loc_cards = []
+    for l in region_locations:
+        loc_cards.append({
+            'slug': l['slug'],
+            'title': l['title'],
+            'description': l['description'],
+            'location_type': l['location_type'],
+            'location_type_label': _TYPE_LABELS.get(l['location_type'], l['location_type']),
+            'danger_pips_html': render_danger_pips(l['location_type']),
+        })
+
+    return render_page(
+        'pages/region-index.html',
+        title=region['title'],
+        location_count=len(region_locations),
+        primary_ancestry=region['primary_ancestry'],
+        faction_weight=region['faction_weight'],
+        region_map_html=region_map_html,
+        content_html=body_html,
+        locations=loc_cards,
+        gm_mode=gm_mode,
+        extra_css=['world-location', 'world-region'],
+        generator_name='generate_locations_html.py',
+    )
+
+
+# ---------------------------------------------------------------------------
+# World home page
+# ---------------------------------------------------------------------------
+
+def _build_world_home(
+    locations: list[LocationData],
+    regions: dict[str, RegionData],
+    locations_geojson: dict | None,
+    routes_geojson: dict | None,
+    regions_geojson: dict | None,
+    gm_mode: bool,
+) -> str:
+    world_map_html = _build_world_map_html(
+        locations, locations_geojson, routes_geojson, regions_geojson
+    )
+
+    region_list = []
+    for slug, r in sorted(regions.items()):
+        region_list.append({
+            'slug': r['slug'],
+            'title': r['title'],
+            'location_count': sum(1 for l in locations if l['parent_region'] == slug),
+            'primary_ancestry': r['primary_ancestry'],
+            'faction_weight': r['faction_weight'],
+        })
+
+    all_locations_sorted = sorted(locations, key=lambda l: l['title'])
+    az_list = [{
+        'slug': l['slug'],
+        'title': l['title'],
+        'location_type': l['location_type'],
+        'location_type_label': _TYPE_LABELS.get(l['location_type'], l['location_type']),
+    } for l in all_locations_sorted]
+
+    return render_page(
+        'pages/world-home.html',
+        title='Tarim-Shaiel — World Map',
+        world_map_html=world_map_html,
+        regions=region_list,
+        all_locations=az_list,
+        gm_mode=gm_mode,
+        extra_css=['world-map'],
+        generator_name='generate_locations_html.py',
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main generation loop
+# ---------------------------------------------------------------------------
+
+def generate(
+    public_only: bool = True,
+    gm_mode: bool = False,
+    dry_run: bool = False,
+) -> int:
+    if gm_mode:
+        os.environ['TS_GM_MODE'] = '1'
+        public_only = False
+
+    locations = load_all_locations(_LOCATIONS_DIR, public_only=public_only)
+    regions   = load_all_regions(_REGIONS_DIR)
+
+    locs_gj   = _load_geojson(_LOCATIONS_GEOJSON)
+    routes_gj = _load_geojson(_ROUTES_GEOJSON)
+    regions_gj = _load_geojson(_REGIONS_GEOJSON)
+
+    print(f"  Loaded {len(locations)} locations, {len(regions)} regions")
+
+    errors: list[str] = []
+
+    # --- Location detail pages ---
+    locs_out = DOCS_DIR / "locations"
+    if not dry_run:
+        locs_out.mkdir(parents=True, exist_ok=True)
+
+    for loc in locations:
+        try:
+            html = _build_location_page(loc, regions, locs_gj, routes_gj, gm_mode)
+        except Exception as e:
+            msg = f"  ERROR building {loc['slug']}: {e}"
+            print(msg, file=sys.stderr)
+            errors.append(msg)
+            continue
+
+        out_path = locs_out / f"{loc['slug']}.html"
+        if dry_run:
+            print(f"  [DRY] would write {out_path.relative_to(VAULT_ROOT)}")
+        else:
+            out_path.write_text(html, encoding='utf-8')
+
+    print(f"  Location pages: {len(locations)}")
+
+    # --- Region index pages ---
+    regions_out = locs_out / "regions"
+    if not dry_run:
+        regions_out.mkdir(parents=True, exist_ok=True)
+
+    for slug, region in regions.items():
+        region_locs = [l for l in locations if l['parent_region'] == slug]
+        try:
+            html = _build_region_page(region, region_locs, locs_gj, routes_gj, gm_mode)
+        except Exception as e:
+            msg = f"  ERROR building region {slug}: {e}"
+            print(msg, file=sys.stderr)
+            errors.append(msg)
+            continue
+
+        out_path = regions_out / f"{slug}.html"
+        if dry_run:
+            print(f"  [DRY] would write {out_path.relative_to(VAULT_ROOT)}")
+        else:
+            out_path.write_text(html, encoding='utf-8')
+
+    print(f"  Region pages: {len(regions)}")
+
+    # --- World home ---
+    try:
+        world_html = _build_world_home(
+            locations, regions, locs_gj, routes_gj, regions_gj, gm_mode
+        )
+    except Exception as e:
+        msg = f"  ERROR building world.html: {e}"
+        print(msg, file=sys.stderr)
+        errors.append(msg)
+        world_html = None
+
+    if world_html:
+        out_path = DOCS_DIR / "world.html"
+        if dry_run:
+            print(f"  [DRY] would write {out_path.relative_to(VAULT_ROOT)}")
+        else:
+            out_path.write_text(world_html, encoding='utf-8')
+        print("  World home: docs/world.html")
+
+    if errors:
+        print(f"\n  {len(errors)} error(s) during generation.")
+        return 1
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate HTML for world locations, regions, and world home page."
+    )
+    parser.add_argument('--public', action='store_true',
+                        help='Only include visibility:public locations (default behaviour)')
+    parser.add_argument('--gm', action='store_true',
+                        help='GM mode: include all locations, render GM callouts')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Show output paths without writing files')
+    args = parser.parse_args()
+
+    return generate(
+        public_only=not args.gm,
+        gm_mode=args.gm,
+        dry_run=args.dry_run,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Generator protocol wrapper (for build.py registry)
+# ---------------------------------------------------------------------------
+
+class _Generator:
+    name = "locations"
+    description = "Location detail pages, region indexes, and world home map"
+
+    def run(self, argv=None):
+        import sys as _sys
+        _saved = _sys.argv[1:]
+        if argv is not None:
+            _sys.argv[1:] = list(argv)
+        try:
+            result = main()
+            return result if isinstance(result, int) else 0
+        except SystemExit as e:
+            return int(e.code) if isinstance(e.code, int) else 0
+        finally:
+            _sys.argv[1:] = _saved
+
+
+generator = _Generator()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utilities/locations/location_components.py
+++ b/utilities/locations/location_components.py
@@ -1,0 +1,207 @@
+"""
+Location HTML component renderers.
+
+Each function takes structured data and returns an HTML fragment string.
+Used by the main generator to assemble location detail pages.
+"""
+
+import json
+from html import escape
+from typing import Optional
+
+from locations.location_parser import LocationData
+from locations.region_parser import RegionData
+
+
+# ---------------------------------------------------------------------------
+# Danger / tier pips
+# ---------------------------------------------------------------------------
+
+_DANGER_BY_TYPE: dict[str, int] = {
+    "city": 1,
+    "route-node": 2,
+    "oasis": 2,
+    "sacred-site": 3,
+    "dungeon": 4,
+    "landmark": 3,
+    "fortress": 3,
+    "poi": 1,
+}
+
+_TYPE_LABELS: dict[str, str] = {
+    "city": "City",
+    "route-node": "Route Node",
+    "oasis": "Oasis",
+    "sacred-site": "Sacred Site",
+    "dungeon": "Dungeon",
+    "landmark": "Landmark",
+    "fortress": "Fortress",
+    "poi": "Point of Interest",
+}
+
+
+def render_danger_pips(location_type: str, count: Optional[int] = None) -> str:
+    """Render filled/empty danger pips (1–5 scale)."""
+    if count is None:
+        count = _DANGER_BY_TYPE.get(location_type, 2)
+    filled = "&#9679;" * count
+    empty = "&#9675;" * (5 - count)
+    return (
+        f'<div class="danger-pips" title="Danger level {count}/5">'
+        f'<span class="pips-filled">{filled}</span>'
+        f'<span class="pips-empty">{empty}</span>'
+        f'</div>'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stats row (type + elevation + region)
+# ---------------------------------------------------------------------------
+
+def render_stats_row(loc: LocationData, region: Optional[RegionData] = None) -> str:
+    """Render the stats badge strip beneath the location title."""
+    type_label = _TYPE_LABELS.get(loc['location_type'], loc['location_type'].replace('-', ' ').title())
+    parts = [f'<span class="stat-badge stat-badge--type">{escape(type_label)}</span>']
+
+    if loc['elevation'] is not None and loc['elevation'] != 0:
+        elev_m = loc['elevation']
+        parts.append(f'<span class="stat-badge stat-badge--elevation">{elev_m:,} m</span>')
+
+    if region:
+        region_url = f'/locations/regions/{escape(region["slug"])}.html'
+        parts.append(
+            f'<span class="stat-badge stat-badge--region">'
+            f'<a href="{region_url}">{escape(region["title"])}</a>'
+            f'</span>'
+        )
+    elif loc['parent_region']:
+        slug = str(loc['parent_region'])
+        label = slug.replace('-', ' ').title()
+        parts.append(
+            f'<span class="stat-badge stat-badge--region">'
+            f'<a href="/locations/regions/{escape(slug)}.html">{escape(label)}</a>'
+            f'</span>'
+        )
+
+    return f'<div class="stats-row">{"".join(parts)}</div>\n'
+
+
+# ---------------------------------------------------------------------------
+# Faction table
+# ---------------------------------------------------------------------------
+
+def render_faction_table(factions: list[str]) -> str:
+    """Render visible factions as a compact table."""
+    if not factions:
+        return ''
+
+    rows = ''.join(
+        f'<tr><td>{escape(f)}</td></tr>\n'
+        for f in factions
+    )
+    return (
+        f'<div class="faction-table">\n'
+        f'  <h3 class="faction-table__heading">Factions Present</h3>\n'
+        f'  <table>\n{rows}  </table>\n'
+        f'</div>\n'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Resources list
+# ---------------------------------------------------------------------------
+
+def render_resources(resources: list[str]) -> str:
+    """Render resource badges."""
+    if not resources:
+        return ''
+    badges = ''.join(
+        f'<span class="resource-badge">{escape(r)}</span>'
+        for r in resources
+    )
+    return f'<div class="resources-list">{badges}</div>\n'
+
+
+# ---------------------------------------------------------------------------
+# Leaflet mini-map
+# ---------------------------------------------------------------------------
+
+_LEAFLET_TILE_SATELLITE = (
+    "https://server.arcgisonline.com/ArcGIS/rest/services/"
+    "World_Imagery/MapServer/tile/{z}/{y}/{x}"
+)
+_LEAFLET_TILE_LABELS = (
+    "https://{s}.basemaps.cartocdn.com/rastertiles/voyager_only_labels/{z}/{x}/{y}{r}.png"
+)
+
+
+def render_mini_map(
+    loc: LocationData,
+    locations_geojson: Optional[dict] = None,
+    routes_geojson: Optional[dict] = None,
+    zoom: int = 6,
+) -> str:
+    """Render a Leaflet mini-map div for a single location.
+
+    Inlines GeoJSON data as JavaScript variables to avoid cross-origin issues.
+    """
+    if loc['lat'] is None or loc['lon'] is None:
+        return '<div class="mini-map mini-map--no-coords"><p>No coordinates available.</p></div>\n'
+
+    map_id = f'map-{escape(loc["slug"])}'
+    lat = loc['lat']
+    lon = loc['lon']
+
+    layers_js = ''
+    if locations_geojson:
+        layers_js += f'var _locationsGeoJSON = {json.dumps(locations_geojson)};\n'
+    if routes_geojson:
+        layers_js += f'var _routesGeoJSON = {json.dumps(routes_geojson)};\n'
+
+    geojson_layers = ''
+    if locations_geojson:
+        geojson_layers += (
+            'L.geoJSON(_locationsGeoJSON, {'
+            'pointToLayer: function(f,ll){return L.circleMarker(ll,{radius:5,color:"#b8892a",weight:2,fillOpacity:0.7});}'
+            '}).addTo(map);\n'
+        )
+    if routes_geojson:
+        geojson_layers += (
+            'L.geoJSON(_routesGeoJSON, {style:{color:"#b8892a",weight:2,opacity:0.6}}).addTo(map);\n'
+        )
+
+    return f"""<div class="mini-map" id="{map_id}"></div>
+<script>
+(function() {{
+  {layers_js}
+  var map = L.map('{map_id}', {{
+    center: [{lat}, {lon}],
+    zoom: {zoom},
+    zoomControl: false,
+    attributionControl: false,
+    dragging: false,
+    scrollWheelZoom: false,
+    doubleClickZoom: false,
+    touchZoom: false
+  }});
+  L.tileLayer('{_LEAFLET_TILE_SATELLITE}', {{maxZoom: 18}}).addTo(map);
+  L.tileLayer('{_LEAFLET_TILE_LABELS}', {{maxZoom: 18, subdomains: 'abcd'}}).addTo(map);
+  {geojson_layers}
+  L.circleMarker([{lat}, {lon}], {{radius: 8, color: '#7a1f1f', weight: 3, fillColor: '#f5edd8', fillOpacity: 1}}).addTo(map);
+}})();
+</script>
+"""
+
+
+# ---------------------------------------------------------------------------
+# Cross-reference stub
+# ---------------------------------------------------------------------------
+
+def render_xref_stub(label: str = "Related Locations") -> str:
+    """Stub cross-reference panel — populated by future cross-link pass."""
+    return (
+        f'<div class="xref-stub">'
+        f'<span class="xref-stub__label">{escape(label)}</span>'
+        f'<span class="xref-stub__note">cross-links pending</span>'
+        f'</div>\n'
+    )

--- a/utilities/locations/location_parser.py
+++ b/utilities/locations/location_parser.py
@@ -1,0 +1,234 @@
+"""
+Location source file parser.
+
+Reads world/locations/*.md files and returns structured LocationData dicts.
+Strips Obsidian leaflet blocks, extracts frontmatter, classifies location type.
+"""
+
+import re
+from pathlib import Path
+from typing import TypedDict, Optional
+
+try:
+    import yaml
+    _YAML_AVAILABLE = True
+except ImportError:
+    _YAML_AVAILABLE = False
+
+
+# ---------------------------------------------------------------------------
+# Type definitions
+# ---------------------------------------------------------------------------
+
+class LocationData(TypedDict):
+    slug: str
+    title: str
+    fantasy_name: str
+    description: str
+    location_type: str       # city | route-node | oasis | dungeon | landmark | poi | sacred-site | fortress
+    visibility: str          # public | secret | gm_secrets
+    status: str
+    parent_region: Optional[str]
+    lat: Optional[float]
+    lon: Optional[float]
+    elevation: Optional[int]
+    mapmarker: str
+    factions_visible: list[str]
+    resources: list[str]
+    tags: list[str]
+    gm_revealed: list[str]   # list of block IDs promoted to player-visible
+    body: str                # raw markdown body (leaflet block stripped)
+    source_path: Path
+
+
+# ---------------------------------------------------------------------------
+# Location type classification
+# ---------------------------------------------------------------------------
+
+_TYPE_FIELD_MAP: dict[str, str] = {
+    "city": "city",
+    "route-node": "route-node",
+    "oasis": "oasis",
+    "dungeon": "dungeon",
+    "landmark": "landmark",
+    "poi": "poi",
+    "sacred-site": "sacred-site",
+    "fortress": "fortress",
+    "water-body": "landmark",
+    "caravanserai": "route-node",
+}
+
+_CONTENT_TYPE_MAP: dict[str, str] = {
+    "location": "city",
+    "poi": "poi",
+    "landmark": "landmark",
+}
+
+_TAG_TYPE_MAP: dict[str, str] = {
+    "type-city": "city",
+    "type-route-node": "route-node",
+    "type-oasis": "oasis",
+    "type-dungeon": "dungeon",
+    "type-sacred-site": "sacred-site",
+    "type-fortress": "fortress",
+}
+
+
+def _classify_type(fm: dict) -> str:
+    """Determine location type from frontmatter fields in priority order."""
+    # 1. explicit `type:` field
+    raw = fm.get("type", "")
+    if isinstance(raw, str):
+        raw = raw.lower().replace("_", "-").strip()
+        if raw in _TYPE_FIELD_MAP:
+            return _TYPE_FIELD_MAP[raw]
+
+    # 2. `mapmarker:` field
+    marker = str(fm.get("mapmarker", "")).lower().strip()
+    if marker in _TYPE_FIELD_MAP:
+        return _TYPE_FIELD_MAP[marker]
+
+    # 3. `content_type:` field
+    ct = str(fm.get("content_type", "")).lower().strip()
+    if ct in _CONTENT_TYPE_MAP:
+        return _CONTENT_TYPE_MAP[ct]
+
+    # 4. tags list
+    tags = _str_list(fm.get("tags", []))
+    for tag in tags:
+        if tag in _TAG_TYPE_MAP:
+            return _TAG_TYPE_MAP[tag]
+
+    return "poi"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_LEAFLET_BLOCK_RE = re.compile(
+    r'```leaflet\n.*?```', re.DOTALL
+)
+
+
+def strip_leaflet_block(body: str) -> str:
+    """Remove Obsidian ```leaflet ... ``` blocks from markdown body."""
+    return _LEAFLET_BLOCK_RE.sub('', body).strip()
+
+
+def _str_list(val) -> list[str]:
+    """Normalise a frontmatter field to a list of strings."""
+    if isinstance(val, list):
+        return [str(v).strip() for v in val if v is not None]
+    if isinstance(val, str) and val.strip():
+        return [val.strip()]
+    return []
+
+
+def _parse_fm(text: str) -> tuple[dict, str]:
+    """Return (frontmatter_dict, body_text)."""
+    m = re.match(r'^---\n(.*?\n)---\n', text, re.DOTALL)
+    if not m:
+        return {}, text
+
+    fm_text = m.group(1)
+    body = text[m.end():]
+
+    if _YAML_AVAILABLE:
+        try:
+            fm = yaml.safe_load(fm_text) or {}
+        except Exception:
+            fm = {}
+    else:
+        fm = {}
+        for line in fm_text.splitlines():
+            kv = line.split(':', 1)
+            if len(kv) == 2 and not line.startswith(' ') and not line.startswith('-'):
+                k, v = kv[0].strip(), kv[1].strip()
+                fm[k] = v.strip('"\'')
+
+    return fm, body
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def parse_location(path: Path) -> Optional[LocationData]:
+    """Parse a location .md file into a LocationData dict.
+
+    Returns None if the file is a template, test fixture, or not a location doc.
+    """
+    name = path.name
+    if name.startswith('_') or name.startswith('zz'):
+        return None
+
+    text = path.read_text(encoding='utf-8')
+    fm, body = _parse_fm(text)
+
+    if not fm:
+        return None
+
+    # Accept content_type in {location, poi, landmark} OR explicit `type:` field
+    ct = str(fm.get('content_type', '')).lower()
+    if ct not in ('location', 'poi', 'landmark', 'region'):
+        # Some files use `type:` only
+        if not fm.get('type') and not fm.get('mapmarker'):
+            return None
+
+    # Extract coordinates
+    lat = lon = None
+    loc = fm.get('location')
+    if isinstance(loc, list) and len(loc) >= 2:
+        try:
+            lat, lon = float(loc[0]), float(loc[1])
+        except (TypeError, ValueError):
+            pass
+
+    # Elevation
+    elev = None
+    try:
+        elev = int(fm.get('elevation', 0) or 0)
+    except (TypeError, ValueError):
+        pass
+
+    title = str(fm.get('title') or fm.get('name') or path.stem).strip()
+    fantasy_name = str(fm.get('fantasy_name') or title).strip()
+    slug = path.stem
+
+    return LocationData(
+        slug=slug,
+        title=title,
+        fantasy_name=fantasy_name,
+        description=str(fm.get('description', '')).strip(),
+        location_type=_classify_type(fm),
+        visibility=str(fm.get('visibility', 'public')).strip(),
+        status=str(fm.get('status', 'draft')).strip(),
+        parent_region=fm.get('parent_region') or None,
+        lat=lat,
+        lon=lon,
+        elevation=elev,
+        mapmarker=str(fm.get('mapmarker', '')).strip(),
+        factions_visible=_str_list(fm.get('factions_visible') or fm.get('factions', [])),
+        resources=_str_list(fm.get('resources', [])),
+        tags=_str_list(fm.get('tags', [])),
+        gm_revealed=_str_list(fm.get('gm_revealed', [])),
+        body=strip_leaflet_block(body),
+        source_path=path,
+    )
+
+
+def load_all_locations(locations_dir: Path, public_only: bool = False) -> list[LocationData]:
+    """Load and parse all location files from a directory.
+
+    public_only: skip files with visibility != 'public'.
+    """
+    results: list[LocationData] = []
+    for p in sorted(locations_dir.glob('*.md')):
+        data = parse_location(p)
+        if data is None:
+            continue
+        if public_only and data['visibility'] != 'public':
+            continue
+        results.append(data)
+    return results

--- a/utilities/locations/region_parser.py
+++ b/utilities/locations/region_parser.py
@@ -1,0 +1,109 @@
+"""
+Region source file parser.
+
+Reads world/regions/*.md files and returns structured RegionData dicts keyed
+by region slug. Used by the locations generator to build region index pages
+and annotate location detail pages.
+"""
+
+import re
+from pathlib import Path
+from typing import TypedDict, Optional
+
+try:
+    import yaml
+    _YAML_AVAILABLE = True
+except ImportError:
+    _YAML_AVAILABLE = False
+
+
+class RegionBounds(TypedDict):
+    sw: list[float]  # [lat, lon]
+    ne: list[float]  # [lat, lon]
+
+
+class RegionData(TypedDict):
+    slug: str
+    title: str
+    geojson_id: Optional[str]
+    bounds: Optional[RegionBounds]
+    location_count: int        # declared in frontmatter; actual count added at runtime
+    primary_ancestry: str
+    faction_weight: str        # low | medium | high
+    visibility: str
+    status: str
+    body: str                  # markdown prose
+
+
+def _parse_fm(text: str) -> tuple[dict, str]:
+    m = re.match(r'^---\n(.*?\n)---\n', text, re.DOTALL)
+    if not m:
+        return {}, text
+    fm_text = m.group(1)
+    body = text[m.end():]
+
+    if _YAML_AVAILABLE:
+        try:
+            fm = yaml.safe_load(fm_text) or {}
+        except Exception:
+            fm = {}
+    else:
+        fm = {}
+        for line in fm_text.splitlines():
+            kv = line.split(':', 1)
+            if len(kv) == 2 and not line.startswith(' '):
+                k, v = kv[0].strip(), kv[1].strip()
+                fm[k] = v.strip('"\'')
+
+    return fm, body
+
+
+def parse_region(path: Path) -> Optional[RegionData]:
+    """Parse a region .md file into a RegionData dict."""
+    if path.name.startswith('_') or path.name.startswith('KEY_'):
+        return None
+
+    text = path.read_text(encoding='utf-8')
+    fm, body = _parse_fm(text)
+
+    if not fm:
+        return None
+
+    ct = str(fm.get('content_type', '')).lower()
+    if ct not in ('region',):
+        return None
+
+    geojson_id = fm.get('geojson_id')
+    if geojson_id == 'null' or geojson_id is None:
+        geojson_id = None
+
+    bounds_raw = fm.get('bounds')
+    bounds: Optional[RegionBounds] = None
+    if isinstance(bounds_raw, dict):
+        sw = bounds_raw.get('sw')
+        ne = bounds_raw.get('ne')
+        if sw and ne:
+            bounds = RegionBounds(sw=list(sw), ne=list(ne))
+
+    return RegionData(
+        slug=path.stem,
+        title=str(fm.get('title', path.stem)).strip(),
+        geojson_id=geojson_id,
+        bounds=bounds,
+        location_count=int(fm.get('location_count', 0) or 0),
+        primary_ancestry=str(fm.get('primary_ancestry', 'mixed')).strip(),
+        faction_weight=str(fm.get('faction_weight', 'medium')).strip(),
+        visibility=str(fm.get('visibility', 'public')).strip(),
+        status=str(fm.get('status', 'draft')).strip(),
+        body=body.strip(),
+    )
+
+
+def load_all_regions(regions_dir: Path) -> dict[str, RegionData]:
+    """Load and parse all region files. Returns a slug→RegionData dict."""
+    result: dict[str, RegionData] = {}
+    for p in sorted(regions_dir.glob('*.md')):
+        data = parse_region(p)
+        if data is not None:
+            result[data['slug']] = data
+    return result

--- a/utilities/search/generate_search_index.py
+++ b/utilities/search/generate_search_index.py
@@ -98,19 +98,29 @@ def _strip_obsidian(text: str) -> str:
     return text.strip()
 
 
+_SUBFOLDER_OVERRIDES: dict[str, str] = {
+    # world/regions/ → locations generator outputs to docs/locations/regions/
+    "regions": "locations/regions",
+}
+
+
 def _compute_url(path: Path) -> str:
     """Compute the site-relative URL for a source .md file.
 
-    Mirrors generate_all_world_html.py's output path logic:
+    Mirrors each generator's output path logic:
       - subfolder via _output_subfolder() (strips scan root from parent)
       - filename via _slug(stem) (lowercase, non-word → hyphens)
+      - _SUBFOLDER_OVERRIDES remaps subfolders whose output path differs from
+        the simple strip-scan-root rule (e.g. world/regions/ → locations/regions/)
 
     Examples:
       world/locations/kucha.md          → /locations/kucha.html
+      world/regions/tarim-basin.md      → /locations/regions/tarim-basin.html
       world/ancestries/PEOPLES_OF_...md → /ancestries/peoples-of-....html
       narrative/lore/The Roads.md       → /lore/the-roads.html
     """
     subfolder = _output_subfolder(path)
+    subfolder = _SUBFOLDER_OVERRIDES.get(subfolder, subfolder)
     slug = _slug(path.stem)
     if subfolder:
         return f"/{subfolder}/{slug}.html"

--- a/utilities/shared/css/gm.css
+++ b/utilities/shared/css/gm.css
@@ -44,3 +44,29 @@
   font-family: 'Inconsolata', monospace; vertical-align: middle;
 }
 .inline-doc-item.public-doc { border-color: rgba(184,146,44,0.3); }
+
+/* --- GM Revealed Content (gm_revealed: [id] frontmatter — build-time promotion) --- */
+/* Block was GM-only; campaign progression has made it player-visible. */
+.revealed-content {
+  background: rgba(184,137,42,0.08);
+  border-left: 3px solid var(--gold);
+  border-radius: 0 4px 4px 0;
+  padding: 0.75rem 1rem;
+  margin: 1rem 0;
+  color: var(--fg);
+}
+.gm-callout--revealed {
+  position: relative;
+}
+.gm-callout--revealed::before {
+  content: "revealed";
+  position: absolute;
+  top: 0.4rem;
+  right: 0.6rem;
+  font-family: 'Inconsolata', monospace;
+  font-size: 9px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--gold);
+  opacity: 0.6;
+}

--- a/utilities/shared/css/world-location.css
+++ b/utilities/shared/css/world-location.css
@@ -1,0 +1,179 @@
+/* world-location.css — Location detail page styles */
+
+/* ---------------------------------------------------------------------------
+ * Page header
+ * ------------------------------------------------------------------------- */
+.page-header--location { padding: 2rem 1.5rem 1.25rem; }
+.page-header--location h1 { margin-bottom: 0.25rem; }
+.page-header--secret h1 { color: var(--crimson); }
+
+.location-header__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  font-family: 'Inconsolata', monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.location-header__type { color: var(--gold); }
+
+.location-header__fantasy-name {
+  font-family: 'EB Garamond', serif;
+  font-style: italic;
+  font-size: 1.1rem;
+  color: var(--muted);
+  margin-bottom: 0.5rem;
+}
+
+.secret-badge {
+  background: rgba(122,31,31,0.15);
+  color: var(--crimson);
+  border: 1px solid rgba(122,31,31,0.3);
+  padding: 2px 8px;
+  border-radius: 100px;
+  font-size: 9px;
+  letter-spacing: 0.2em;
+}
+
+/* ---------------------------------------------------------------------------
+ * Stats row & badges
+ * ------------------------------------------------------------------------- */
+.stats-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0.5rem 0;
+}
+
+.stat-badge {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 100px;
+  font-family: 'Inconsolata', monospace;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  background: rgba(184,137,42,0.12);
+  color: var(--gold);
+  border: 1px solid rgba(184,137,42,0.25);
+  white-space: nowrap;
+}
+
+.stat-badge--type { background: rgba(44,107,180,0.12); color: var(--steel); border-color: rgba(44,107,180,0.25); }
+.stat-badge--elevation { background: rgba(154,142,122,0.12); color: var(--muted); border-color: rgba(154,142,122,0.25); }
+.stat-badge--region a { color: inherit; text-decoration: none; }
+.stat-badge--region a:hover { text-decoration: underline; }
+
+/* ---------------------------------------------------------------------------
+ * Danger pips
+ * ------------------------------------------------------------------------- */
+.danger-pips {
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  margin-top: 0.25rem;
+}
+.pips-filled { color: var(--crimson); }
+.pips-empty  { color: var(--muted); opacity: 0.4; }
+
+/* ---------------------------------------------------------------------------
+ * Mini-map
+ * ------------------------------------------------------------------------- */
+.mini-map {
+  height: 300px;
+  width: 100%;
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  margin-bottom: 1.5rem;
+  background: var(--surface);
+}
+
+.mini-map--no-coords {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.location-map-panel { margin-bottom: 1.5rem; }
+
+/* ---------------------------------------------------------------------------
+ * Body layout
+ * ------------------------------------------------------------------------- */
+.location-body { max-width: 860px; }
+
+.location-description {
+  font-family: 'EB Garamond', serif;
+  font-size: 1.1rem;
+  font-style: italic;
+  color: var(--muted);
+  border-left: 3px solid var(--rule);
+  padding-left: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.location-prose { margin-bottom: 2rem; }
+
+/* ---------------------------------------------------------------------------
+ * Faction table
+ * ------------------------------------------------------------------------- */
+.faction-table { margin-bottom: 1.5rem; }
+.faction-table__heading {
+  font-family: 'Cinzel', serif;
+  font-size: 0.8rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--gold);
+  margin-bottom: 0.5rem;
+}
+.faction-table table { width: 100%; border-collapse: collapse; }
+.faction-table td {
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid var(--rule);
+  font-size: 0.95rem;
+}
+.faction-table tr:last-child td { border-bottom: none; }
+
+/* ---------------------------------------------------------------------------
+ * Resources
+ * ------------------------------------------------------------------------- */
+.location-resources { margin-bottom: 1.5rem; }
+.resources-heading {
+  font-family: 'Cinzel', serif;
+  font-size: 0.8rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--gold);
+  margin-bottom: 0.5rem;
+}
+.resources-list { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.resource-badge {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 100px;
+  font-size: 0.85rem;
+  background: var(--surface);
+  border: 1px solid var(--rule);
+  color: var(--fg);
+}
+
+/* ---------------------------------------------------------------------------
+ * Cross-reference stub
+ * ------------------------------------------------------------------------- */
+.xref-stub {
+  padding: 0.6rem 1rem;
+  background: var(--surface);
+  border: 1px dashed var(--rule);
+  border-radius: 4px;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  font-size: 0.85rem;
+  margin-top: 1.5rem;
+}
+.xref-stub__label { color: var(--muted); font-family: 'Inconsolata', monospace; letter-spacing: 0.1em; }
+.xref-stub__note  { color: var(--muted); font-style: italic; }

--- a/utilities/shared/css/world-map.css
+++ b/utilities/shared/css/world-map.css
@@ -1,0 +1,139 @@
+/* world-map.css — World home page & full Leaflet map styles */
+
+/* ---------------------------------------------------------------------------
+ * Page header
+ * ------------------------------------------------------------------------- */
+.page-header--world { padding: 2rem 1.5rem 1.25rem; text-align: center; }
+.world-header__subtitle {
+  font-family: 'EB Garamond', serif;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--muted);
+  max-width: 640px;
+  margin: 0.5rem auto 0;
+}
+
+/* ---------------------------------------------------------------------------
+ * Full world map
+ * ------------------------------------------------------------------------- */
+.world-map-panel {
+  width: 100%;
+  margin-bottom: 2rem;
+}
+
+#world-map {
+  height: 520px;
+  width: 100%;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  background: var(--surface);
+}
+
+/* Leaflet popup overrides */
+.leaflet-popup-content-wrapper {
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  box-shadow: 0 2px 12px var(--shadow);
+}
+.leaflet-popup-tip { background: var(--bg); }
+.leaflet-popup-content { margin: 0.6rem 0.8rem; font-family: 'EB Garamond', serif; font-size: 0.95rem; }
+.leaflet-popup-content strong { font-family: 'Cinzel', serif; font-size: 0.85rem; display: block; color: var(--gold); }
+.leaflet-popup-content a { color: var(--steel); }
+
+/* ---------------------------------------------------------------------------
+ * Region card grid
+ * ------------------------------------------------------------------------- */
+.world-regions-section h2,
+.world-all-locations h2 {
+  font-family: 'Cinzel', serif;
+  font-size: 0.85rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--gold);
+  margin-bottom: 1rem;
+}
+
+.region-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 2.5rem;
+}
+
+.region-card {
+  display: block;
+  padding: 0.9rem 1rem;
+  background: var(--surface);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  text-decoration: none;
+  color: var(--fg);
+  transition: border-color 0.15s, background 0.15s;
+}
+.region-card:hover {
+  border-color: var(--gold);
+  background: rgba(184,137,42,0.06);
+}
+.region-card--high  { border-left: 3px solid var(--crimson); }
+.region-card--medium { border-left: 3px solid var(--gold); }
+.region-card--low   { border-left: 3px solid var(--muted); }
+
+.region-card__title {
+  font-family: 'EB Garamond', serif;
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-bottom: 0.3rem;
+}
+.region-card__stats {
+  display: flex;
+  gap: 0.75rem;
+  font-size: 0.8rem;
+  color: var(--muted);
+  font-family: 'Inconsolata', monospace;
+}
+.region-card__ancestry { color: var(--steel); }
+
+/* ---------------------------------------------------------------------------
+ * All-locations A-Z grid
+ * ------------------------------------------------------------------------- */
+.location-az-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+  gap: 0.5rem;
+  margin-bottom: 2rem;
+}
+
+.location-az-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 0.4rem 0.6rem;
+  text-decoration: none;
+  color: var(--fg);
+  border: 1px solid transparent;
+  border-radius: 3px;
+  transition: border-color 0.1s, background 0.1s;
+}
+.location-az-item:hover {
+  border-color: var(--rule);
+  background: var(--surface);
+}
+.location-az-item__title {
+  font-family: 'EB Garamond', serif;
+  font-size: 1rem;
+}
+.location-az-item__type {
+  font-family: 'Inconsolata', monospace;
+  font-size: 9px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--muted);
+  white-space: nowrap;
+  margin-left: 0.5rem;
+}
+
+.location-az-item--city .location-az-item__title { font-weight: 600; }
+.location-az-item--dungeon .location-az-item__title { color: var(--crimson); }
+.location-az-item--sacred-site .location-az-item__title { color: var(--steel); }

--- a/utilities/shared/css/world-region.css
+++ b/utilities/shared/css/world-region.css
@@ -1,0 +1,97 @@
+/* world-region.css — Region index page styles */
+
+/* ---------------------------------------------------------------------------
+ * Page header
+ * ------------------------------------------------------------------------- */
+.page-header--region { padding: 2rem 1.5rem 1.25rem; }
+
+.region-header__meta {
+  margin-bottom: 0.4rem;
+  font-family: 'Inconsolata', monospace;
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.region-header__eyebrow { color: var(--gold); }
+
+.region-header__stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.5rem;
+}
+
+/* Reuse stat-badge from world-location.css — include that file too when using this page */
+.stat-badge--faction-weight.stat-badge--high   { background: rgba(122,31,31,0.12); color: var(--crimson); border-color: rgba(122,31,31,0.25); }
+.stat-badge--faction-weight.stat-badge--medium { background: rgba(184,137,42,0.12); color: var(--gold); border-color: rgba(184,137,42,0.25); }
+.stat-badge--faction-weight.stat-badge--low    { background: rgba(154,142,122,0.12); color: var(--muted); border-color: rgba(154,142,122,0.25); }
+.stat-badge--ancestry { background: rgba(44,107,180,0.12); color: var(--steel); border-color: rgba(44,107,180,0.25); }
+
+/* ---------------------------------------------------------------------------
+ * Body layout
+ * ------------------------------------------------------------------------- */
+.region-body { max-width: 960px; }
+.region-map-panel { margin-bottom: 1.5rem; }
+.region-prose { margin-bottom: 2rem; }
+
+/* ---------------------------------------------------------------------------
+ * Location card grid
+ * ------------------------------------------------------------------------- */
+.region-locations h2 {
+  font-family: 'Cinzel', serif;
+  font-size: 0.85rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--gold);
+  margin-bottom: 1rem;
+}
+
+.location-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 0.75rem;
+}
+
+.location-card {
+  display: block;
+  padding: 0.9rem 1rem;
+  background: var(--surface);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  text-decoration: none;
+  color: var(--fg);
+  transition: border-color 0.15s, background 0.15s;
+}
+.location-card:hover {
+  border-color: var(--gold);
+  background: rgba(184,137,42,0.06);
+}
+
+.location-card__type {
+  font-family: 'Inconsolata', monospace;
+  font-size: 9px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 0.25rem;
+}
+.location-card--city .location-card__type { color: var(--gold); }
+.location-card--sacred-site .location-card__type { color: var(--steel); }
+.location-card--dungeon .location-card__type { color: var(--crimson); }
+
+.location-card__title {
+  font-family: 'EB Garamond', serif;
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+.location-card__desc {
+  font-size: 0.85rem;
+  color: var(--muted);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}

--- a/utilities/shared/html_render.py
+++ b/utilities/shared/html_render.py
@@ -189,6 +189,7 @@ def render_body(
     vault: 'Path',
     docs: 'Path',
     gm_mode: bool = False,
+    revealed_ids: 'set[str] | None' = None,
 ) -> 'tuple[str, list[dict]]':
     """Render a full Markdown body to HTML with component support.
 
@@ -247,17 +248,26 @@ def render_body(
         feature_buffer = []
 
     for para in paragraphs:
-        # Tier 2: GM-only callout block > [!gm-only]
+        # Tier 2: GM-only callout block > [!gm-only] or > [!gm-only id=some-id]
         # The preprocessing regex (^>\s*\[!\w+\]\s*$) leaves [!gm-only] intact because
         # \w+ does not match across hyphens, so the marker survives to here.
-        if re.match(r'^>\s*\[!gm-only\]', para):
+        # Optional id= attribute enables build-time promotion via gm_revealed frontmatter.
+        gm_marker = re.match(r'^>\s*\[!gm-only(?:\s+id=([^\]\s]+))?\]', para)
+        if gm_marker:
             _flush_features()
+            block_id = gm_marker.group(1)  # None if no id= attribute
             lines = para.splitlines()
             inner_lines = [re.sub(r'^>\s?', '', ln) for ln in lines[1:]]
             inner = '\n'.join(inner_lines).strip()
-            if gm_mode:
-                html_parts.append(f'<div class="gm-callout">{inline_md(inner)}</div>\n')
-            # public: strip entirely — GM content never reaches the DOM
+            # Revealed block: promoted to player-visible `.revealed-content` regardless of gm_mode
+            if block_id and revealed_ids is not None and block_id in revealed_ids:
+                html_parts.append(
+                    f'<div class="revealed-content gm-callout--revealed">{inline_md(inner)}</div>\n'
+                )
+            elif gm_mode:
+                css_cls = f'gm-callout gm-callout--id-{block_id}' if block_id else 'gm-callout'
+                html_parts.append(f'<div class="{css_cls}">{inline_md(inner)}</div>\n')
+            # public + unrevealed: strip entirely — GM content never reaches the DOM
             continue
 
         # Wiki-embed: ![[file|caption|width]] → figure, audio, or GM prose block

--- a/utilities/templates/base.html
+++ b/utilities/templates/base.html
@@ -35,6 +35,7 @@
   <div class="site-nav-links">
     <a href="/campaign-frame.html">Campaign Frame</a>
     <a href="/peoples-of-tarim-shaiel.html">Peoples</a>
+    <a href="/world.html">World</a>
     <a href="/search.html" title="Search">&#x2315; Search</a>
   </div>
   <button class="site-nav-mobile-toggle" onclick="(function(){var d=document.getElementById('site-nav-drawer');d.classList.toggle('open');})()" title="Menu">&#9776;</button>
@@ -43,6 +44,7 @@
   <a href="/index.html">Home</a>
   <a href="/campaign-frame.html">Campaign Frame</a>
   <a href="/peoples-of-tarim-shaiel.html">Peoples</a>
+  <a href="/world.html">World</a>
   <a href="/search.html">&#x2315; Search</a>
 </div>
 {% endblock %}

--- a/utilities/templates/pages/location-detail.html
+++ b/utilities/templates/pages/location-detail.html
@@ -1,0 +1,74 @@
+{% extends "base.html" %}
+
+{% block extra_head %}
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV/XN/WLcE=" crossorigin=""></script>
+{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="/assets/css/world-location.css">
+{% endblock %}
+
+{% block page_gm_banner %}
+{% if gm_page_banner_html %}{{ gm_page_banner_html | safe }}{% endif %}
+{% endblock %}
+
+{% block page_header %}
+<div class="page-header page-header--location{% if visibility == 'secret' %} page-header--secret{% endif %}">
+  <div class="location-header__meta">
+    {% if visibility == 'secret' %}<span class="secret-badge">Secret</span>{% endif %}
+    <span class="location-header__type">{{ location_type_label }}</span>
+  </div>
+  <h1>{{ title }}</h1>
+  {% if fantasy_name and fantasy_name != title %}<div class="location-header__fantasy-name">{{ fantasy_name }}</div>{% endif %}
+  {% if stats_row_html %}{{ stats_row_html | safe }}{% endif %}
+  {% if danger_pips_html %}{{ danger_pips_html | safe }}{% endif %}
+</div>
+{% endblock %}
+
+{% block site_nav_active %}locations{% endblock %}
+
+{% block content %}
+<div class="location-body">
+
+  {% if mini_map_html %}
+  <div class="location-map-panel">
+    {{ mini_map_html | safe }}
+  </div>
+  {% endif %}
+
+  {% if description %}
+  <p class="location-description">{{ description }}</p>
+  {% endif %}
+
+  <div class="location-prose">
+    {{ content_html | safe }}
+  </div>
+
+  {% if faction_table_html %}
+  <div class="location-factions">
+    {{ faction_table_html | safe }}
+  </div>
+  {% endif %}
+
+  {% if resources_html %}
+  <div class="location-resources">
+    <h3 class="resources-heading">Resources</h3>
+    {{ resources_html | safe }}
+  </div>
+  {% endif %}
+
+  {% if xref_html %}
+  <div class="location-xrefs">
+    {{ xref_html | safe }}
+  </div>
+  {% endif %}
+
+</div>
+{% endblock %}
+
+{% block credits %}
+    <a href="/world.html">World Map</a> &middot;
+    {% if region_title %}<a href="/locations/regions/{{ region_slug }}.html">{{ region_title }}</a> &middot; {% endif %}
+    Tarim-Shaiel &middot; Daggerheart Campaign &middot; 2026
+{% endblock %}

--- a/utilities/templates/pages/region-index.html
+++ b/utilities/templates/pages/region-index.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+
+{% block extra_head %}
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV/XN/WLcE=" crossorigin=""></script>
+{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="/assets/css/world-region.css">
+{% endblock %}
+
+{% block page_gm_banner %}
+{% if gm_page_banner_html %}{{ gm_page_banner_html | safe }}{% endif %}
+{% endblock %}
+
+{% block page_header %}
+<div class="page-header page-header--region">
+  <div class="region-header__meta">
+    <span class="region-header__eyebrow">Region</span>
+  </div>
+  <h1>{{ title }}</h1>
+  <div class="region-header__stats">
+    <span class="stat-badge">{{ location_count }} location{% if location_count != 1 %}s{% endif %}</span>
+    <span class="stat-badge stat-badge--ancestry">{{ primary_ancestry | title }}</span>
+    <span class="stat-badge stat-badge--faction-weight stat-badge--{{ faction_weight }}">{{ faction_weight | title }} activity</span>
+  </div>
+</div>
+{% endblock %}
+
+{% block site_nav_active %}locations{% endblock %}
+
+{% block content %}
+<div class="region-body">
+
+  {% if region_map_html %}
+  <div class="region-map-panel">
+    {{ region_map_html | safe }}
+  </div>
+  {% endif %}
+
+  <div class="region-prose">
+    {{ content_html | safe }}
+  </div>
+
+  {% if locations %}
+  <section class="region-locations">
+    <h2>Locations</h2>
+    <div class="location-card-grid">
+    {% for loc in locations %}
+      <a class="location-card location-card--{{ loc.location_type }}" href="/locations/{{ loc.slug }}.html">
+        <div class="location-card__type">{{ loc.location_type_label }}</div>
+        <div class="location-card__title">{{ loc.title }}</div>
+        {% if loc.description %}<div class="location-card__desc">{{ loc.description }}</div>{% endif %}
+        {{ loc.danger_pips_html | safe }}
+      </a>
+    {% endfor %}
+    </div>
+  </section>
+  {% endif %}
+
+</div>
+{% endblock %}
+
+{% block credits %}
+    <a href="/world.html">World Map</a> &middot;
+    Tarim-Shaiel &middot; Daggerheart Campaign &middot; 2026
+{% endblock %}

--- a/utilities/templates/pages/world-home.html
+++ b/utilities/templates/pages/world-home.html
@@ -1,0 +1,68 @@
+{% extends "base.html" %}
+
+{% block extra_head %}
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV/XN/WLcE=" crossorigin=""></script>
+{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="/assets/css/world-map.css">
+{% endblock %}
+
+{% block page_gm_banner %}
+{% if gm_page_banner_html %}{{ gm_page_banner_html | safe }}{% endif %}
+{% endblock %}
+
+{% block page_header %}
+<div class="page-header page-header--world">
+  <div class="page-header-eyebrow">World Map</div>
+  <h1>Tarim-Shaiel</h1>
+  <p class="world-header__subtitle">The Silk Road, ~1450s CE — a post-imperial crossroads of peoples, faiths, and trade.</p>
+</div>
+{% endblock %}
+
+{% block site_nav_active %}world{% endblock %}
+
+{% block content %}
+<div class="world-home-body">
+
+  <!-- Full interactive map -->
+  <div class="world-map-panel" id="world-map-container">
+    {{ world_map_html | safe }}
+  </div>
+
+  <!-- Region index -->
+  <section class="world-regions-section">
+    <h2>Regions</h2>
+    <div class="region-card-grid">
+    {% for region in regions %}
+      <a class="region-card region-card--{{ region.faction_weight }}" href="/locations/regions/{{ region.slug }}.html">
+        <div class="region-card__title">{{ region.title }}</div>
+        <div class="region-card__stats">
+          <span>{{ region.location_count }} location{% if region.location_count != 1 %}s{% endif %}</span>
+          <span class="region-card__ancestry">{{ region.primary_ancestry | title }}</span>
+        </div>
+      </a>
+    {% endfor %}
+    </div>
+  </section>
+
+  <!-- All locations A–Z -->
+  <section class="world-all-locations">
+    <h2>All Locations</h2>
+    <div class="location-az-grid">
+    {% for loc in all_locations %}
+      <a class="location-az-item location-az-item--{{ loc.location_type }}" href="/locations/{{ loc.slug }}.html">
+        <span class="location-az-item__title">{{ loc.title }}</span>
+        <span class="location-az-item__type">{{ loc.location_type_label }}</span>
+      </a>
+    {% endfor %}
+    </div>
+  </section>
+
+</div>
+{% endblock %}
+
+{% block credits %}
+    Tarim-Shaiel &middot; Daggerheart Campaign &middot; 2026
+{% endblock %}

--- a/utilities/world/normalize_locations.py
+++ b/utilities/world/normalize_locations.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+Location Frontmatter Normalizer
+================================
+One-time migration script: ensures all world/locations/*.md files have
+consistent frontmatter fields required by the locations HTML generator.
+
+Changes applied per file:
+  - Adds `parent_region` (inferred from location coordinates or defaulted to null)
+  - Adds `visibility: public` if missing
+  - Adds `status: draft` if missing
+  - Renames `factions:` → `factions_visible:` (if `factions_visible:` not already present)
+
+Usage:
+    python utilities/world/normalize_locations.py --dry-run
+    python utilities/world/normalize_locations.py
+    python utilities/world/normalize_locations.py --vault /path/to/vault
+"""
+
+import re
+import sys
+import argparse
+from pathlib import Path
+
+HERE = Path(__file__).parent
+VAULT_ROOT = HERE.parent.parent
+LOCATIONS_DIR = VAULT_ROOT / "world" / "locations"
+
+try:
+    import yaml
+    _YAML_AVAILABLE = True
+except ImportError:
+    _YAML_AVAILABLE = False
+
+# ---------------------------------------------------------------------------
+# Region inference — rough bounding-box assignment
+# Coordinate pairs are (lat, lon); bounds are [lat_min, lon_min, lat_max, lon_max]
+# ---------------------------------------------------------------------------
+
+_REGION_BOUNDS = [
+    # (region_slug, lat_min, lon_min, lat_max, lon_max)
+    # Order matters: first match wins, so more-specific boxes come first.
+    ("eastern-terminus",   33.0, 104.0, 36.5, 112.0),
+    ("eastern-gateway",    39.0,  93.0, 43.5, 103.5),
+    ("tarim-basin",        36.0,  73.0, 43.5,  95.0),  # extended to 43.5 to include Turfan (42.95)
+    ("mountain-passes",    36.0,  70.0, 43.0,  80.0),
+    ("central-asian-hubs", 36.0,  56.0, 43.0,  73.0),  # extended to lat 36.0 to include Balkh (36.76)
+    ("transoxiana",        37.5,  58.0, 43.0,  68.0),
+    ("steppe-confederations", 43.0, 60.0, 55.0, 95.0),
+]
+
+
+def _infer_region(lat: float, lon: float) -> str | None:
+    """Return the region slug for the given coordinates, or None."""
+    for slug, lat_min, lon_min, lat_max, lon_max in _REGION_BOUNDS:
+        if lat_min <= lat <= lat_max and lon_min <= lon <= lon_max:
+            return slug
+    return None
+
+
+def _parse_frontmatter_raw(text: str) -> tuple[str, str, str]:
+    """Return (before_fm, fm_text, after_fm) — raw string split.
+
+    before_fm includes the opening '---\\n' delimiter.
+    after_fm includes the closing '---\\n' delimiter followed by the body.
+    Returns ('', '', text) if no frontmatter block found.
+    """
+    m = re.match(r'^(---\n)(.*?\n)(---\n)', text, re.DOTALL)
+    if not m:
+        return '', '', text
+    # Include closing delimiter in after_fm so the caller's reassembly is:
+    #   before_fm + new_fm + after_fm  →  '---\n' + fields + '---\n' + body
+    return m.group(1), m.group(2), m.group(3) + text[m.end():]
+
+
+def _normalize_fm(fm_text: str, source_path: Path, dry_run: bool) -> tuple[str, list[str]]:
+    """Apply normalization rules to the raw YAML frontmatter text.
+
+    Returns (updated_fm_text, list_of_changes).
+    """
+    changes: list[str] = []
+
+    # Load the YAML to inspect values
+    if _YAML_AVAILABLE:
+        try:
+            fm = yaml.safe_load(fm_text) or {}
+        except Exception as e:
+            return fm_text, [f"  SKIP — YAML parse error: {e}"]
+    else:
+        # Regex fallback: limited but functional for simple cases
+        fm = {}
+        for line in fm_text.splitlines():
+            kv = line.split(':', 1)
+            if len(kv) == 2 and not line.startswith(' '):
+                k, v = kv[0].strip(), kv[1].strip()
+                fm[k] = v.strip('"\'')
+
+    lines = fm_text.splitlines()
+    new_lines = list(lines)
+    inserted_after: dict[int, list[str]] = {}
+
+    # --- Rule 1: factions → factions_visible ---
+    has_factions = 'factions' in fm
+    has_factions_visible = 'factions_visible' in fm
+    if has_factions and not has_factions_visible:
+        for i, line in enumerate(new_lines):
+            if re.match(r'^factions\s*:', line):
+                new_lines[i] = 'factions_visible' + line[len('factions'):]
+                # Also rename any continuation lines (YAML block list)
+                j = i + 1
+                while j < len(new_lines) and new_lines[j].startswith('-'):
+                    j += 1
+                changes.append("  renamed factions → factions_visible")
+                break
+
+    # --- Rule 2: visibility ---
+    if 'visibility' not in fm:
+        # Insert after title if present, else at end
+        insert_pos = len(new_lines)
+        for i, line in enumerate(new_lines):
+            if re.match(r'^title\s*:', line):
+                insert_pos = i + 1
+                break
+        inserted_after.setdefault(insert_pos, []).append('visibility: public')
+        changes.append("  added visibility: public")
+
+    # --- Rule 3: status ---
+    if 'status' not in fm:
+        insert_pos = len(new_lines)
+        for i, line in enumerate(new_lines):
+            if re.match(r'^(visibility|title)\s*:', line):
+                insert_pos = i + 1
+                break
+        inserted_after.setdefault(insert_pos, []).append('status: draft')
+        changes.append("  added status: draft")
+
+    # --- Rule 4: parent_region ---
+    if 'parent_region' not in fm:
+        lat = lon = None
+        loc = fm.get('location')
+        if isinstance(loc, list) and len(loc) >= 2:
+            try:
+                lat, lon = float(loc[0]), float(loc[1])
+            except (TypeError, ValueError):
+                pass
+        region = _infer_region(lat, lon) if lat is not None else None
+        region_val = region if region else 'null'
+        insert_pos = len(new_lines)
+        for i, line in enumerate(new_lines):
+            if re.match(r'^(domain|project)\s*:', line):
+                insert_pos = i + 1
+                break
+        inserted_after.setdefault(insert_pos, []).append(f'parent_region: {region_val}')
+        changes.append(f"  added parent_region: {region_val}")
+
+    if not changes:
+        return fm_text, []
+
+    # Rebuild lines with insertions
+    result: list[str] = []
+    for i, line in enumerate(new_lines):
+        result.append(line)
+        if i + 1 in inserted_after:
+            result.extend(inserted_after[i + 1])
+
+    # Handle insertions at position 0 (before first line)
+    if 0 in inserted_after:
+        result = inserted_after[0] + result
+
+    return '\n'.join(result) + '\n', changes
+
+
+def normalize_file(path: Path, dry_run: bool) -> bool:
+    """Normalize a single location file. Returns True if changes were made."""
+    text = path.read_text(encoding='utf-8')
+    before, fm_text, after = _parse_frontmatter_raw(text)
+    if not fm_text:
+        print(f"  {path.name}: no frontmatter — SKIPPED")
+        return False
+
+    new_fm, changes = _normalize_fm(fm_text, path, dry_run)
+    if not changes:
+        return False
+
+    print(f"  {path.name}:")
+    for c in changes:
+        print(c)
+
+    if not dry_run:
+        new_text = before + new_fm + after
+        path.write_text(new_text, encoding='utf-8')
+
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Normalize world/locations/*.md frontmatter for the HTML generator."
+    )
+    parser.add_argument(
+        '--dry-run', action='store_true',
+        help="Show changes without writing files"
+    )
+    parser.add_argument(
+        '--vault', default=None,
+        help="Vault root path (default: auto-detected from script location)"
+    )
+    args = parser.parse_args()
+
+    vault = Path(args.vault) if args.vault else VAULT_ROOT
+    locations_dir = vault / "world" / "locations"
+
+    if not locations_dir.is_dir():
+        print(f"ERROR: locations directory not found: {locations_dir}", file=sys.stderr)
+        return 1
+
+    files = sorted(locations_dir.glob("*.md"))
+    if not files:
+        print("No .md files found in world/locations/")
+        return 0
+
+    mode = "DRY RUN" if args.dry_run else "WRITING"
+    print(f"\nLocation normalizer — {mode}")
+    print(f"Processing {len(files)} files in {locations_dir}\n")
+
+    changed = 0
+    for f in files:
+        if normalize_file(f, args.dry_run):
+            changed += 1
+
+    verb = "would change" if args.dry_run else "changed"
+    print(f"\nDone — {verb} {changed} of {len(files)} files.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/world/locations/aksu.md
+++ b/world/locations/aksu.md
@@ -1,6 +1,7 @@
 ---
 title: Aksu
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: location
@@ -10,7 +11,7 @@ created: 2025-12-13
 description: A waypoint on the northern route. An oasis providing critical supplies
   for westbound merchants.
 elevation: 1141
-factions:
+factions_visible:
 - Merchants & Caravanners
 fantasy_name: Aksu
 historical_basis: Tarim Basin - Oasis waypoint on northern corridor

--- a/world/locations/alak-mor.md
+++ b/world/locations/alak-mor.md
@@ -1,6 +1,7 @@
 ---
 title: Alak-Mor
 project: TTRPG_Tarim_Shaiel
+parent_region: steppe-confederations
 domain: world
 doc_type: canon
 content_type: landmark

--- a/world/locations/anvil-sunder-switchbacks.md
+++ b/world/locations/anvil-sunder-switchbacks.md
@@ -1,6 +1,7 @@
 ---
 title: The Anvil-Sunder Switchbacks
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: poi

--- a/world/locations/balkh-kamen.md
+++ b/world/locations/balkh-kamen.md
@@ -1,6 +1,7 @@
 ---
 title: Balkh-Kamen
 project: TTRPG_Tarim_Shaiel
+parent_region: steppe-confederations
 domain: world
 doc_type: canon
 content_type: landmark

--- a/world/locations/balkh.md
+++ b/world/locations/balkh.md
@@ -1,6 +1,7 @@
 ---
 title: Balkh
 project: TTRPG_Tarim_Shaiel
+parent_region: central-asian-hubs
 domain: world
 doc_type: canon
 content_type: location
@@ -12,7 +13,7 @@ cultural_notes: Major oasis hub before destruction; one of the 'great cities' of
 description: Once the 'Mother of Cities,' Balkh was destroyed by Genghis Khan and
   never fully recovered. Now a haunting reminder of past glory.
 elevation: 366
-factions:
+factions_visible:
 - Afghan Remnant Authority
 fantasy_name: Balkh
 historical_basis: Bactria - Destroyed by Genghis Khan (1220s); never rebuilt to former

--- a/world/locations/black-timber-post.md
+++ b/world/locations/black-timber-post.md
@@ -1,6 +1,7 @@
 ---
 title: Black-Timber Post
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: poi

--- a/world/locations/bukhara.md
+++ b/world/locations/bukhara.md
@@ -1,6 +1,7 @@
 ---
 title: Bukhara
 project: TTRPG_Tarim_Shaiel
+parent_region: central-asian-hubs
 domain: world
 doc_type: canon
 content_type: location
@@ -11,7 +12,7 @@ cultural_notes: Fifth-largest city historically; center of trade and religion
 description: Center of Islamic scholarship and trade. A major city of Sogdiana with
   140+ architectural monuments.
 elevation: 219
-factions:
+factions_visible:
 - Islamic Scholarly Network
 fantasy_name: Bukhara
 historical_basis: Sogdania - Zoroastrian→Islamic; survived Mongol destruction and

--- a/world/locations/buried-lens.md
+++ b/world/locations/buried-lens.md
@@ -1,6 +1,7 @@
 ---
 title: The Buried Lens
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: landmark

--- a/world/locations/caravan-crypt.md
+++ b/world/locations/caravan-crypt.md
@@ -1,6 +1,7 @@
 ---
 title: The Caravan-Crypt
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: poi

--- a/world/locations/chang-an.md
+++ b/world/locations/chang-an.md
@@ -1,6 +1,7 @@
 ---
 title: Chang'an
 project: TTRPG_Tarim_Shaiel
+parent_region: eastern-terminus
 domain: world
 doc_type: canon
 content_type: location
@@ -12,7 +13,7 @@ cultural_notes: Massive fortified city; destination of all Silk Road merchants; 
 description: The eastern terminus of the Silk Road. An imperial capital with 12-mile
   walls built in 1370. Where merchants complete their epic journeys.
 elevation: 402
-factions:
+factions_visible:
 - Imperial Government
 - Merchant Guilds
 - Buddhist Communities

--- a/world/locations/charklik.md
+++ b/world/locations/charklik.md
@@ -1,6 +1,7 @@
 ---
 title: Charklik
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: poi
@@ -9,7 +10,7 @@ status: draft
 created: 2025-12-13
 description: A waypoint on the southern route between desert sections.
 elevation: 800
-factions:
+factions_visible:
 - Oasis Keepers
 fantasy_name: Charklik
 historical_basis: Tarim Basin - Oasis waypoint

--- a/world/locations/cherchen.md
+++ b/world/locations/cherchen.md
@@ -1,6 +1,7 @@
 ---
 title: Cherchen
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: poi
@@ -10,7 +11,7 @@ created: 2025-12-13
 description: A waypoint on the southern route between eastern and western Taklamakan
   sections.
 elevation: 900
-factions:
+factions_visible:
 - Oasis Settlers
 fantasy_name: Cherchen
 historical_basis: Tarim Basin - Oasis waypoint on southern corridor

--- a/world/locations/dun-kharan.md
+++ b/world/locations/dun-kharan.md
@@ -1,6 +1,7 @@
 ---
 title: Dun-Kharan
 project: TTRPG_Tarim_Shaiel
+parent_region: null
 domain: world
 doc_type: canon
 content_type: poi

--- a/world/locations/dunhuang.md
+++ b/world/locations/dunhuang.md
@@ -1,6 +1,7 @@
 ---
 title: Dunhuang
 project: TTRPG_Tarim_Shaiel
+parent_region: eastern-gateway
 domain: world
 doc_type: canon
 content_type: location
@@ -10,7 +11,7 @@ created: 2025-12-13
 description: Gateway to China; home to the Mogao Caves with thousands of Buddhist
   artworks spanning centuries.
 elevation: 1140
-factions:
+factions_visible:
 - Buddhist Monastic Order
 fantasy_name: Dunhuang
 last_updated: 2025-12-13

--- a/world/locations/endere.md
+++ b/world/locations/endere.md
@@ -1,6 +1,7 @@
 ---
 title: Endere
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: poi
@@ -9,7 +10,7 @@ status: draft
 created: 2025-12-13
 description: An isolated waypoint on the southern route through harsh desert.
 elevation: 1000
-factions:
+factions_visible:
 - Desert Survivors
 fantasy_name: Endere
 historical_basis: Tarim Basin - Remote southern route waypoint

--- a/world/locations/isyk-zhel.md
+++ b/world/locations/isyk-zhel.md
@@ -1,6 +1,7 @@
 ---
 title: Isyk-Zhel
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: landmark

--- a/world/locations/jade-gate.md
+++ b/world/locations/jade-gate.md
@@ -1,6 +1,7 @@
 ---
 title: Jade Gate
 project: TTRPG_Tarim_Shaiel
+parent_region: eastern-gateway
 domain: world
 doc_type: canon
 content_type: location
@@ -9,7 +10,7 @@ created: 2025-12-13
 description: The western gateway to imperial China. A heavily fortified checkpoint
   where all merchants are inspected and taxed.
 elevation: 1400
-factions:
+factions_visible:
 - Imperial Guard Post
 fantasy_name: Jade Gate
 historical_basis: Gansu Corridor - Western border of imperial Chinese territory

--- a/world/locations/kashkar.md
+++ b/world/locations/kashkar.md
@@ -1,6 +1,7 @@
 ---
 title: Kashgar
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: location
@@ -9,7 +10,7 @@ status: draft
 created: 2025-12-13
 description: Westernmost major Chinese city; crossroads of cultures and trade.
 elevation: 1289
-factions:
+factions_visible:
 - Tarim Basin Traders
 fantasy_name: Kashgar
 last_updated: 2025-12-13
@@ -29,7 +30,6 @@ tags:
 - type-city
 - test
 type: city
----
 
 ```leaflet
 id: location-kashgar

--- a/world/locations/khotan.md
+++ b/world/locations/khotan.md
@@ -1,6 +1,7 @@
 ---
 title: Khotan
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: location
@@ -11,7 +12,7 @@ cultural_notes: Jade production center; world-renowned for craftsmanship
 description: The jade capital of the Silk Road. A mountain kingdom that converted
   from Buddhism to Islam, but jade remains its lifeblood.
 elevation: 1300
-factions:
+factions_visible:
 - Jade Merchants Guild
 - Buddhist Monastic Order
 fantasy_name: Khotan

--- a/world/locations/kucha.md
+++ b/world/locations/kucha.md
@@ -1,6 +1,7 @@
 ---
 title: Kucha
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: landmark
@@ -11,7 +12,7 @@ cultural_notes: Kizil Caves nearby contain thousands of Buddhist artworks and sc
 description: A major Buddhist center with magnificent Kizil Caves nearby. A place
   of pilgrimage and monastic study.
 elevation: 1140
-factions:
+factions_visible:
 - Buddhist Monastic Community
 fantasy_name: Kucha
 historical_basis: Tarim Basin - Buddhist state; major monasteries and artistic center

--- a/world/locations/maralbashi.md
+++ b/world/locations/maralbashi.md
@@ -1,6 +1,7 @@
 ---
 title: Maralbashi
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: poi
@@ -10,7 +11,7 @@ created: 2025-12-13
 description: A waypoint at the base of mountain passes. Guides here help merchants
   navigate the treacherous western mountain crossing.
 elevation: 1000
-factions:
+factions_visible:
 - Mountain Guides
 fantasy_name: Maralbashi
 historical_basis: Tarim Basin - Mountain gateway on northern route

--- a/world/locations/merv.md
+++ b/world/locations/merv.md
@@ -1,6 +1,7 @@
 ---
 title: Merv (Mary)
 project: TTRPG_Tarim_Shaiel
+parent_region: central-asian-hubs
 domain: world
 doc_type: canon
 content_type: location
@@ -11,7 +12,7 @@ cultural_notes: '''Ruined Silk Road city'' - archaeological significance'
 description: Once a great oasis city, destroyed by Genghis Khan's son. Now rebuilt
   as Mary, a smaller settlement.
 elevation: 218
-factions:
+factions_visible:
 - Turkmen Locals
 fantasy_name: Merv (Mary)
 historical_basis: Margiana - Destroyed by Mongol invasion; rebuilt as smaller settlement

--- a/world/locations/miran-temple-district.md
+++ b/world/locations/miran-temple-district.md
@@ -1,6 +1,7 @@
 ---
 title: Miran Temple District
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: poi

--- a/world/locations/miran.md
+++ b/world/locations/miran.md
@@ -1,6 +1,7 @@
 ---
 title: Miran
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: poi
@@ -10,7 +11,7 @@ created: 2025-12-13
 description: A waypoint on the southern desert route. An ancient settlement with ruins
   of Buddhist temples.
 elevation: 890
-factions:
+factions_visible:
 - Oasis Guardians
 fantasy_name: Miran
 historical_basis: Tarim Basin - Ancient oasis settlement on southern route

--- a/world/locations/niya-outer-fields.md
+++ b/world/locations/niya-outer-fields.md
@@ -1,6 +1,7 @@
 ---
 title: Niya Outer Fields
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: poi

--- a/world/locations/niya.md
+++ b/world/locations/niya.md
@@ -1,6 +1,7 @@
 ---
 title: Niya
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: poi
@@ -10,7 +11,7 @@ created: 2025-12-13
 description: Ancient oasis ruins on the southern route. Archaeological treasures hidden
   in the sands await discovery.
 elevation: 1200
-factions:
+factions_visible:
 - Desert Guardians
 fantasy_name: Niya
 historical_basis: Tarim Basin - Ancient oasis settlement with archaeological significance

--- a/world/locations/salt-reed-oasis.md
+++ b/world/locations/salt-reed-oasis.md
@@ -1,6 +1,7 @@
 ---
 title: Salt-Reed Oasis
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: location

--- a/world/locations/samarkand.md
+++ b/world/locations/samarkand.md
@@ -1,6 +1,7 @@
 ---
 title: Samarqandh
 project: TTRPG_Tarim_Shaiel
+parent_region: central-asian-hubs
 domain: world
 doc_type: canon
 content_type: location
@@ -9,7 +10,7 @@ status: draft
 created: 2025-12-13
 description: A major hub on the Silk Road, known for its bazaars and monumental architecture.
 elevation: 700
-factions:
+factions_visible:
 - Sogdian Merchants Guild
 fantasy_name: Samarqandh
 last_updated: 2025-12-13

--- a/world/locations/shorchuk.md
+++ b/world/locations/shorchuk.md
@@ -1,6 +1,7 @@
 ---
 title: Shorchuk
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: poi
@@ -10,7 +11,7 @@ created: 2025-12-13
 description: A waypoint on the northern route where merchants rest before mountain
   passages.
 elevation: 1050
-factions:
+factions_visible:
 - Route Keepers
 fantasy_name: Shorchuk
 historical_basis: Tarim Basin - Northern route waypoint
@@ -27,7 +28,6 @@ tags:
 - campaign-arc-northern-route
 - type-route-node
 type: route-node
----
 
 ```leaflet
 id: location-shorchuk

--- a/world/locations/stone-ledger-gate.md
+++ b/world/locations/stone-ledger-gate.md
@@ -1,6 +1,7 @@
 ---
 title: The Stone Ledger Gate
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: poi

--- a/world/locations/tarim-shaiel.md
+++ b/world/locations/tarim-shaiel.md
@@ -1,6 +1,7 @@
 ---
 title: Tarim-Shaiel
 project: TTRPG_Tarim_Shaiel
+parent_region: null
 domain: world
 doc_type: canon
 content_type: landmark

--- a/world/locations/tashkent.md
+++ b/world/locations/tashkent.md
@@ -1,6 +1,7 @@
 ---
 title: Tashkent
 project: TTRPG_Tarim_Shaiel
+parent_region: central-asian-hubs
 domain: world
 doc_type: canon
 content_type: location
@@ -10,7 +11,7 @@ created: 2025-12-13
 cultural_notes: Largest city in Central Asia; major agricultural and trade center
 description: The largest city in Central Asia. Known as the 'Stone City' for its fortifications.
 elevation: 440
-factions:
+factions_visible:
 - Central Asian Trade Union
 fantasy_name: Tashkent
 historical_basis: Fergana Valley - Turkic origin; Islamic conversion; Mongol conquest

--- a/world/locations/turfan.md
+++ b/world/locations/turfan.md
@@ -1,6 +1,7 @@
 ---
 title: Turfan Depression
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: poi
@@ -10,7 +11,7 @@ created: 2025-12-13
 description: An oasis in a depression, protected from harsh desert winds. Known for
   cultivation of grapes and wine production.
 elevation: -154
-factions:
+factions_visible:
 - Oasis Settlers
 fantasy_name: Turfan Depression
 historical_basis: Tarim Basin - Oasis settlement in depression; known for agriculture

--- a/world/locations/wind-cut-narrows.md
+++ b/world/locations/wind-cut-narrows.md
@@ -1,6 +1,7 @@
 ---
 title: The Wind-Cut Narrows
 project: TTRPG_Tarim_Shaiel
+parent_region: eastern-gateway
 domain: world
 doc_type: canon
 content_type: poi

--- a/world/locations/yarkand.md
+++ b/world/locations/yarkand.md
@@ -1,6 +1,7 @@
 ---
 title: Yarkand
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: poi
@@ -10,7 +11,7 @@ created: 2025-12-13
 description: A major waypoint where the southern and northern routes converge. A hub
   of trade and communication.
 elevation: 1200
-factions:
+factions_visible:
 - Southern Route Merchants
 fantasy_name: Yarkand
 historical_basis: Tarim Basin - Convergence point of major trade routes

--- a/world/locations/yumen-waystation.md
+++ b/world/locations/yumen-waystation.md
@@ -1,6 +1,7 @@
 ---
 title: Yumen Waystation (Outer)
 project: TTRPG_Tarim_Shaiel
+parent_region: eastern-gateway
 domain: world
 doc_type: canon
 content_type: poi

--- a/world/locations/zzkashkar.md
+++ b/world/locations/zzkashkar.md
@@ -1,6 +1,7 @@
 ---
 title: Kashkar
 project: TTRPG_Tarim_Shaiel
+parent_region: tarim-basin
 domain: world
 doc_type: canon
 content_type: location
@@ -9,7 +10,7 @@ status: draft
 created: 2025-12-13
 description: Westernmost major trade city; crossroads of cultures and journey origins.
 elevation: 1289
-factions:
+factions_visible:
 - Tarim Basin Traders
 fantasy_name: Kashkar
 last_updated: 2026-01-05

--- a/world/regions/central-asian-hubs.md
+++ b/world/regions/central-asian-hubs.md
@@ -1,0 +1,40 @@
+---
+title: Central Asian Hubs
+project: TTRPG_Tarim_Shaiel
+domain: world
+doc_type: canon
+content_type: region
+visibility: public
+status: draft
+created: 2026-05-04
+last_updated: 2026-05-04
+tags:
+  - region
+  - central-asian-hubs
+  - transoxiana
+  - sogdiana
+geojson_id: region_central_asia
+bounds:
+  sw: [37.0, 56.0]
+  ne: [42.5, 70.0]
+location_count: 5
+primary_ancestry: human
+faction_weight: high
+---
+
+# Central Asian Hubs
+
+The great cities of Transoxiana and Sogdiana — Samarqandh, Bukhara, Tashkent, Merv — that once defined civilisation west of the Tarim. These were the cities where scholars translated Greek texts into Arabic, where paper reached the Islamic world, where the Silk Road met the steppe and the caravans stopped to trade, pray, and argue philosophy.
+
+The empire that built them is gone. The cities endure. More than that — they thrive. Freed from tribute obligations and garrisoned governors, the merchant guilds and scholarly networks have discovered that prosperity does not require a distant emperor to authorize it.
+
+## Character
+
+Cosmopolitan in a way that makes the Tarim Basin look provincial. Orcish influence is growing, particularly through the Orc Confederation of Samarqandh, which has established itself not through conquest but through commercial relationships the old imperial order would never have permitted. The cities are adapting.
+
+## Key Tensions
+
+- Orc Confederation versus Human Imperial Remnants for political legitimacy
+- Sogdian Merchants Guild navigating the new power landscape
+- The Islamic Scholarly Network and its complex relationship with older Zoroastrian traditions
+- Merv's position as a partially-ruined city with significant archaeological layers

--- a/world/regions/eastern-gateway.md
+++ b/world/regions/eastern-gateway.md
@@ -1,0 +1,39 @@
+---
+title: Eastern Gateway
+project: TTRPG_Tarim_Shaiel
+domain: world
+doc_type: canon
+content_type: region
+visibility: public
+status: draft
+created: 2026-05-04
+last_updated: 2026-05-04
+tags:
+  - region
+  - eastern-gateway
+  - gansu-corridor
+  - dunhuang
+geojson_id: region_eastern_gateway
+bounds:
+  sw: [39.0, 93.0]
+  ne: [42.0, 103.0]
+location_count: 2
+primary_ancestry: elven
+faction_weight: medium
+---
+
+# Eastern Gateway
+
+The Gansu Corridor — a narrow land passage between the mountains and the desert that connects the Tarim Basin to the Eastern Terminus. It is the needle's eye through which all east-west trade must pass, and the people who have lived here longest know it.
+
+Dunhuang sits at the western entrance: city of caves, city of scrolls, city of pilgrims. The Elven sacred sites here predate the imperial road by centuries. What the empire called a border checkpoint, the Elven communities call the threshold of something much older.
+
+## Character
+
+Two overlapping realities inhabit this corridor. The imperial infrastructure — garrisons, customs posts, waystation networks — is fading, its bureaucratic legitimacy hollowing out as the Eastern Dominion loses its ability to enforce collection. Beneath it, the older reality: Elven sacred geography, pilgrimage circuits, and the Eastern Gateway Council that has always understood the corridor as spiritual territory, not political territory.
+
+## Key Tensions
+
+- Eastern Gateway Council versus Eastern Imperial Dominion over customs authority
+- Pilgrimage traffic and the Cave Temples as a destination independent of political control
+- The jade trade and who controls it when the checkpoint fades

--- a/world/regions/eastern-terminus.md
+++ b/world/regions/eastern-terminus.md
@@ -1,0 +1,38 @@
+---
+title: Eastern Terminus
+project: TTRPG_Tarim_Shaiel
+domain: world
+doc_type: canon
+content_type: region
+visibility: public
+status: draft
+created: 2026-05-04
+last_updated: 2026-05-04
+tags:
+  - region
+  - eastern-terminus
+  - imperial-heartland
+geojson_id: null
+bounds:
+  sw: [33.0, 104.0]
+  ne: [36.5, 110.0]
+location_count: 1
+primary_ancestry: human
+faction_weight: medium
+---
+
+# Eastern Terminus
+
+The easternmost anchor of the Silk Road — where the routes converge into the imperial heartland. Chang'an sits at the center: once the largest city in the world, now a city haunted by the weight of a collapsed empire and the memory of what it meant to be the center of everything.
+
+The Eastern Terminus is not a destination; it is where the road begins, or ends, depending on which direction you are facing. Merchants who survive the crossing of the Tarim Basin arrive here and find themselves in a world governed by paperwork, taxation, and the slow machinery of a bureaucracy that has outlasted the empire it was designed to serve.
+
+## Character
+
+Faded imperial grandeur. The city still functions — perhaps more efficiently than during the height of empire — but the cultural confidence that once animated it has curdled into nostalgia. The Eastern Imperial Dominion maintains formal structures, but its reach beyond the Gansu Corridor is largely theoretical.
+
+## Key Tensions
+
+- Imperial Dominion seeking to reassert control over the Gansu trade routes
+- Merchant guilds that have learned to operate without imperial protection
+- The deep memory of what Chang'an once was — and who built it

--- a/world/regions/mountain-passes.md
+++ b/world/regions/mountain-passes.md
@@ -1,0 +1,40 @@
+---
+title: Mountain Passes
+project: TTRPG_Tarim_Shaiel
+domain: world
+doc_type: canon
+content_type: region
+visibility: public
+status: draft
+created: 2026-05-04
+last_updated: 2026-05-04
+tags:
+  - region
+  - mountain-passes
+  - dwarven
+  - karakoram
+  - tianshan
+geojson_id: null
+bounds:
+  sw: [36.0, 70.0]
+  ne: [42.0, 80.0]
+location_count: 3
+primary_ancestry: dwarven
+faction_weight: medium
+---
+
+# Mountain Passes
+
+The Karakoram, Kunlun, and Tian Shan ranges that bracket the Tarim Basin — the walls of the world, and the only ways through them. Dwarven communities have maintained these passes since before the empire existed, and they will maintain them long after.
+
+The pass-keepers are not gatekeepers in a political sense. They do not take sides in the lowland disputes. They take tolls, maintain the road, and ensure that the mountain weather does not kill you — for a fee. This arrangement has outlasted every empire that has tried to nationalize the pass infrastructure.
+
+## Character
+
+Dwarven Mountain Confederations operate as fully independent polities. They have no interest in the lowland political situation except insofar as it affects traffic volume. Anvil-Sunder Switchbacks, Dun-Kharan, and the other named pass locations are Dwarven civic infrastructure — ancient, functional, and not for sale.
+
+## Key Tensions
+
+- Dwarven Tarim Authority (lowland infrastructure) versus Mountain Confederations (pass infrastructure) — two different Dwarven political entities with different relationships to lowlanders
+- Increasing traffic from the liberated routes putting pressure on pass maintenance capacity
+- Rumors of older tunnels beneath the passes that predate even Dwarven occupation

--- a/world/regions/steppe-confederations.md
+++ b/world/regions/steppe-confederations.md
@@ -1,0 +1,39 @@
+---
+title: Steppe Confederations
+project: TTRPG_Tarim_Shaiel
+domain: world
+doc_type: canon
+content_type: region
+visibility: public
+status: draft
+created: 2026-05-04
+last_updated: 2026-05-04
+tags:
+  - region
+  - steppe-confederations
+  - orcish
+  - nomadic
+geojson_id: null
+bounds:
+  sw: [42.0, 60.0]
+  ne: [50.0, 90.0]
+location_count: 0
+primary_ancestry: orcish
+faction_weight: low
+---
+
+# Steppe Confederations
+
+The great grasslands north of the trade routes, home to the Orcish nomadic confederations whose relationship to the Silk Road is complex, ancient, and frequently misunderstood by sedentary peoples who write the history.
+
+The Steppe is not empty. It is differently populated — by peoples who move with purpose rather than building in one place, whose political structures are confederate rather than territorial, and whose knowledge of the routes, the water sources, and the seasonal conditions is more comprehensive than any mapmaker's.
+
+## Character
+
+No fixed locations yet — the Steppe Confederations region will grow as the campaign develops and heroes encounter Orcish political actors. The Orc Confederation of Samarqandh represents the settled diplomatic face of steppe politics; the Orc Steppe Confederations are the mobile reality behind it.
+
+## Key Tensions
+
+- Confederation politics: competing clan interests beneath the unified external face
+- Relationship to the Orcish community in Samarqandh — diaspora or vanguard?
+- Historical memory of when the steppe peoples controlled the routes, not the cities

--- a/world/regions/tarim-basin.md
+++ b/world/regions/tarim-basin.md
@@ -1,0 +1,38 @@
+---
+title: Tarim Basin Oases
+project: TTRPG_Tarim_Shaiel
+domain: world
+doc_type: canon
+content_type: region
+visibility: public
+status: draft
+created: 2026-05-04
+last_updated: 2026-05-04
+tags:
+  - region
+  - tarim-basin
+  - silk-road-core
+geojson_id: region_tarim_basin
+bounds:
+  sw: [36.0, 73.0]
+  ne: [42.5, 95.0]
+location_count: 11
+primary_ancestry: mixed
+faction_weight: high
+---
+
+# Tarim Basin Oases
+
+The beating heart of the Silk Road. A chain of oasis cities strung along the rim of the Taklamakan desert — each one an island of life in an ocean of sand and salt flat, connected by trade routes carved by centuries of merchants, pilgrims, and armies.
+
+The Basin is neither eastern nor western. It has always belonged to everyone who passed through it, and therefore to no one. Imperial powers claimed it; none held it long. What endures is the trade itself: the caravans, the inns, the brokers who speak five languages and trust none of them fully.
+
+## Character
+
+The Basin cities are cosmopolitan in the way only necessity can create. Ancestry matters less than what you carry and who owes you. Political allegiance shifts with the trade winds. The dominant powers are the merchant councils and the Dwarven Tarim Authority, whose engineering keeps the qanats flowing.
+
+## Key Tensions
+
+- Dwarven infrastructure maintenance versus increasing human council autonomy
+- Expansion of the Peoples of the Nine Roads network
+- Lich Cadre interests in the deeper ruins beneath several oasis foundations

--- a/world/regions/transoxiana.md
+++ b/world/regions/transoxiana.md
@@ -1,0 +1,39 @@
+---
+title: Transoxiana
+project: TTRPG_Tarim_Shaiel
+domain: world
+doc_type: canon
+content_type: region
+visibility: public
+status: draft
+created: 2026-05-04
+last_updated: 2026-05-04
+tags:
+  - region
+  - transoxiana
+  - amu-darya
+  - syr-darya
+geojson_id: null
+bounds:
+  sw: [37.5, 58.0]
+  ne: [42.5, 68.0]
+location_count: 0
+primary_ancestry: human
+faction_weight: low
+---
+
+# Transoxiana
+
+The lands between the rivers — Amu Darya and Syr Darya — that form the western extension of the Silk Road network. This is the frontier zone beyond the Central Asian Hubs, where the road dissolves into the steppe and the familiar grammar of oasis-city politics gives way to something more fluid.
+
+Currently underpopulated in the campaign's active geography, but several active routes pass through it. Future location development will address the riverine cities and the steppe-interface settlements.
+
+## Character
+
+A liminal zone between the settled world of the Central Asian Hubs and the Steppe Confederations. Governance is loose, trade relationships are personal, and the old maps are not reliable guides to the current political situation.
+
+## Key Tensions
+
+- Steppe Confederation raiding versus trade route maintenance
+- The river crossings as choke points — who controls the ferries controls the route
+- Lingering Khwarazmian-era infrastructure being repurposed by new occupants


### PR DESCRIPTION
Closes #201

## Summary

Implements all 7 phases of the `/locations` HTML build stub.

- **Phase 1 — Frontmatter foundation:** 7 region source files in `world/regions/` (tarim-basin, eastern-terminus, central-asian-hubs, eastern-gateway, mountain-passes, transoxiana, steppe-confederations) with stub prose + full Schema C frontmatter. `utilities/world/normalize_locations.py` migration script applied to all 37 location files: adds `parent_region`, `visibility`, `status`; renames `factions → factions_visible`.

- **Phase 2 — GM reveal mechanic:** Extended `render_body()` in `utilities/shared/html_render.py` with `revealed_ids` param; `[!gm-only id=X]` syntax captures optional block IDs; blocks whose ID appears in `gm_revealed:` frontmatter are promoted to `.revealed-content.gm-callout--revealed` at build time. CSS added to `gm.css`.

- **Phase 3 — Generator modules:** `utilities/locations/` package — `location_parser.py` (`LocationData`, type classification, leaflet block stripping), `region_parser.py` (`RegionData`), `location_components.py` (mini-map, faction table, danger pips, stats row, xref stub).

- **Phase 4 — Templates + CSS:** Jinja2 templates `location-detail.html`, `region-index.html`, `world-home.html`. CSS: `world-location.css`, `world-region.css`, `world-map.css`.

- **Phase 5 — Generator + build registration:** `utilities/locations/generate_locations_html.py` — full generation loop; inline GeoJSON for Leaflet maps (ESRI satellite + Carto labels). Registered in `build.py` as `locations` generator, included in `all` pipeline.

- **Phase 6 — Navigation index:** `lat.md/locations.md` domain index; row added to `CLAUDE.md` and `lat.md/subagent-context.md` Quick Navigation tables.

- **Phase 7 — Verification:** 33 location pages + 7 region pages + `docs/world.html` generated. No leaflet blocks in output. `jade-gate` correctly excluded in `--public` mode (`visibility: secret`). GM reveal mechanic tested. `build.py all` exits 0.

## Test plan

- [ ] Pull branch locally and run `python utilities/build.py locations`
- [ ] Confirm `docs/world.html` opens and Leaflet map renders with location markers
- [ ] Confirm `docs/locations/samarkand.html` shows mini-map, faction table, stats row
- [ ] Confirm `docs/locations/regions/tarim-basin.html` shows region map + location cards
- [ ] Run `python utilities/build.py all` — confirm exit 0 and no regressions
- [ ] Test GM reveal: add `gm_revealed: [test-id]` to a location frontmatter with matching `[!gm-only id=test-id]` block; rebuild; confirm `.revealed-content` in output
- [ ] Check open questions from issue (GeoJSON feature IDs, region bounds, tile server choice)

https://claude.ai/code/session_01RjENXagQs99B5Bp7WTc9px

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjENXagQs99B5Bp7WTc9px)_