### PR TITLE
narrative: add CAMPAIGN_SUMMARY.md — living timeline & plot synthesis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ Read the relevant `lat.md/` file before diving into domain content — one read 
 
 | Domain | File | When to read |
 |---|---|---|
+| Full campaign timeline, plot arc, established story structure | [[narrative/CAMPAIGN_SUMMARY]] | Full orientation, timeline questions, act structure overview |
 | Cosmological architecture, Warren, R/H/K, Held Breath | [[lat.md/cosmology]] | Any cosmology / Warren / Wizard question |
 | Session 0 design, awakenings, flashbacks, memory events | [[lat.md/session0]] | Session 0 work, pacing, scenario status |
 | Archetypes, tools system, surrendered-layer, identity | [[lat.md/characters]] | Archetype description constraints, tools-as-divine-marks, identity mechanics |

--- a/lat.md/subagent-context.md
+++ b/lat.md/subagent-context.md
@@ -5,7 +5,7 @@ type: navigation
 visibility: internal
 status: canon
 created: 2026-04-11
-last_updated: 2026-05-06
+last_updated: 2026-05-07
 ---
 
 > _Derived from CLAUDE.md and `lat.md/` files — update in the same commit when those change. Inject into spawned agent prompts; this file is not automatically read by any session._
@@ -27,6 +27,7 @@ Read the relevant `lat.md/` file before diving into domain content — one read 
 
 | Domain | File | When to read |
 |---|---|---|
+| Full campaign timeline, plot arc, established story structure | [[narrative/CAMPAIGN_SUMMARY]] | Full orientation, timeline questions, act structure overview |
 | Cosmological architecture, Warren, R/H/K, Held Breath | [[lat.md/cosmology]] | Any cosmology / Warren / Wizard question |
 | Session 0 design, awakenings, flashbacks, memory events | [[lat.md/session0]] | Session 0 work, pacing, scenario status |
 | Archetypes, tools system, surrendered-layer, identity | [[lat.md/characters]] | Archetype description constraints, tools-as-divine-marks, identity mechanics |

--- a/narrative/CAMPAIGN_SUMMARY.md
+++ b/narrative/CAMPAIGN_SUMMARY.md
@@ -1,0 +1,139 @@
+---
+title: Campaign Summary — Timeline & Plot Synthesis
+project: TTRPG_Tarim_Shaiel
+domain: narrative
+doc_type: canon
+content_type: campaign_frame
+visibility: gm_secrets
+status: draft
+created: 2026-05-07
+last_updated: 2026-05-07
+tags: [timeline, plot, synthesis, orientation]
+---
+
+# Tarim-Shaiel — Campaign Summary & Timeline
+
+> **Living document.** Update this whenever the established plot arc, timeline, or act structure is revised. This is the authoritative orientation doc for anyone needing a full picture fast — AI sessions, new collaborators, or returning after a break.
+>
+> For cosmological detail: [[lat.md/cosmology]]. For locked decisions: [[lat.md/decisions]]. For Session 0 structure: [[lat.md/session0]].
+
+---
+
+## Era 0: The Heroes' Time (~200–250 HB) — "The Age of Chains"
+
+A human empire controls the Silk Road through tribute, bureaucracy, and enslaved Orc legions bound through magical compulsion. The heroes were a legendary party of archetypally distinct champions who:
+
+- Discovered the binding spell mechanism and systematically broke it across the continent, freeing tens of thousands
+- Defeated the empire militarily — destroying key infrastructure, rallying regional powers
+- Lost a teammate in the final push; their death became the rallying cry that secured victory
+- Were granted the Celestial Peak (Hero Heaven) as their earned reward — a real, geographic sanctuary of rest and knowledge
+
+They believed the work was complete. They were wrong.
+
+**The failure:** The Wizard survived, retreated, and was presumed gone. The heroes didn't recognize their charge as incomplete. They departed for the Celestial Peak without ensuring long-term stability.
+
+**World state at their departure:** Empire fragmenting into warlord states; freed Orcs suddenly autonomous with no cultural memory of self-governance; trade routes collapsing.
+
+---
+
+## Era 1: The Scattering (~250–400 HB) — "The Age of Blood and Ash"
+
+The heroes rest in the Celestial Peak. The world bleeds.
+
+- ~70 years of Orc eruption — raids, inter-Orc warfare, depopulation of entire regions (the Breaker's specific fear: *was that blood on me?*)
+- High Elves nearly fully withdraw from mortal view; mortal Elves retreat into deep forests
+- Dwarves seal mountain passes; begin detailed record-keeping of the chaos (the Chronicle of Ages)
+- Halfling mediators and Dwarf record-keepers pioneer the first trade protocols
+- **~370 HB — The Truce of Nine Caravans:** first multi-species trade agreement; establishes protected corridors and a precedent for all future diplomacy
+- The Wizard uses the chaos as cover — establishing influence networks, recruiting proto-Liches, building the first hidden undead laboratories in remote ruins
+
+---
+
+## Era 2: The Flowering (~400–700 HB) — "The Age of Many Voices"
+
+The world stabilizes into something genuinely beautiful. No single hegemon; dozens of independent powers coexisting through trade rather than dominance. The heroes, still resting, become legend.
+
+- Multi-species governance becomes the norm in cosmopolitan hubs; Orc oral epic tradition emerges — the heroes become mythic figures sung before ancestors' names
+- **~550 HB — The Convocation of Eleven Cities:** first pan-regional trade laws; creates institutions the Wizard later infiltrates
+- **~620 HB — The Great Drought:** a decade-long water crisis forces Dwarf engineers, Gnome inventors, and Elf water-mages into collaboration that forges lasting inter-species bonds
+- **~680 HB — The Scholar's Plague:** presented as disease; actually the Wizard eliminating researchers who were getting too close to ancient necromantic texts
+- Across these centuries the Wizard poses as different scholars and philosophers, recruiting 8–12 powerful mages of diverse species — teaching each the Lichdom ritual in isolation, none aware of the others
+
+---
+
+## Era 3: The Consolidation (~700–1000 HB) — "The Age of Pacts and Suspicions"
+
+Loose alliances formalize into recognizable powers: the Northern Dwarven League, the Southern Orc Confederacy, the Eastern Human Dynasties, the Goblin Free Cities. The world looks increasingly stable. Beneath it, the Wizard is nearly ready.
+
+- **~780 HB — The Siege of Kalar's Gate:** three-year siege ends in negotiated settlement; the Wizard uses it as cover to collect thousands of corpses
+- **~850 HB — The Copper Accord:** major trade treaty standardising currency across species
+- **~700–900 HB:** All recruited mages undergo Lichdom transformation; each begins raising an undead legion independently — hidden in crypts, mountain fortresses, desert ruins, subterranean complexes — none knowing about the others
+- **~950 HB — The Vanishing of Khorashar:** an entire city of ~8,000 disappears overnight; buildings intact, inhabitants gone; blamed on magical disaster; the hidden truth — the Wizard's first test of coordinated Lich-Legion assault; the entire population killed and reanimated
+- A handful of long-lived mortal Elves begin noticing patterns — the same "advisor" appearing in different courts across centuries; their reports are dismissed
+
+---
+
+## Era 4: The Gathering Storm (~1000–1200 HB) — "The Age of Whispers and Warnings"
+
+The surface is a golden age: trade at its historical peak, art and philosophy flourishing, a "Long Peace" stretching across generations. Beneath it, the stress fractures are invisible to almost everyone.
+
+- Remote villages vanishing; travelers disappearing on well-traveled routes; Dwarf census records noting population discrepancies — all attributed to mundane causes
+- **~1050 HB — The Night of Falling Stars:** a meteor shower distracts the continent while the Wizard moves major undead forces undetected
+- **~1120 HB — The Grey Council:** emergency multi-species summit after disappearances escalate; disbands without resolution; the Wizard's agents sabotage every attempt at unity
+- **~1175 HB — The Scholar's Purge:** a wave of assassinations targeting necromancy researchers; key libraries burned; blamed on religious extremists; the Wizard eliminating everyone who might understand what's coming
+- **~1180–1200 HB:** The Wizard locates the threshold to the Celestial Peak. He realizes he needs the heroes' knowledge and essence to breach it. He finds the fallen teammate's lingering spiritual connection — and enacts the gaes through necromantic manipulation of that bond.
+
+The Celestial Peak expels the heroes. Not as punishment. As deployment.
+
+---
+
+## Era 5: Campaign Present (~1200 HB) — "The Age of Reckoning"
+
+**This is where play begins.**
+
+> **Timing note:** The expulsion is the present-day inciting incident — it IS Session 0. The heroes did not fall 1,000 years ago; they rested in the Peak for 1,000 years and are expelled NOW, at the start of play. The Warrior awakening, the Seeker's night, the Breaker's dilemma — these are the expulsion landing. From the world's perspective: ~1,000 years have passed. From the heroes' perspective: time in the Peak will be remembered differently.
+
+**What the world remembers:**
+- **Humans** — no living memory; the heroes are pure myth, contradictory across cultures
+- **Dwarves** — extensive written records, no personal memory (oldest are ~230 years old); treat the heroes as historical figures requiring verification
+- **Mortal Elf elders (~300–350 years old)** — fragmented childhood memories of the era; emotional, not detailed
+- **Orcs** — the heroes are central mythology; their names spoken before ancestors'
+- **Goblins and Halflings** — pragmatic: *"Prove it, then we'll talk"*
+
+**What the world doesn't know:**
+The Lich-Legion (~100,000+ undead) is hidden across the continent, all commanders active, awaiting the Wizard's signal. The world looks stable and prosperous. The threat is entirely invisible at campaign start.
+
+---
+
+## The Three-Act Campaign Arc
+
+### Act I — "What Happened to Us?"
+
+The heroes discover why they were expelled, who they are now, what the world has become. First encounters with dead zones where magic fails. Fragmentary, contradictory evidence that the Wizard survived. Act I climax: first real contact with the Lich-Legion — the heroes realize the threat is both military and magical.
+
+### Act II — "Stop the Wizard"
+
+Rally factions, track the Wizard, fight escalating Lich-Legion incursions. Distributed knowledge surfaces: Dwarven archivists with 1,000 years of disturbing patterns; Orc shamans sensing the ancestors growing harder to reach; human scholars in hiding; Goblin networks sitting on continent-wide observational data they can't interpret. The heroes begin sensing the cosmological stress themselves. Act II climax: a localized ecosystem failure makes the real stakes visible — this is bigger than one man.
+
+### Act III — "The Real Charge"
+
+The Three-Layer Revelation fully resolves:
+1. *Stop the Wizard* — the surface quest, known early
+2. *The Wizard's plan would crack the cosmological ecosystem* — mid-campaign
+3. *The ecosystem is already strained; the heroes' incomplete liberation left damage only they can repair* — endgame
+
+Full-scale Lich-Legion war across multiple fronts. Confrontation with the Wizard at the threshold — his awareness of the deeper threat is locked as tragic hubris + cosmic manipulation (Decision 4, B+C), though the specific motivation for breaching the Threshold remains an open question. A final choice that isn't just "do we stop him" but "what do we do about what's underneath all of this?"
+
+---
+
+## Key Open Questions
+
+| Question | Status |
+|---|---|
+| Wizard's specific motivation for breaching the Threshold | Open (Decision 4 B+C locked; specifics unresolved) |
+| The fallen teammate — name, personality, archetype | Open |
+| Ghost mechanics — how communication works, what it knows | Open |
+| Names of the empire, Lich commanders, major kingdoms | Open |
+| Threshold location (geographic) | Open |
+| Endgame shape — which of the 5 possible endings | Open |
+| Can any Lich commanders be redeemed? | Proposed but undecided |


### PR DESCRIPTION
## Summary

- Adds `narrative/CAMPAIGN_SUMMARY.md` — a new living document that synthesises the full campaign timeline (Eras 0–5) and three-act plot arc in one updatable place
- Updates the Quick Navigation table in both `CLAUDE.md` and `lat.md/subagent-context.md` to point to it as the first entry
- Includes a timing note (mirroring the one added to `CORE_CAMPAIGN_NARRATIVE.md` directly on main) clarifying that the expulsion **is** Session 0 — not a historical event

## Why

There was no single document representing the complete established plot arc with a readable timeline. This gap caused an AI session to misread the expulsion as happening ~1,000 years ago rather than as the present-day inciting incident. `CAMPAIGN_SUMMARY.md` fills that gap and is now indexed in both navigation tables so future sessions find it immediately.

## What a reviewer should know

- The timing correction on `CORE_CAMPAIGN_NARRATIVE.md` was committed directly to main earlier in this session (commit `9587fd8`) — that change is not in this PR
- `CAMPAIGN_SUMMARY.md` has `status: draft` — content reflects established lore but hasn't been through a formal canon review
- The Quick Navigation row is added as the first entry in both tables, making it the first thing read on orientation

## Test plan

- [ ] Open `narrative/CAMPAIGN_SUMMARY.md` and confirm the timeline reads coherently Era 0 → Era 5
- [ ] Confirm the timing note in Era 5 is clear that Session 0 = the expulsion landing
- [ ] Confirm the nav table row appears in both `CLAUDE.md` and `lat.md/subagent-context.md`