### PR TITLE
mechanics: remove all Charm references from active docs (HeroHeaven-6vd)

### DIFF
--- a/mechanics/Index.md
+++ b/mechanics/Index.md
@@ -35,7 +35,7 @@ FROM "mechanics/magic-systems"
 SORT file.name ASC
 ```
 
-### 💎 Charm Analysis
+### 💎 Legendary Capabilities (Archive)
 ```dataview
 LIST 
 FROM "mechanics/charm-analysis" 
@@ -60,9 +60,9 @@ SORT file.name ASC
 
 This directory contains all game mechanics organized by domain:
 - **Character Creation** - Session 0 and character development mechanics
-- **Character Progression** - Charms, tools, and advancement systems
-- **Magic Systems** - Spells vs charms analysis and magic frameworks
-- **Charm Analysis** - Detailed charm system research and design
+- **Character Progression** - Legendary capabilities, tools, and advancement systems
+- **Magic Systems** - Spells vs legendary capabilities analysis and magic frameworks
+- **Legendary Capabilities (Archive)** - Archived charm system research and design
 - **Design Decisions** - Mechanical design rationale and decisions
 
 ## Related Directories

--- a/mechanics/character-progression/CELESTIAL_DICE_MECHANICS.md
+++ b/mechanics/character-progression/CELESTIAL_DICE_MECHANICS.md
@@ -7,7 +7,7 @@ content_type: concept
 visibility: gm_secrets
 status: draft
 created: 2026-02-09
-last_updated: 2026-02-09
+last_updated: 2026-05-07
 ---
 
 # CELESTIAL DICE MECHANICS
@@ -37,30 +37,30 @@ Celestial dice mechanics form the core of Tarim-Shaiel's narrative and mechanica
 
 ### Tier 0: Dormant (Pre-Awakening)
 - Standard duality dice (1d12 Hope + 1d12 Fear)
-- No Charm access
+- Legendary capabilities dormant
 - Standard Daggerheart mechanics
 
 ### Tier 1 (Level 1): First Awakening
 - Celestial dice: 2d12 Hope (keep highest) + 1d12 Fear when using tool
-- Access to Tier 1 Charms
+- Tier 1 legendary capabilities accessible
 - Hope bonuses: +1 Hope per scene
 - Recall cost: 0 Hope
 
 ### Tier 2 (Levels 2-4): Expanding Consciousness
 - Celestial dice: 3d12 Hope (keep highest) + 1d12 Fear when aligned with purpose
-- Access to Tier 2 Charms + enhanced Tier 1
+- Tier 2 legendary capabilities accessible + enhanced Tier 1
 - Hope bonuses: +2 Hope per scene
 - Recall cost: 1 Hope
 
 ### Tier 3 (Levels 5-7): Purpose Clarity
 - Celestial dice: 3d12 Hope (keep highest) + 1d12 Fear always active
-- Access to Tier 3 Charms + maximum Tier 2 scaling
+- Tier 3 legendary capabilities accessible + maximum Tier 2 scaling
 - Hope bonuses: +2 Hope per scene
 - Recall cost: 2 Hope
 
 ### Tier 4 (Levels 8-10): Full Awakening
 - Celestial dice: 3d12 Hope (keep highest) + 1d12 Fear + mythic bonuses
-- Access to Tier 4 Charms + maximum scaling all tiers
+- Tier 4 legendary capabilities accessible + maximum scaling all tiers
 - Hope bonuses: +3 Hope per scene
 - Recall cost: 3 Hope
 
@@ -92,17 +92,17 @@ Celestial dice mechanics form the core of Tarim-Shaiel's narrative and mechanica
 
 **Tier 1 Spending**
 - Minor narrative adjustments
-- Simple Charm activations
+- Tier 1 legendary activations
 - Tactical rerolls
 
 **Tier 2 Spending**
 - Moderate narrative interventions
-- Complex Charm activations
+- Tier 2 legendary activations
 - Combining multiple action types
 
 **Tier 3 Spending**
 - Massive narrative transformations
-- Apocalyptic Charm activations
+- Tier 3 legendary activations
 - Rewriting immediate reality
 
 ## TOOL WHISPER INTERACTIONS

--- a/mechanics/character-progression/TOOL_EVOLUTION_FRAMEWORK.md
+++ b/mechanics/character-progression/TOOL_EVOLUTION_FRAMEWORK.md
@@ -40,7 +40,7 @@ last_updated: 2026-01-11
 ### **Why This Works**
 
 **Mechanically:**
-- Explains Charm activation: "I channel power through my tool"
+- Explains legendary capability activation: "I channel power through my tool"
 - Explains whisper system: Tool remembers what hero has forgotten
 - Explains R/H/K discovery: Learning what the tool knows about shared identity
 - Explains binding: Tools are keyed to specific legendary nature
@@ -98,7 +98,7 @@ Realization: "What IS this thing?"
 
 **Mechanical Properties:**
 - Enhanced damage/range/effect (+1 tier improvement)
-- First Charm tier unlocked (Tier 1 Charms accessible)
+- First legendary capabilities unlock (Tier 1 accessible)
 - Celestial dice progression: 2d12 Hope advantage when using tool
 
 **Narrative Moment:**
@@ -127,7 +127,7 @@ It whispers: "Remember..."
 
 **Mechanical Properties:**
 - Significant enhancement (+2 tier improvement)
-- Second Charm tier unlocked (Tier 2 Charms accessible)
+- Second tier legendary capabilities unlock (Tier 2 accessible)
 - Celestial dice: 2d12 Hope when aligned with purpose
 
 **Narrative Moment:**
@@ -157,7 +157,7 @@ and you KNOW its name for the first time.
 
 **Mechanical Properties:**
 - Maximum enhancement (+3 tier improvement)
-- Third Charm tier unlocked (Tier 3 Charms accessible)
+- Third tier legendary capabilities unlock (Tier 3 accessible)
 - Celestial dice: 3d12 Hope advantage always active
 - Unique legendary property (TBD per tool)
 
@@ -227,18 +227,18 @@ The tool whispers: "We are whole again."
 | Stage | Damage Bonus | Range Increase | Special Properties |
 |-------|--------------|----------------|-------------------|
 | Crude (Stage 0) | Standard | Standard | Tether only |
-| Masterwork (Essence 1) | +1 damage die size | +1 range band | Never breaks, Tier 1 Charms |
-| Ornate (Essence 2) | +2 damage die size | +2 range bands | Ignores mundane armor, Tier 2 Charms |
-| Legendary (Essence 3) | +3 damage die size | +3 range bands | Legendary property, Tier 3 Charms |
+| Masterwork (Essence 1) | +1 damage die size | +1 range band | Never breaks, Tier 1 legendary capabilities |
+| Ornate (Essence 2) | +2 damage die size | +2 range bands | Ignores mundane armor, Tier 2 legendary capabilities |
+| Legendary (Essence 3) | +3 damage die size | +3 range bands | Legendary property, Tier 3 legendary capabilities |
 
 **NON-WEAPON TOOLS:**
 
 | Stage | Effect Bonus | Clarity/Power | Special Properties |
 |-------|--------------|---------------|-------------------|
 | Crude (Stage 0) | Standard | Limited | Tether only |
-| Masterwork (Essence 1) | +1 to relevant rolls | Clear/Functional | Enhanced utility, Tier 1 Charms |
-| Ornate (Essence 2) | +2 to relevant rolls | Exceptional | Multiple uses, Tier 2 Charms |
-| Legendary (Essence 3) | +3 to relevant rolls | Perfect/Absolute | Reality-bending, Tier 3 Charms |
+| Masterwork (Essence 1) | +1 to relevant rolls | Clear/Functional | Enhanced utility, Tier 1 legendary capabilities |
+| Ornate (Essence 2) | +2 to relevant rolls | Exceptional | Multiple uses, Tier 2 legendary capabilities |
+| Legendary (Essence 3) | +3 to relevant rolls | Perfect/Absolute | Reality-bending, Tier 3 legendary capabilities |
 
 ### **Tether Mechanics (Death & Resurrection)**
 
@@ -256,7 +256,7 @@ The tool whispers: "We are whole again."
 
 **Tool Separated Completely:**
 - Hero feels constant pull toward tool
-- Cannot access Charms while separated
+- Cannot access legendary capabilities while separated
 - Vulnerability: Standard mortal capabilities only
 
 ---
@@ -369,7 +369,7 @@ Tools are **limited entities** with their own nature (Moorcock-style). Their per
 
 **Class Change Mid-Campaign:**
 - Tool form remains constant (reflects Session 0 choice)
-- Charms adjust to maintain thematic fit
+- Legendary capabilities adjust to maintain thematic fit
 - Narrative: "My tool remembers who I was, even as I change"
 
 **Tool Damage/Destruction:**
@@ -412,6 +412,6 @@ Tools are **limited entities** with their own nature (Moorcock-style). Their per
 
 ---
 
-**Last Updated:** 2026-03-20
+**Last Updated:** 2026-05-07
 **Next Steps:** Create CHARACTER_CREATION_SEQUENCE.md with Session -1 questionnaire structure; resolve Seeker tome/bow discrepancy between Stage 0 examples and written awakening scenario
 **Maintained by:** Lore Keeper, with input from Mythweaver

--- a/narrative/HERO_IDENTITY.md
+++ b/narrative/HERO_IDENTITY.md
@@ -6,7 +6,7 @@ content_type: concept
 visibility: gm_secrets
 status: canon
 created: 2026-03-17
-last_updated: 2026-03-17
+last_updated: 2026-05-07
 ---
 
 # HERO HEAVEN: HERO IDENTITY & COSMOLOGICAL FOUNDATION
@@ -46,7 +46,7 @@ last_updated: 2026-03-17
 
 **Hero Heaven Heroes ≈ Exalted Solars**
 - Chosen champions with legendary power
-- Legendary abilities manifest through Charms
+- Legendary abilities manifest through Tools (R/H/K)
 - Tools as proxy for anima/caste marks
 - Legendary past drives current identity
 
@@ -87,7 +87,7 @@ Heroes were RIGHT to do what they did (earned paradise), but INCOMPLETE in under
 **No Mechanical Punishment for Past:**
 - Heroes don't lose power for "being wrong"
 - Tools don't betray heroes for incomplete understanding
-- Charms work regardless of alignment discovery
+- Legendary capabilities activate regardless of alignment discovery
 - Hope/Fear economy reflects present choices, not past
 
 ---
@@ -160,7 +160,7 @@ Heroes were RIGHT to do what they did (earned paradise), but INCOMPLETE in under
 
 **At Session 0 (Tier 0):**
 - Skills: Fully retained (GURPS attributes/skills intact)
-- Power: Dormant (Charms not yet recovered)
+- Power: Dormant (legendary capabilities not yet awakened)
 - Identity: Fragmented ("I'm a warrior... I think?")
 - Past: Emotional echoes only (feelings without context)
 
@@ -177,19 +177,19 @@ Warrior doesn't know WHY they protect (purpose unclear)
 ### **What Heroes Recover**
 
 **Tier 1 (First Awakening):**
-- First Charm: Legendary ability returns
+- First awakening: Legendary capability expresses through the tool
 - First Memory: Flashback to heroic deed
 - First Whisper: Tool recognizes hero
 - Aspirational R/H/K: Hero defines who they think they are
 
 **Tier 2 (Purpose Clarity):**
-- More Charms: Additional legendary abilities
+- Deeper awakening: Additional legendary capabilities
 - Purpose Memory: Flashback to WHY they were heroic
 - R/H/K Discovery: Hero realizes aspirational ≠ actual
 - Tool Alignment: Whispers reveal truth
 
 **Tier 3 (Full Awakening):**
-- Final Charms: Maximum legendary power
+- Full awakening: Maximum legendary power
 - Complete Memory: Full understanding of legendary past
 - Actual R/H/K: Hero knows who they truly are
 - Future Choice: Reclaim paradise or forge new path
@@ -202,7 +202,7 @@ Warrior doesn't know WHY they protect (purpose unclear)
 
 **Mechanical Layer (Always Transparent):**
 - Players know: "Following whisper = advantage dice"
-- Players know: "Spending Hope = Charm activation"
+- Players know: "Spending Hope = legendary capability activation"
 - Players know: "Resisting = +1 Hope gain"
 - No hidden mechanics, no GM fiat
 
@@ -263,7 +263,7 @@ Actual R/H/K revealed through mechanical choice
 4. Does this respect hero power? (No diminishment?)
 
 **Examples:**
-- ✅ Hope-Only Charms: Transparent costs, meaningful choices
+- ✅ Hope-triggered legendary capabilities: Transparent costs, meaningful choices
 - ✅ Celestial Dice: Tactile power growth, narrative triggers
 - ✅ Tool Whispers: Clear mechanics, ambiguous alignment
 - ❌ Hidden costs: Violates transparency


### PR DESCRIPTION
Replace all "Charm/Charms" mechanical references in active mechanics and narrative files with current system language (legendary capabilities, Tools/R/H/K).

Files updated:
- CELESTIAL_DICE_MECHANICS.md — tier progression + Hope spending section
- TOOL_EVOLUTION_FRAMEWORK.md — stage mechanics, tables, tether, edge cases
- HERO_IDENTITY.md — analogues section, power retention, mechanical layer
- mechanics/Index.md — section headers and directory descriptions