### PR TITLE
infra: class primer HTML generator + pipeline wiring (HeroHeaven-5cf)

### DIFF
--- a/.github/workflows/generate-html.yml
+++ b/.github/workflows/generate-html.yml
@@ -10,6 +10,7 @@ on:
       - 'templates/tarim-shaiel-campaign-frame-v2.md'
       - 'world/**/*.md'
       - 'narrative/**/*.md'
+      - 'world/classes/class_primer.md'
       - 'utilities/**/*.py'
       - 'utilities/**/*.css'
   workflow_dispatch:  # allows manual trigger from GitHub Actions UI
@@ -42,6 +43,9 @@ jobs:
 
       - name: Generate ancestry guide
         run: python utilities/ancestries/generate_ancestry_html.py
+
+      - name: Generate class primer
+        run: python utilities/class_primer/generate_class_primer.py
 
       - name: Generate world HTML + index
         run: python utilities/world/generate_all_world_html.py --public

--- a/utilities/build.py
+++ b/utilities/build.py
@@ -72,6 +72,7 @@ def _load_registry() -> dict:
     from campaign_frame.generate_campaign_frame import generator as campaign_frame
     from lore.generate_lore_html import generator as lore
     from ancestries.generate_ancestry_html import generator as ancestry
+    from class_primer.generate_class_primer import generator as class_primer
     from search.generate_search_index import generator as search_index
     from search.generate_search_html import generator as search
     from world.generate_world_html import generator as world
@@ -81,7 +82,7 @@ def _load_registry() -> dict:
 
     return {
         g.name: g for g in [
-            homepage, dashboard, campaign_frame, lore, ancestry,
+            homepage, dashboard, campaign_frame, lore, ancestry, class_primer,
             search_index, search, world, world_all, geojson, locations,
         ]
     }

--- a/utilities/class_primer/generate_class_primer.py
+++ b/utilities/class_primer/generate_class_primer.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Tarim-Shaiel Class Primer HTML Generator
+=========================================
+Reads world/classes/class_primer.md and renders it as docs/class-primer.html.
+"""
+
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+VAULT_ROOT  = SCRIPT_DIR.parent.parent
+DOCS_DIR    = VAULT_ROOT / "docs"
+
+sys.path.insert(0, str(SCRIPT_DIR.parent))
+from shared.frontmatter import parse_frontmatter
+from shared.html_render import render_body
+from shared.renderer import render_page
+
+SOURCE = VAULT_ROOT / "world" / "classes" / "class_primer.md"
+OUTPUT = DOCS_DIR / "class-primer.html"
+
+
+def main(argv=None) -> int:
+    if not SOURCE.exists():
+        print(f"ERROR: source file not found: {SOURCE}", file=sys.stderr)
+        return 1
+
+    raw = SOURCE.read_text(encoding="utf-8")
+    fm, body = parse_frontmatter(raw)
+
+    title    = fm.get("title") or "Character Classes"
+    date_str = str(fm.get("last_updated") or fm.get("created") or "")
+
+    body_html, _ = render_body(body, VAULT_ROOT, DOCS_DIR)
+
+    html = render_page(
+        "pages/lore.html",
+        title=title,
+        eyebrow="Character Classes",
+        cover_subtitle="Character Classes · Tarim-Shaiel",
+        banner_left="Character Classes",
+        banner_right="Class Primer · Tarim-Shaiel",
+        cover_image_url=None,
+        extra_css=["page-lore"],
+        generator_name="utilities/class_primer/generate_class_primer.py",
+        audio_url=None,
+        audio_title=None,
+        audio_mime=None,
+        description="Daggerheart classes framed for the world of Tarim-Shaiel.",
+        body_html=body_html,
+        date_str=date_str,
+    )
+
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text(html, encoding="utf-8")
+    print(f"Class primer generated: {OUTPUT}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+
+from shared.base_generator import make_generator
+generator = make_generator(
+    "class-primer",
+    "Class primer page (docs/class-primer.html)",
+    main,
+)

--- a/utilities/homepage/generate_homepage.py
+++ b/utilities/homepage/generate_homepage.py
@@ -30,6 +30,12 @@ FEATURED_DOCS = [
         "href": "/peoples-of-tarim-shaiel.html",
     },
     {
+        "tag": "Class Primer · 13 Classes",
+        "title": "Character Classes",
+        "sub": "Daggerheart classes framed for the world of Tarim-Shaiel.",
+        "href": "/class-primer.html",
+    },
+    {
         "tag": "World Lore",
         "title": "The Roads",
         "sub": "History, factions, and the shape of the known world.",

--- a/utilities/templates/pages/lore.html
+++ b/utilities/templates/pages/lore.html
@@ -2,7 +2,7 @@
 
 {% block page_header %}
 <div class="page-header{% if cover_image_url %} page-header--hero{% endif %}"{% if cover_image_url %} style="--cover-img: url('{{ cover_image_url | e }}')"{% endif %}>
-  <div class="page-header-eyebrow">World Lore</div>
+  <div class="page-header-eyebrow">{{ eyebrow | default('World Lore') }}</div>
   <h1>{{ title }}</h1>
   <div class="page-header-meta">{{ date_str }}</div>
 </div>


### PR DESCRIPTION
## Summary

- Adds `utilities/class_primer/generate_class_primer.py` — reads `world/classes/class_primer.md` → `docs/class-primer.html` via existing lore template + CSS (no new assets)
- Registers `class-primer` in `utilities/build.py` pipeline and `build.py all` run
- Adds a "Character Classes · 13 Classes" card to the homepage `FEATURED_DOCS` list
- Parameterises the eyebrow label in `utilities/templates/pages/lore.html` via `{{ eyebrow | default('World Lore') }}` — fully backwards-compatible
- Adds a GitHub Actions step + path trigger for `world/classes/class_primer.md`

The content file (`world/classes/class_primer.md`) was committed directly to main (content path). This PR wires the generator and CI so Netlify builds the page on every push.

## Test plan

- [ ] Run `python utilities/class_primer/generate_class_primer.py` — `docs/class-primer.html` is created
- [ ] Open `docs/class-primer.html` — 13 classes render with headings, italic subclasses line, Tarim-Shaiel framing, playtest labels
- [ ] Run `python utilities/build.py homepage` — homepage renders the "Character Classes" card
- [ ] Run `python utilities/build.py lore --source narrative/lore/The\ Roads.md` — lore page eyebrow still shows "World Lore" (backwards-compat check)
- [ ] Merge → GitHub Actions runs the new step → `docs/class-primer.html` committed back

🤖 Generated with [Claude Code](https://claude.com/claude-code)