### PR TITLE
infra: drive homepage featured-docs list from vault file

### DIFF
--- a/utilities/homepage/featured-docs.md
+++ b/utilities/homepage/featured-docs.md
@@ -1,0 +1,36 @@
+---
+title: Homepage Featured Documents
+project: TTRPG_Tarim_Shaiel
+doc_type: operational
+visibility: internal
+featured_docs:
+  - tag: "Player-Facing · v2.0"
+    title: Campaign Frame
+    sub: Themes, principles, and Session Zero questions.
+    href: /campaign-frame.html
+
+  - tag: "Ancestry Guide · 14 Peoples"
+    title: Peoples of Tarim-Shaiel
+    sub: Lore descriptions and features for character creation.
+    href: /peoples-of-tarim-shaiel.html
+
+  - tag: "Class Primer · 13 Classes"
+    title: Character Classes
+    sub: Daggerheart classes framed for the world of Tarim-Shaiel.
+    href: /class-primer.html
+
+  - tag: "World Lore"
+    title: The Roads
+    sub: History, factions, and the shape of the known world.
+    href: /lore/the-roads.html
+
+  - tag: "Interactive Map · 6 Regions"
+    title: World Map
+    sub: Locations, regions, and the Silk Road trade network.
+    href: /world.html
+---
+
+# Homepage Featured Documents
+
+Edit the frontmatter above to add, remove, or reorder cards on the campaign site homepage.
+Each entry needs: `tag` (small label), `title` (card heading), `sub` (one-line description), `href` (URL path).

--- a/utilities/homepage/generate_homepage.py
+++ b/utilities/homepage/generate_homepage.py
@@ -16,38 +16,9 @@ sys.path.insert(0, str(UTILITIES_DIR / "world"))
 from shared.renderer import render_page
 from shared.frontmatter import parse_frontmatter
 
-FEATURED_DOCS = [
-    {
-        "tag": "Player-Facing · v2.0",
-        "title": "Campaign Frame",
-        "sub": "Themes, principles, and Session Zero questions.",
-        "href": "/campaign-frame.html",
-    },
-    {
-        "tag": "Ancestry Guide · 14 Peoples",
-        "title": "Peoples of Tarim-Shaiel",
-        "sub": "Lore descriptions and features for character creation.",
-        "href": "/peoples-of-tarim-shaiel.html",
-    },
-    {
-        "tag": "Class Primer · 13 Classes",
-        "title": "Character Classes",
-        "sub": "Daggerheart classes framed for the world of Tarim-Shaiel.",
-        "href": "/class-primer.html",
-    },
-    {
-        "tag": "World Lore",
-        "title": "The Roads",
-        "sub": "History, factions, and the shape of the known world.",
-        "href": "/lore/the-roads.html",
-    },
-    {
-        "tag": "Interactive Map · 6 Regions",
-        "title": "World Map",
-        "sub": "Locations, regions, and the Silk Road trade network.",
-        "href": "/world.html",
-    },
-]
+_FEATURED_DOCS_FILE = SCRIPT_DIR / "featured-docs.md"
+_fm, _ = parse_frontmatter(_FEATURED_DOCS_FILE.read_text(encoding="utf-8"))
+FEATURED_DOCS = _fm.get("featured_docs", [])
 
 # Categories suppressed from the homepage (subcategories, GM-only, or low-value index noise)
 SUPPRESS_FROM_HOME = {


### PR DESCRIPTION
## Summary

- Adds `utilities/homepage/featured-docs.md` — YAML frontmatter list of homepage cards
- `generate_homepage.py` reads `featured_docs:` from that file instead of a hardcoded Python list

## To add a new homepage card

Edit `utilities/homepage/featured-docs.md` and add an entry to `featured_docs:` in the frontmatter:

```yaml
  - tag: "My Tag"
    title: My Page Title
    sub: One-line description.
    href: /my-page.html
```

No generator code changes required.

## Test plan

- [ ] `python utilities/build.py homepage` — builds without error
- [ ] All 5 existing cards appear in `docs/index.html`
- [ ] Add a test entry to featured-docs.md, rebuild, confirm new card appears
- [ ] Remove test entry, rebuild, confirm card gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)