### PR TITLE
infra: add featured-docs.md path trigger + homepage CI step

### DIFF
--- a/.github/workflows/generate-html.yml
+++ b/.github/workflows/generate-html.yml
@@ -11,6 +11,7 @@ on:
       - 'world/**/*.md'
       - 'narrative/**/*.md'
       - 'world/classes/class_primer.md'
+      - 'utilities/homepage/featured-docs.md'
       - 'utilities/**/*.py'
       - 'utilities/**/*.css'
   workflow_dispatch:  # allows manual trigger from GitHub Actions UI
@@ -34,6 +35,9 @@ jobs:
 
       - name: Install dependencies
         run: pip install -r requirements.txt
+
+      - name: Generate homepage
+        run: python utilities/homepage/generate_homepage.py
 
       - name: Generate dashboard
         run: python utilities/dashboard/generate_dashboard.py --out docs/dashboard.html

--- a/utilities/homepage/featured-docs.md
+++ b/utilities/homepage/featured-docs.md
@@ -24,10 +24,10 @@ featured_docs:
     sub: History, factions, and the shape of the known world.
     href: /lore/the-roads.html
 
-  - tag: "Interactive Map · 6 Regions"
-    title: World Map
-    sub: Locations, regions, and the Silk Road trade network.
-    href: /world.html
+#  - tag: "Interactive Map · 6 Regions"
+#       title: World Map
+#       sub: Locations, regions, and the Silk Road trade network.
+#       href: /world.html
 ---
 
 # Homepage Featured Documents


### PR DESCRIPTION
- featured-docs.md edits now fire the workflow
- generate_homepage.py runs in CI so docs/index.html stays current