### PR TITLE
infra: LK bridge — vault↔LegendKeeper converter, validator, tests (HeroHeaven-x1i)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ moulinette/
 .dolt/
 *.db
 .beads-credential-key
+
+# LK bridge round-trip artifacts (generated exports, LK re-exports, reimports)
+utilities/lk-bridge/roundtrip/
+utilities/lk-bridge/lk_manifest.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PyYAML>=6.0.1
 python-frontmatter>=1.0.1
 markdown>=3.5.0
 jinja2>=3.1.6
+jsonschema>=4.21.0

--- a/tests/fixtures/lk_bridge/gm_constructs_fixture.md
+++ b/tests/fixtures/lk_bridge/gm_constructs_fixture.md
@@ -1,0 +1,47 @@
+---
+title: "LK Bridge Fixture — All GM Constructs"
+project: TTRPG_Tarim_Shaiel
+domain: narrative
+doc_type: draft
+content_type: lore
+visibility: public
+status: draft
+created: 2026-07-03
+last_updated: 2026-07-03
+tags: [test, lk-bridge]
+---
+# LK Bridge Fixture — All GM Constructs
+
+This synthetic fixture exercises every GM construct — the whole-vault census
+(GH #213) showed real content only uses Tier 2 and percent-comment blocks,
+so Tier 1 and Tier 3 must be tested synthetically. (A bare double-percent in
+prose would pair with the real comment block below and swallow everything
+between — in Obsidian too.)
+
+The Wizard's true name is {gm:Sylaveth Vorn}, bound to the Sixth Warren.
+
+> [!gm-only]
+> Tier 2 without id: the tower was sealed after a containment failure.
+
+> [!gm-only] id=fixture-1
+> Tier 2 with id: the Held Breath "Dust of the Closed Eye" nearly awakened
+> here in 1209 CE.
+> - Perception DC 16 reveals the seal
+> - The lower chamber holds the truth
+
+![[gm_secrets/heroes_original_deed]]
+
+%%
+GM comment block: this entire aside is invisible to players in every
+pipeline — HTML and LK alike.
+%%
+
+A public paragraph with **bold**, *italic*, `inline code`, an aliased link
+[[tarim-basin|the Basin]], and an external [link](https://example.com).
+
+| Column A | Column B |
+|---|---|
+| plain cell | cell with {gm:secret number 42} |
+
+- [ ] open task
+- [x] done task

--- a/tests/test_lk_bridge.py
+++ b/tests/test_lk_bridge.py
@@ -1,0 +1,265 @@
+"""LK bridge test suite — lk_schema builders, md↔pm converters, round-trip.
+
+Fixtures live in tests/fixtures/lk_bridge/. The offline round-trip test is the
+executable form of the manual protocol's step 2 (GH #213).
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).parent.parent
+BRIDGE = REPO / 'utilities' / 'lk-bridge'
+FIXTURES = Path(__file__).parent / 'fixtures' / 'lk_bridge'
+sys.path.insert(0, str(BRIDGE))
+sys.path.insert(0, str(REPO / 'utilities'))
+
+import lk_schema as lk           # noqa: E402
+import md_to_pm                  # noqa: E402
+import pm_to_md                  # noqa: E402
+from shared.frontmatter import parse_frontmatter, doc_type_of   # noqa: E402
+
+FIXTURE_MD = FIXTURES / 'gm_constructs_fixture.md'
+
+
+def _no_resolve(_target):
+    return None
+
+
+def _convert(body, audience):
+    return md_to_pm.convert(body, audience=audience, resolve_link=_no_resolve,
+                            source='test')
+
+
+# ── lk_schema ────────────────────────────────────────────────────────────────
+
+class TestLkSchema:
+    def test_short_id_format_and_determinism(self):
+        a, b = lk.short_id('narrative/foo.md'), lk.short_id('narrative/foo.md')
+        assert a == b and len(a) == 8 and a.isalnum() and a == a.lower()
+        assert lk.short_id('other') != a
+
+    def test_envelope_self_consistency_hash(self):
+        import hashlib
+        env = lk.envelope([lk.resource('abcd1234', 'X', '', [lk.doc('d1', [lk.para('hi')])])])
+        payload = {k: v for k, v in env.items() if k != 'hash'}
+        expect = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+        assert env['hash'] == expect
+        assert env['resourceCount'] == 1
+
+    def test_doc_presentation_never_null(self):
+        d = lk.doc('d1', [])
+        assert d['presentation'] == {'documentType': 'page'}
+
+    def test_mention_carries_document_id(self):
+        m = lk.mention('abcd1234', 'Page')
+        assert m['attrs']['documentId'] == ''   # LK round-trip fidelity
+
+    def test_write_lk_gzip_roundtrip(self, tmp_path):
+        import gzip
+        env = lk.envelope([])
+        out = tmp_path / 'x.lk'
+        lk.write_export(env, out, as_lk=True)
+        assert json.loads(gzip.decompress(out.read_bytes())) == env
+
+
+# ── frontmatter shim ─────────────────────────────────────────────────────────
+
+class TestDocTypeOf:
+    def test_schema_c_precedence(self):
+        assert doc_type_of({'content_type': 'Timeline', 'type': 'lore'}) == 'timeline'
+
+    def test_doc_type_fallback(self):
+        assert doc_type_of({'doc_type': 'canon'}) == 'canon'
+
+    def test_legacy_fallback(self):
+        assert doc_type_of({'type': 'myth'}) == 'myth'
+
+    def test_empty(self):
+        assert doc_type_of({}) == ''
+
+
+# ── md → pm: GM constructs by audience ───────────────────────────────────────
+
+class TestGmMapping:
+    @pytest.fixture(scope='class')
+    def fixture_body(self):
+        _, body = parse_frontmatter(FIXTURE_MD.read_text())
+        return body
+
+    def _secrets(self, nodes):
+        found = []
+        def walk(n):
+            if isinstance(n, dict):
+                if n.get('type') == 'bodiedExtension':
+                    found.append(n)
+                for v in n.values():
+                    walk(v)
+            elif isinstance(n, list):
+                for v in n:
+                    walk(v)
+        walk(nodes)
+        return found
+
+    def test_gm_mode_secret_blocks_and_titles(self, fixture_body):
+        res = _convert(fixture_body, 'gm')
+        titles = [s['attrs']['parameters']['extensionTitle']
+                  for s in self._secrets(res.nodes)]
+        assert 'GM' in titles                                   # Tier 2 no id
+        assert 'GM id=fixture-1' in titles                      # Tier 2 with id
+        assert any(t.startswith('GM embed: gm_secrets/') for t in titles)  # Tier 3
+        assert 'GM comment' in titles                           # %% block
+
+    def test_gm_mode_tier1_passthrough(self, fixture_body):
+        res = _convert(fixture_body, 'gm')
+        text = json.dumps(res.nodes)
+        assert '{gm:Sylaveth Vorn}' in text
+        assert '██████' not in text
+
+    def test_player_mode_purity(self, fixture_body):
+        res = _convert(fixture_body, 'player')
+        text = json.dumps(res.nodes, ensure_ascii=False)
+        assert 'Sylaveth' not in text
+        assert 'block-secret' not in text
+        assert 'gm_secrets' not in text
+        assert 'containment failure' not in text                # Tier 2 stripped
+        assert 'invisible to players' not in text               # %% stripped
+        assert '██████' in text                                 # Tier 1 redaction bar
+
+    def test_tier3_marker_only_never_inlines(self, fixture_body):
+        res = _convert(fixture_body, 'gm')
+        embeds = [s for s in self._secrets(res.nodes)
+                  if s['attrs']['parameters']['extensionTitle'].startswith('GM embed')]
+        assert embeds
+        assert 'lives in vault file' in json.dumps(embeds[0]['content'])
+
+
+# ── md → pm: general constructs ──────────────────────────────────────────────
+
+class TestMdToPm:
+    def test_heading_and_para(self):
+        res = _convert('# Title\n\nBody text.', 'gm')
+        assert res.nodes[0]['type'] == 'heading'
+        assert res.nodes[1]['type'] == 'paragraph'
+
+    def test_table(self):
+        res = _convert('| A | B |\n|---|---|\n| 1 | 2 |', 'gm')
+        tables = [n for n in res.nodes if n['type'] == 'table']
+        assert len(tables) == 1
+        assert tables[0]['content'][0]['content'][0]['type'] == 'tableHeader'
+
+    def test_tasklist(self):
+        res = _convert('- [ ] open\n- [x] done', 'gm')
+        tl = res.nodes[0]
+        assert tl['type'] == 'taskList'
+        states = [i['attrs']['state'] for i in tl['content']]
+        assert states == ['TODO', 'DONE']
+
+    def test_skip_fences_warn(self):
+        res = _convert('```leaflet\nid: map\n```', 'gm')
+        assert res.nodes == []
+        assert any('leaflet' in w for w in res.warnings)
+
+    def test_callout_maps_to_panel(self):
+        res = _convert('> [!tip]\n> Useful.', 'gm')
+        assert res.nodes[0]['type'] == 'panel'
+        assert res.nodes[0]['attrs']['panelType'] == 'success'
+
+    def test_wikilink_resolution(self):
+        def resolver(target):
+            return ('abcd1234', 'Target Page') if target == 'target' else None
+        res = md_to_pm.convert('See [[target|the page]] and [[missing]].',
+                               audience='gm', resolve_link=resolver, source='t')
+        para = res.nodes[0]['content']
+        mentions = [n for n in para if n['type'] == 'mention']
+        assert len(mentions) == 1
+        assert mentions[0]['attrs']['alias'] == 'the page'
+        assert any(n.get('text') == 'missing' for n in para)    # degraded
+
+
+# ── pm → md and full offline round-trip ─────────────────────────────────────
+
+class TestRoundTrip:
+    def test_pm_to_md_reconstructs_gm_syntax(self):
+        nodes = [
+            lk.secret_block([lk.para('hidden fact')], 'GM id=x1'),
+            lk.secret_block([lk.para('aside')], 'GM comment'),
+            lk.secret_block([lk.para('marker')], 'GM embed: gm_secrets/deed.md'),
+        ]
+        md = pm_to_md.doc_to_markdown({'type': 'doc', 'content': nodes}, {})
+        assert '> [!gm-only id=x1]' in md
+        assert '%%\naside\n%%' in md
+        assert '![[gm_secrets/deed]]' in md
+        assert 'marker' not in md                # Tier 3 content discarded
+
+    def test_fixture_survives_md_pm_md(self):
+        _, body = parse_frontmatter(FIXTURE_MD.read_text())
+        res = _convert(body, 'gm')
+        md = pm_to_md.doc_to_markdown({'type': 'doc', 'content': res.nodes}, {})
+        # the constructs the HTML pipeline parses must reconstruct exactly
+        assert '{gm:Sylaveth Vorn}' in md
+        assert '> [!gm-only id=fixture-1]' in md
+        assert '![[gm_secrets/heroes_original_deed]]' in md
+        assert '%%' in md
+        assert '- [ ] open task' in md
+        assert '- [x] done task' in md
+
+    def test_cli_roundtrip_on_real_file(self, tmp_path):
+        """to_lk → from_lk on the flagship real file; verify Tier 2 count survives."""
+        src = REPO / 'narrative' / 'lore' / 'liberation_aftermath.md'
+        if not src.exists():
+            pytest.skip('vault content file not present')
+        out_json = tmp_path / 'rt.json'
+        r1 = subprocess.run(
+            [sys.executable, str(BRIDGE / 'to_lk.py'), str(src),
+             '--audience', 'gm', '-o', str(out_json),
+             '--manifest', str(tmp_path / 'manifest.json')],
+            capture_output=True, text=True)
+        assert r1.returncode == 0, r1.stderr
+        r2 = subprocess.run(
+            [sys.executable, str(BRIDGE / 'from_lk.py'), str(out_json),
+             '--out', str(tmp_path / 'back'),
+             '--manifest', str(tmp_path / 'manifest.json')],
+            capture_output=True, text=True)
+        assert r2.returncode == 0, r2.stderr
+        back = next((tmp_path / 'back').rglob('liberation_aftermath.md'))
+        src_count = src.read_text().count('[!gm-only')
+        assert back.read_text().count('[!gm-only') == src_count
+
+    def test_from_lk_refuses_vault_content_out(self, tmp_path):
+        r = subprocess.run(
+            [sys.executable, str(BRIDGE / 'from_lk.py'), 'x.json',
+             '--out', str(REPO / 'world' / 'nope')],
+            capture_output=True, text=True)
+        assert r.returncode != 0
+        assert 'REFUSED' in (r.stdout + r.stderr)
+
+
+# ── player-export purity at the CLI level ────────────────────────────────────
+
+class TestPlayerExportCli:
+    def test_player_export_excludes_gm_pages(self, tmp_path):
+        fixture_gm = tmp_path / 'gm_secrets'
+        fixture_gm.mkdir()
+        (fixture_gm / 'secret_page.md').write_text(
+            '---\ntitle: Secret\nvisibility: gm_secrets\n---\n# Hidden\n')
+        pub = tmp_path / 'public_page.md'
+        pub.write_text('---\ntitle: Pub\nvisibility: public\n---\n# Open {gm:X}\n')
+        out = tmp_path / 'player.json'
+        r = subprocess.run(
+            [sys.executable, str(BRIDGE / 'to_lk.py'),
+             str(pub), str(fixture_gm / 'secret_page.md'),
+             '--audience', 'player', '-o', str(out),
+             '--manifest', str(tmp_path / 'm.json')],
+            capture_output=True, text=True)
+        assert r.returncode == 0, r.stderr
+        data = json.loads(out.read_text())
+        text = json.dumps(data, ensure_ascii=False)
+        names = [res['name'] for res in data['resources']]
+        assert 'Secret' not in names
+        assert '{gm:' not in text
+        assert '██████' in text

--- a/utilities/legendkeeper-pipeline/from_lk_json.py
+++ b/utilities/legendkeeper-pipeline/from_lk_json.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
 """
-LK JSON → Source Markdown Converter
+LK JSON → Source Markdown Converter  [LEGACY — timelines only]
 =====================================
 Converts a LegendKeeper JSON export (timeline) back to the canonical
 Obsidian source format understood by the publishing pipeline.
+
+LEGACY NOTICE (2026-07-03): this script emits pre-Schema-C frontmatter
+(``type: timeline``) and handles timeline documents only. Prose pages are
+handled by the superseding bridge in ``utilities/lk-bridge/`` (``from_lk.py``),
+which emits Schema C frontmatter. Timeline re-import is out of scope for the
+bridge's first round; when it is migrated, this script retires. See GH #213.
 
 Usage:
     python from_lk_json.py Timeline_Export.json

--- a/utilities/legendkeeper-pipeline/generate_lk_json.py
+++ b/utilities/legendkeeper-pipeline/generate_lk_json.py
@@ -25,6 +25,7 @@ Usage:
 """
 
 import re
+import sys
 import json
 import gzip
 import hashlib
@@ -32,6 +33,10 @@ import argparse
 from pathlib import Path
 from datetime import datetime, timezone
 from uuid import uuid4
+
+# Make utilities/shared importable regardless of working directory
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from shared.frontmatter import doc_type_of
 
 try:
     import yaml
@@ -482,7 +487,7 @@ def main() -> None:
 
     raw = src.read_text(encoding='utf-8')
     fm, body = parse_frontmatter(raw)
-    doc_type = fm.get('type', '').lower()
+    doc_type = doc_type_of(fm)  # Schema C aware (content_type → doc_type → legacy type)
 
     if doc_type == 'timeline':
         export = build_timeline_json(fm, body)

--- a/utilities/legendkeeper-pipeline/generate_lk_markdown.py
+++ b/utilities/legendkeeper-pipeline/generate_lk_markdown.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 # Make utilities/shared importable regardless of working directory
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from shared.frontmatter import parse_frontmatter
+from shared.frontmatter import parse_frontmatter, doc_type_of
 from shared.md_utils import (
     extract_secret_blocks,
     strip_wikilinks,
@@ -172,7 +172,7 @@ def main() -> None:
 
     raw = src.read_text(encoding='utf-8')
     fm, body = parse_frontmatter(raw)
-    doc_type = fm.get('type', '').lower()
+    doc_type = doc_type_of(fm)  # Schema C aware (content_type → doc_type → legacy type)
 
     if doc_type in ('myth', 'fable', 'lore', 'page'):
         result = generate_myth_md(fm, body)

--- a/utilities/lk-bridge/README.md
+++ b/utilities/lk-bridge/README.md
@@ -1,0 +1,108 @@
+# LK Bridge — Obsidian vault ↔ LegendKeeper
+
+Bidirectional conversion between the Tarim-Shaiel vault (Schema C Markdown)
+and LegendKeeper import/export JSON. Supersedes `utilities/legendkeeper-pipeline/`
+for prose pages (that pipeline remains authoritative for timelines only).
+
+Spec and findings log: [GH #213](https://github.com/mofro/tarim-shaiel-campaign-frame/issues/213).
+Format provenance: [schemas/SOURCE.md](schemas/SOURCE.md).
+
+## Status: interim (no LK API)
+
+LK has no public API. Imports always create new resources (IDs are minted per
+import; they are stable database keys thereafter — they survive rewrites and
+renames, proven 2026-07-03). Until the API ships:
+
+- **The LK project is a disposable build artifact** — like `docs/`. Resync =
+  delete vault-managed resources in the LK UI → re-import → `manifest.py build`
+  on the fresh re-export.
+- Hand-edits inside LK are lost on resync unless captured first with
+  `from_lk.py` and merged into the vault manually. **The vault is the single
+  source of truth.**
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `to_lk.py` | Vault files/directories → LK import file (`.json` / `.lk`) |
+| `from_lk.py` | LK export → Schema C Markdown (scratch dir only — refuses vault content roots) |
+| `validate_lk.py` | Offline validation: envelope schema + LK-dialect content schema + semantic checks |
+| `manifest.py` | Capture real LK resource IDs from a re-export into `lk_manifest.json` |
+| `lk_schema.py` | LK JSON builders (library) |
+| `md_to_pm.py` / `pm_to_md.py` | Markdown ↔ ProseMirror converters (library) |
+| `generate_stub_test.py` | Minimal 3-resource stub for importer probing (legacy shape, uses `lk_schema`) |
+
+```bash
+# full narrative+world GM mirror
+python utilities/lk-bridge/to_lk.py narrative world --audience gm --lk \
+    -o utilities/lk-bridge/roundtrip/full-gm.json
+
+# arbitrary files, player-safe
+python utilities/lk-bridge/to_lk.py narrative/lore/The\ Roads.md \
+    --audience player -o utilities/lk-bridge/roundtrip/roads.json
+
+python utilities/lk-bridge/validate_lk.py utilities/lk-bridge/roundtrip/full-gm.json
+python utilities/lk-bridge/from_lk.py <lk-reexport.json> --out utilities/lk-bridge/roundtrip/post-lk/
+python utilities/lk-bridge/manifest.py build <lk-reexport.json>
+```
+
+## Secrets mapping (vault ↔ LK)
+
+`--audience player` (public-HTML parity) vs `--audience gm` (full mirror,
+default). The round-trip discriminator is `parameters.extensionTitle` on
+LK's `block-secret` extension.
+
+| Vault construct | player | gm (→ LK) | reverse (LK → vault) |
+|---|---|---|---|
+| `visibility: gm_secrets` file | excluded | resource `isHidden: true` + tag `gm-secret` | hidden/tagged → `visibility: gm_secrets` |
+| Tier 1 `{gm:text}` | `██████` literal | `{gm:text}` literal passthrough | verbatim |
+| Tier 2 `> [!gm-only id=x]` | stripped | `block-secret` title `GM` / `GM id=x` | title `GM*` → callout, id restored |
+| Tier 3 `![[gm_secrets/f]]` | stripped | `block-secret` title `GM embed: <path>`, **marker only — never inlined** | title → `![[path]]`, inner content discarded |
+| `%%…%%` | stripped | `block-secret` title `GM comment` | title → `%%…%%` |
+| LK-authored secret (title `Secret` etc.) | — | — | `> [!gm-only]` |
+
+Round-trip safety: Tier 3 is marker-only and Tier 1 is passthrough, so
+vault→LK(gm)→vault reconstructs the exact syntax the HTML pipeline parses.
+A stray unpaired `%%` in prose swallows text to the next `%%` — same behavior
+as Obsidian itself.
+
+## Scope rules (directory mode)
+
+- Non-`.md` files: never picked up
+- `Index.md` / `_category.md`: skipped (navigation + dataview)
+- `world/abilities/`, `world/classes/`: default-excluded SRD reference data
+  (`--include-all` to include)
+- Old-schema (pre-Schema-C) files: tolerated; counted in the run summary
+
+## Quirk verdicts (whole-vault census 2026-07-03, GH #213)
+
+| Construct | Handling |
+|---|---|
+| ```` ```leaflet ```` (35 location files) | skip + warning — future: LK native `map` doc type |
+| audio embeds | italic `♪ label` + warning (CDN upload is API-gated) |
+| image embeds `![[x.png]]` | skip + warning (same) — external `![](url)` maps to media |
+| ```` ```dataview ```` / ```` ```mermaid ```` | skip + warning |
+| other fences (incl. ```` ```daggerheart ````) | code-marked paragraphs (LK block-code node unverified) |
+| `[[x#heading]]` | mention to page, anchor dropped + warning |
+| section/note transclusions (non-GM) | mention link, not inlined |
+| `==highlight==` / `~~strike~~` | em / plain + warning (LK marks: strong·em·code·link only) |
+| nested sub-lists | flatten to sibling items (known limitation) |
+
+## Manual round-trip protocol
+
+1. Generate + validate (see commands above); import the **small fixture export
+   first**, then the full one, into a **scratch LK project**
+2. In LK verify: no import hang; tree structure; mentions click through;
+   secret blocks render collapsed; hidden resources arrive hidden (**open
+   question — isHidden import preservation**)
+3. Re-export from LK → save under `roundtrip/`; run `from_lk.py` on it and
+   diff against sources; grep the re-export for `extensionTitle` values
+   (**open question — custom title survival**)
+4. `manifest.py build <re-export>` → captures real IDs
+5. **Retarget probe**: `to_lk.py` a single new page containing a `mention`
+   whose id is a real ID from the manifest; import into the same project;
+   click the link (**open question — cross-import mention retargeting**)
+6. Author a code block in LK, re-export, capture the node shape
+   (**open question — block-level code node**)
+
+Record all four verdicts in GH #213.

--- a/utilities/lk-bridge/from_lk.py
+++ b/utilities/lk-bridge/from_lk.py
@@ -31,7 +31,22 @@ sys.path.insert(0, str(BRIDGE_DIR))
 import pm_to_md
 
 CONTENT_ROOTS = ('world', 'narrative', 'mechanics', 'characters', 'templates')
-SKIP_TAGS = {'section', 'lk-bridge'}      # bridge-generated scaffolding resources
+HUB_MARKER = 'Generated from vault by lk-bridge'
+
+
+def is_scaffolding(resource: dict) -> bool:
+    """Bridge-generated hub/section resources — never real vault content.
+
+    Sections carry the 'section' tag; the hub is identified by its generated
+    marker text, NOT by the 'lk-bridge' tag alone (real vault pages may
+    legitimately carry that tag — e.g. the GM-constructs fixture)."""
+    tags = set(resource.get('tags') or [])
+    if 'section' in tags:
+        return True
+    if 'lk-bridge' in tags:
+        text = json.dumps(resource.get('documents') or [])
+        return HUB_MARKER in text
+    return False
 
 
 def load_export(path: Path) -> dict:
@@ -88,7 +103,7 @@ def main() -> None:
 
     for r in export.get('resources', []):
         tags = r.get('tags') or []
-        if not args.include_scaffolding and (set(tags) & SKIP_TAGS):
+        if not args.include_scaffolding and is_scaffolding(r):
             skipped += 1
             continue
         pages = [d for d in r.get('documents', [])
@@ -109,7 +124,7 @@ def main() -> None:
         else:
             rel_out = Path(slugify(r['name']) + '.md')
 
-        content_tags = [t for t in tags if t not in SKIP_TAGS and t != 'gm-secret']
+        content_tags = [t for t in tags if t not in ('section', 'gm-secret')]
         fm_lines = [
             '---',
             f'title: "{r["name"]}"',

--- a/utilities/lk-bridge/from_lk.py
+++ b/utilities/lk-bridge/from_lk.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+LegendKeeper export → Schema C Markdown files.
+
+Usage:
+    python utilities/lk-bridge/from_lk.py roundtrip/lk-reexport.json \
+        --out roundtrip/post-lk/
+
+Safety: REFUSES to write inside vault content roots (world/, narrative/,
+mechanics/, characters/, templates/) — output goes to a scratch directory and
+is merged into the vault by a human, never by this tool.
+
+Frontmatter: emits Schema C (never legacy ``type:``). When a manifest
+(lk_manifest.json) maps the resource back to a vault path, the original path
+and gm-flag are honored; otherwise defaults apply (domain: narrative,
+doc_type: canon, content_type: lore, status: draft).
+"""
+
+import re
+import sys
+import json
+import gzip
+import argparse
+from datetime import date
+from pathlib import Path
+
+BRIDGE_DIR = Path(__file__).parent
+VAULT = BRIDGE_DIR.parent.parent
+sys.path.insert(0, str(BRIDGE_DIR))
+
+import pm_to_md
+
+CONTENT_ROOTS = ('world', 'narrative', 'mechanics', 'characters', 'templates')
+SKIP_TAGS = {'section', 'lk-bridge'}      # bridge-generated scaffolding resources
+
+
+def load_export(path: Path) -> dict:
+    raw = path.read_bytes()
+    if raw[:2] == b'\x1f\x8b':
+        raw = gzip.decompress(raw)
+    return json.loads(raw)
+
+
+def safe_out_dir(out: Path) -> Path:
+    out = out.resolve()
+    for root in CONTENT_ROOTS:
+        content_root = (VAULT / root).resolve()
+        if out == content_root or out.is_relative_to(content_root):
+            sys.exit(f"REFUSED: --out {out} is inside vault content root {content_root}. "
+                     f"Write to a scratch directory and merge manually.")
+    return out
+
+
+def slugify(name: str) -> str:
+    slug = re.sub(r'[^\w\- ]+', '', name).strip().replace(' ', '_')
+    return slug or 'untitled'
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="LK export → Schema C Markdown")
+    ap.add_argument('export_file')
+    ap.add_argument('--out', required=True, help="Scratch output directory")
+    ap.add_argument('--manifest', default=str(BRIDGE_DIR / 'lk_manifest.json'))
+    ap.add_argument('--include-scaffolding', action='store_true',
+                    help="Also emit bridge-generated hub/section resources")
+    args = ap.parse_args()
+
+    out_dir = safe_out_dir(Path(args.out))
+    export = load_export(Path(args.export_file))
+
+    manifest = {}
+    mpath = Path(args.manifest)
+    if mpath.exists():
+        try:
+            manifest = json.loads(mpath.read_text())
+        except Exception:
+            pass
+    # provisional-ID → vault rel path (from to_lk run); lkId → path (post-capture)
+    id_to_vaultpath = {}
+    for rel, entry in (manifest.get('resources') or {}).items():
+        for key in ('provisionalId', 'lkId'):
+            if entry.get(key):
+                id_to_vaultpath[entry[key]] = rel
+
+    id_to_name = {r['id']: r['name'] for r in export.get('resources', [])}
+    today = date.today().isoformat()
+    written, skipped = 0, 0
+
+    for r in export.get('resources', []):
+        tags = r.get('tags') or []
+        if not args.include_scaffolding and (set(tags) & SKIP_TAGS):
+            skipped += 1
+            continue
+        pages = [d for d in r.get('documents', [])
+                 if d.get('type') == 'page' and (d.get('content') or {}).get('type')]
+        if not pages:
+            skipped += 1
+            continue
+
+        body = '\n\n'.join(
+            pm_to_md.doc_to_markdown(d['content'], id_to_name) for d in pages).strip()
+
+        gm = bool(r.get('isHidden')) or 'gm-secret' in tags
+        vault_rel = id_to_vaultpath.get(r['id'])
+        if vault_rel:
+            rel_out = Path(vault_rel)
+            entry = (manifest.get('resources') or {}).get(vault_rel, {})
+            gm = gm or entry.get('gm', False)
+        else:
+            rel_out = Path(slugify(r['name']) + '.md')
+
+        content_tags = [t for t in tags if t not in SKIP_TAGS and t != 'gm-secret']
+        fm_lines = [
+            '---',
+            f'title: "{r["name"]}"',
+            'project: TTRPG_Tarim_Shaiel',
+            f'domain: {content_tags[0] if content_tags else "narrative"}',
+            'doc_type: canon',
+            f'content_type: {content_tags[1] if len(content_tags) > 1 else "lore"}',
+            f'visibility: {"gm_secrets" if gm else "public"}',
+            'status: draft',
+            f'created: {today}',
+            f'last_updated: {today}',
+            f'tags: [{", ".join(content_tags[2:])}]',
+            f'lk_id: {r["id"]}',
+            '---',
+            '',
+        ]
+        target = out_dir / rel_out
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text('\n'.join(fm_lines) + body + '\n')
+        written += 1
+
+    print(f"Wrote {written} file(s) to {out_dir} ({skipped} scaffolding/empty skipped)")
+
+
+if __name__ == '__main__':
+    main()

--- a/utilities/lk-bridge/generate_stub_test.py
+++ b/utilities/lk-bridge/generate_stub_test.py
@@ -20,87 +20,20 @@ import json
 import gzip
 import hashlib
 import argparse
+import sys
 from pathlib import Path
-from datetime import datetime, timezone
 
-NOW = datetime.now(timezone.utc).isoformat(timespec='milliseconds').replace('+00:00', 'Z')
+# Builders now live in the shared lk_schema library (extracted 2026-07-03)
+sys.path.insert(0, str(Path(__file__).parent))
+from lk_schema import doc, resource, heading, para, text, mention
 
-
-def doc(doc_id: str, content_nodes: list, name: str = "Main") -> dict:
-    return {
-        "id": doc_id,
-        "pos": "Q",
-        "createdAt": NOW,
-        "updatedAt": NOW,
-        "locatorId": f"document:{doc_id}",
-        "name": name,
-        "type": "page",
-        "isHidden": False,
-        "isFullWidth": False,
-        "isFirst": True,
-        "transforms": [],
-        "sources": [],
-        "presentation": {"documentType": "page"},
-        "content": {
-            "type": "doc",
-            "content": content_nodes,
-        },
-    }
-
-
-def resource(res_id: str, name: str, parent_id: str, docs: list,
-             tags: list = None, pos: str = "Q") -> dict:
-    return {
-        "schemaVersion": 1,
-        "aliases": [],
-        "banner": {"enabled": False, "url": "", "yPosition": 50},
-        "createdBy": "",
-        "iconColor": "#FFFFFF",
-        "iconGlyph": "fas fa-book",
-        "iconShape": "pin-icon",
-        "id": res_id,
-        "isHidden": False,
-        "isLocked": False,
-        "name": name,
-        "parentId": parent_id,
-        "pos": pos,
-        "properties": [],
-        "showPropertyBar": False,
-        "tags": tags or [],
-        "documents": docs,
-    }
-
-
-def heading(text: str, level: int = 1) -> dict:
-    return {"type": "heading", "attrs": {"level": level},
-            "content": [{"type": "text", "text": text}]}
-
-
-def para(*inline) -> dict:
-    return {"type": "paragraph", "content": list(inline)}
-
-
-def text(t: str) -> dict:
-    return {"type": "text", "text": t}
-
-
-def mention(res_id: str, name: str) -> dict:
-    return {"type": "mention",
-            "attrs": {"id": res_id, "text": name, "alias": "",
-                      "accessLevel": "", "userType": ""}}
+NOW = None  # timestamps now handled by lk_schema.now_iso()
 
 
 def secret_block(*inner_nodes) -> dict:
-    return {
-        "type": "bodiedExtension",
-        "attrs": {
-            "extensionType": "com.algorific.legendkeeper.extensions",
-            "extensionKey": "block-secret",
-            "parameters": {"extensionTitle": "Secret"},
-            "layout": "default",
-        },
-        "content": list(inner_nodes),
-    }
+    """Stub-test flavor: LK's default 'Secret' title (legacy call shape)."""
+    from lk_schema import secret_block as _sb
+    return _sb(list(inner_nodes), title="Secret")
 
 
 def build() -> dict:

--- a/utilities/lk-bridge/lk_schema.py
+++ b/utilities/lk-bridge/lk_schema.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+LK export-format builders — the executable embodiment of the reverse-engineered
+LegendKeeper JSON schema (GH #213).
+
+Facts this module encodes (verified 2026-05 round-trip + 2026-07-03 baseline diff
+against the post-rewrite export):
+
+* Envelope: {version, exportId, exportedAt, resources, calendars, resourceCount,
+  hash}. The hash LK writes uses an unknown algorithm, and LK does NOT verify
+  the field on import — we emit a deterministic SHA-256 over the sorted payload
+  purely as a self-consistency fingerprint.
+* ``presentation`` must be ``{"documentType": "page"}`` — ``null`` hangs the
+  LK importer.
+* LK reassigns all resource IDs on import (mentions are remapped within one
+  import); pre-assigned IDs here are provisional.
+* Content is Atlassian-ADF-dialect ProseMirror. Marks may carry ``attrs: {}``;
+  mentions carry a ``documentId`` attr; GM sections use ``bodiedExtension``
+  with extensionKey ``block-secret``.
+* ``.lk`` files are gzip-compressed JSON, byte-identical schema.
+"""
+
+import gzip
+import json
+import hashlib
+import string
+from datetime import datetime, timezone
+
+LK_EXTENSION_TYPE = "com.algorific.legendkeeper.extensions"
+_B36 = string.digits + string.ascii_lowercase
+
+
+def now_iso() -> str:
+    """LK-style UTC timestamp: millisecond precision, Z suffix."""
+    return datetime.now(timezone.utc).isoformat(timespec='milliseconds').replace('+00:00', 'Z')
+
+
+def short_id(seed: str) -> str:
+    """Deterministic 8-char base36 ID from a seed string (LK ID format).
+
+    Deterministic so repeated exports of the same vault path produce the same
+    provisional ID — LK reassigns on import anyway, but stable provisional IDs
+    keep diffs quiet and internal mentions consistent.
+    """
+    digest = int.from_bytes(hashlib.sha256(seed.encode()).digest()[:8], 'big')
+    chars = []
+    for _ in range(8):
+        digest, rem = divmod(digest, 36)
+        chars.append(_B36[rem])
+    return ''.join(chars)
+
+
+# ── inline nodes / marks ─────────────────────────────────────────────────────
+
+def text(t: str, marks: list | None = None) -> dict:
+    node = {"type": "text", "text": t}
+    if marks:
+        node["marks"] = marks
+    return node
+
+
+def mark(kind: str) -> dict:
+    """strong | em | code — LK emits empty attrs on marks; mirror that."""
+    return {"type": kind, "attrs": {}}
+
+
+def link_mark(href: str) -> dict:
+    return {"type": "link", "attrs": {"href": href, "__confluenceMetadata": None}}
+
+
+def mention(res_id: str, name: str, alias: str = "") -> dict:
+    """Internal page link. LK remaps ``id`` within one import.
+
+    ``documentId`` is included for fidelity with LK's own output (2026-07-03
+    baseline: LK adds it on round-trip).
+    """
+    return {"type": "mention",
+            "attrs": {"id": res_id, "text": name, "alias": alias,
+                      "accessLevel": "", "userType": "", "documentId": ""}}
+
+
+def hard_break() -> dict:
+    return {"type": "hardBreak"}
+
+
+# ── block nodes ──────────────────────────────────────────────────────────────
+
+def heading(inline: list | str, level: int = 1) -> dict:
+    content = [text(inline)] if isinstance(inline, str) else inline
+    return {"type": "heading", "attrs": {"level": level}, "content": content}
+
+
+def para(*inline) -> dict:
+    node = {"type": "paragraph"}
+    flat = [text(i) if isinstance(i, str) else i for i in inline]
+    if flat:
+        node["content"] = flat
+    return node
+
+
+def rule() -> dict:
+    return {"type": "rule"}
+
+
+def blockquote(*blocks) -> dict:
+    return {"type": "blockquote", "content": list(blocks)}
+
+
+def bullet_list(items: list) -> dict:
+    return {"type": "bulletList", "content": [list_item(i) for i in items]}
+
+
+def ordered_list(items: list) -> dict:
+    return {"type": "orderedList", "content": [list_item(i) for i in items]}
+
+
+def list_item(blocks) -> dict:
+    if isinstance(blocks, dict):
+        blocks = [blocks]
+    return {"type": "listItem", "content": blocks}
+
+
+def task_list(items: list) -> dict:
+    """items: list of (checked: bool, inline_nodes: list)."""
+    return {"type": "taskList",
+            "content": [{"type": "taskItem",
+                         "attrs": {"state": "DONE" if done else "TODO"},
+                         "content": inline}
+                        for done, inline in items]}
+
+
+def panel(panel_type: str, *blocks) -> dict:
+    """LK callout. panelType: info | note | warning | success."""
+    return {"type": "panel", "attrs": {"panelType": panel_type}, "content": list(blocks)}
+
+
+def table(rows: list, header_row: bool = True) -> dict:
+    """rows: list of list of cell-block-lists (each cell = list of block nodes)."""
+    trows = []
+    for i, row in enumerate(rows):
+        cell_type = "tableHeader" if (header_row and i == 0) else "tableCell"
+        cells = [{"type": cell_type, "attrs": {"colspan": 1, "rowspan": 1},
+                  "content": cell} for cell in row]
+        trows.append({"type": "tableRow", "content": cells})
+    return {"type": "table",
+            "attrs": {"isNumberColumnEnabled": False, "layout": "default", "__autoSize": False},
+            "content": trows}
+
+
+def media_external(url: str) -> dict:
+    """External-URL image (no CDN upload path without the API)."""
+    return {"type": "mediaSingle", "attrs": {"layout": "center"},
+            "content": [{"type": "media",
+                         "attrs": {"id": "", "type": "file", "collection": "",
+                                   "__external": True, "url": url}}]}
+
+
+def secret_block(inner_blocks: list, title: str = "Secret") -> dict:
+    """GM-only section — LK's single native secret mechanism.
+
+    ``title`` doubles as the round-trip discriminator channel (see the
+    secrets mapping table in README.md): "GM", "GM id=x", "GM comment",
+    "GM embed: <path>".
+    """
+    return {"type": "bodiedExtension",
+            "attrs": {"extensionType": LK_EXTENSION_TYPE,
+                      "extensionKey": "block-secret",
+                      "parameters": {"extensionTitle": title},
+                      "layout": "default"},
+            "content": inner_blocks}
+
+
+# ── documents / resources / envelope ─────────────────────────────────────────
+
+def doc(doc_id: str, content_nodes: list, name: str = "Main") -> dict:
+    ts = now_iso()
+    return {"id": doc_id, "pos": "Q", "createdAt": ts, "updatedAt": ts,
+            "locatorId": f"document:{doc_id}", "name": name, "type": "page",
+            "isHidden": False, "isFullWidth": False, "isFirst": True,
+            "transforms": [], "sources": [],
+            "presentation": {"documentType": "page"},   # null hangs the importer
+            "content": {"type": "doc", "content": content_nodes}}
+
+
+def resource(res_id: str, name: str, parent_id: str, docs: list, *,
+             tags: list | None = None, pos: str = "Q",
+             is_hidden: bool = False, icon_glyph: str = "fas fa-book") -> dict:
+    return {"schemaVersion": 1, "aliases": [],
+            "banner": {"enabled": False, "url": "", "yPosition": 50},
+            "createdBy": "", "iconColor": "#FFFFFF", "iconGlyph": icon_glyph,
+            "iconShape": "pin-icon", "id": res_id, "isHidden": is_hidden,
+            "isLocked": False, "name": name, "parentId": parent_id, "pos": pos,
+            "properties": [], "showPropertyBar": False, "tags": tags or [],
+            "documents": docs}
+
+
+def envelope(resources: list, export_id: str = "lkbridge") -> dict:
+    """Assemble the export envelope with a self-consistency hash.
+
+    The hash is OUR deterministic fingerprint (SHA-256, sorted compact JSON,
+    hash field excluded) — NOT LK's algorithm, which is unknown. LK does not
+    verify this field on import (proven 2026-05, re-confirmed 2026-07-03).
+    """
+    export = {"version": 1, "exportId": export_id, "exportedAt": now_iso(),
+              "resources": resources, "calendars": [],
+              "resourceCount": len(resources), "hash": ""}
+    payload = {k: v for k, v in export.items() if k != "hash"}
+    export["hash"] = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    return export
+
+
+def write_export(export: dict, out_path, as_lk: bool = False) -> None:
+    """Write plain .json, or gzip .lk when as_lk is True."""
+    data = json.dumps(export, separators=(",", ":"), ensure_ascii=False)
+    if as_lk:
+        out_path.write_bytes(gzip.compress(data.encode()))
+    else:
+        out_path.write_text(json.dumps(export, indent=2, ensure_ascii=False))

--- a/utilities/lk-bridge/manifest.py
+++ b/utilities/lk-bridge/manifest.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+LK resource-ID manifest tooling.
+
+``build``: capture real LK resource IDs from an LK re-export into
+lk_manifest.json, matching by resource name against the provisional entries
+written by to_lk.py.
+
+    python utilities/lk-bridge/manifest.py build roundtrip/lk-reexport.json
+
+ID semantics (proven 2026-07-03): LK resource IDs are stable database keys —
+they survive application rewrites and renames — but every IMPORT mints new
+IDs. The manifest is therefore valid per LK-project generation; the
+``generation.exportId`` field is the staleness guard.
+"""
+
+import sys
+import json
+import gzip
+import argparse
+from pathlib import Path
+
+BRIDGE_DIR = Path(__file__).parent
+MANIFEST_PATH = BRIDGE_DIR / 'lk_manifest.json'
+
+
+def load_export(path: Path) -> dict:
+    raw = path.read_bytes()
+    if raw[:2] == b'\x1f\x8b':
+        raw = gzip.decompress(raw)
+    return json.loads(raw)
+
+
+def build(export_file: str, manifest_path: Path) -> None:
+    export = load_export(Path(export_file))
+    if not manifest_path.exists():
+        sys.exit(f"No manifest at {manifest_path} — run to_lk.py first "
+                 f"(it writes the provisional entries).")
+    manifest = json.loads(manifest_path.read_text())
+
+    by_name = {}
+    for r in export.get('resources', []):
+        by_name.setdefault(r['name'], []).append(r['id'])
+
+    matched, ambiguous, missing = 0, [], []
+    for rel, entry in (manifest.get('resources') or {}).items():
+        name = entry.get('lkName', '')
+        ids = by_name.get(name, [])
+        if len(ids) == 1:
+            entry['lkId'] = ids[0]
+            matched += 1
+        elif len(ids) > 1:
+            ambiguous.append((rel, name, ids))
+        else:
+            missing.append((rel, name))
+
+    manifest['generation'] = {
+        'exportId': export.get('exportId'),
+        'capturedAt': export.get('exportedAt'),
+        'note': 'lkId values are real LK database keys for THIS project generation; '
+                'a delete+re-import mints new IDs and requires a fresh capture.',
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=1))
+
+    print(f"Manifest updated: {manifest_path}")
+    print(f"  matched: {matched}")
+    if ambiguous:
+        print(f"  AMBIGUOUS (same name, multiple LK resources) — resolve manually:")
+        for rel, name, ids in ambiguous[:10]:
+            print(f"    {rel} → {name!r}: {ids}")
+    if missing:
+        print(f"  missing from export: {len(missing)}")
+        for rel, name in missing[:10]:
+            print(f"    {rel} → {name!r}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="LK manifest tooling")
+    sub = ap.add_subparsers(dest='cmd', required=True)
+    b = sub.add_parser('build', help="Capture real LK IDs from a re-export")
+    b.add_argument('export_file')
+    b.add_argument('--manifest', default=str(MANIFEST_PATH))
+    args = ap.parse_args()
+    if args.cmd == 'build':
+        build(args.export_file, Path(args.manifest))
+
+
+if __name__ == '__main__':
+    main()

--- a/utilities/lk-bridge/md_to_pm.py
+++ b/utilities/lk-bridge/md_to_pm.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""
+Obsidian Markdown → LK ProseMirror (ADF-dialect) converter.
+
+Implements the vault↔LK mapping table (utilities/lk-bridge/README.md, GH #213),
+including the GM-secrets mapping switched by ``audience``:
+
+  audience="player": Tier 1 → ██████ literal; Tier 2 / Tier 3 / %%..%% stripped
+  audience="gm":     Tier 1 → literal passthrough; Tier 2 → block-secret "GM [id=x]";
+                     Tier 3 → block-secret "GM embed: <path>" (marker only);
+                     %%..%% → block-secret "GM comment"
+
+Quirk-audit verdicts (2026-07-03 census): leaflet/dataview/mermaid code fences
+skip with a warning; daggerheart fences render as code-marked paragraphs;
+unknown-target wikilinks degrade to plain text; image/audio embeds skip with a
+warning (CDN upload is API-gated); ==highlight==/~~strike~~ degrade to em/plain.
+
+Never writes any file — pure text → node-list transformation.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+import lk_schema as lk
+
+# fences whose content cannot execute in LK → skip with warning
+SKIP_FENCE_LANGS = {'leaflet', 'dataview', 'mermaid'}
+
+IMG_EXTS = {'.png', '.jpg', '.jpeg', '.webp', '.gif', '.svg'}
+AUDIO_EXTS = {'.mp3', '.wav', '.ogg', '.m4a', '.flac'}
+
+
+class ConversionResult:
+    def __init__(self, nodes: list, warnings: list):
+        self.nodes = nodes
+        self.warnings = warnings
+
+
+def convert(body: str, *, audience: str, resolve_link, source: str = "?") -> ConversionResult:
+    """Convert a Markdown body to a list of ProseMirror block nodes.
+
+    resolve_link(target: str) -> (res_id, name) | None
+        Maps a wikilink target (path or stem, no alias/anchor) to an export-set
+        resource. None → degrade to plain text.
+    """
+    warnings: list[str] = []
+
+    def warn(msg: str) -> None:
+        warnings.append(f"{source}: {msg}")
+
+    blocks = _split_blocks(body, audience, warn)
+    nodes: list[dict] = []
+    for kind, payload in blocks:
+        produced = _render_block(kind, payload, audience, resolve_link, warn)
+        nodes.extend(produced)
+    return ConversionResult(nodes, warnings)
+
+
+# ── block splitting ──────────────────────────────────────────────────────────
+
+def _split_blocks(body: str, audience: str, warn) -> list:
+    """Tokenize into (kind, payload) blocks; GM constructs isolated here."""
+    out = []
+    # 1. %%...%% comments (multiline + inline) — pull out before anything else
+    def _pct(m):
+        content = m.group(1).strip()
+        if content:
+            out_marker = f"\x00PCT{len(_pct_store)}\x00"
+            _pct_store.append(content)
+            return out_marker
+        return ''
+    _pct_store: list[str] = []
+    body = re.sub(r'%%(.*?)%%', _pct, body, flags=re.DOTALL)
+
+    # 2. fenced code blocks
+    fence_re = re.compile(r'^(```|~~~)([^\n`]*)\n(.*?)^\1\s*$\n?', re.M | re.S)
+    segments: list[tuple[str, object]] = []
+    pos = 0
+    for m in fence_re.finditer(body):
+        if m.start() > pos:
+            segments.append(('md', body[pos:m.start()]))
+        segments.append(('fence', (m.group(2).strip().lower(), m.group(3))))
+        pos = m.end()
+    segments.append(('md', body[pos:]))
+
+    # 3. within md segments: line-group parsing
+    for seg_kind, seg in segments:
+        if seg_kind == 'fence':
+            out.append(('fence', seg))
+            continue
+        lines = seg.split('\n')
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            stripped = line.strip()
+            if not stripped:
+                i += 1
+                continue
+            if stripped.startswith('\x00PCT'):
+                idx = int(stripped[4:-1])
+                out.append(('pct', _pct_store[idx]))
+                i += 1
+                continue
+            m = re.match(r'^#{1,6} ', stripped)
+            if m:
+                level = len(stripped) - len(stripped.lstrip('#'))
+                out.append(('heading', (min(level, 6), stripped[level:].strip())))
+                i += 1
+                continue
+            if re.match(r'^(---|\*\*\*|___)\s*$', stripped):
+                out.append(('hrule', None))
+                i += 1
+                continue
+            if stripped.startswith('>'):
+                # gather the quote/callout run
+                run = []
+                while i < len(lines) and lines[i].strip().startswith('>'):
+                    run.append(re.sub(r'^\s*>\s?', '', lines[i]))
+                    i += 1
+                head = run[0].strip() if run else ''
+                cm = re.match(r'^\[!([\w-]+)[+-]?\]\s*(?:id=(\S+))?\s*(.*)$', head)
+                if cm:
+                    out.append(('callout', (cm.group(1).lower(), cm.group(2) or '',
+                                            ([cm.group(3)] if cm.group(3) else []) + run[1:])))
+                else:
+                    out.append(('blockquote', run))
+                continue
+            if re.match(r'^\s*- \[[ xX/-]\] ', line):
+                run = []
+                while i < len(lines) and re.match(r'^\s*- \[[ xX/-]\] ', lines[i]):
+                    mm = re.match(r'^\s*- \[([ xX/-])\] (.*)$', lines[i])
+                    run.append((mm.group(1).lower() == 'x', mm.group(2)))
+                    i += 1
+                out.append(('tasklist', run))
+                continue
+            if re.match(r'^\s*[-*+] ', line):
+                run = []
+                while i < len(lines) and re.match(r'^\s*[-*+] ', lines[i]):
+                    run.append(re.sub(r'^\s*[-*+] ', '', lines[i]))
+                    i += 1
+                out.append(('bullets', run))
+                continue
+            if re.match(r'^\s*\d+\. ', line):
+                run = []
+                while i < len(lines) and re.match(r'^\s*\d+\. ', lines[i]):
+                    run.append(re.sub(r'^\s*\d+\. ', '', lines[i]))
+                    i += 1
+                out.append(('ordered', run))
+                continue
+            if stripped.startswith('|') and i + 1 < len(lines) \
+                    and re.match(r'^\|[\s:|-]+\|\s*$', lines[i + 1].strip()):
+                run = []
+                while i < len(lines) and lines[i].strip().startswith('|'):
+                    run.append(lines[i].strip())
+                    i += 1
+                out.append(('table', run))
+                continue
+            # standalone embed line?
+            if re.fullmatch(r'!\[\[[^\]]+\]\]', stripped):
+                out.append(('embed', stripped[3:-2]))
+                i += 1
+                continue
+            # paragraph: gather until blank/structural line
+            run = [line]
+            i += 1
+            while i < len(lines):
+                nxt = lines[i]
+                ns = nxt.strip()
+                if (not ns or ns.startswith(('>', '#', '|', '\x00PCT'))
+                        or re.match(r'^\s*([-*+]|\d+\.) ', nxt)
+                        or re.match(r'^(---|\*\*\*|___)\s*$', ns)
+                        or re.fullmatch(r'!\[\[[^\]]+\]\]', ns)):
+                    break
+                run.append(nxt)
+                i += 1
+            out.append(('para', ' '.join(l.strip() for l in run)))
+    return out
+
+
+# ── block rendering ──────────────────────────────────────────────────────────
+
+def _render_block(kind, payload, audience, resolve_link, warn) -> list:
+    gm = audience == 'gm'
+
+    if kind == 'heading':
+        level, txt = payload
+        return [lk.heading(_inline(txt, audience, resolve_link, warn), level)]
+
+    if kind == 'hrule':
+        return [lk.rule()]
+
+    if kind == 'para':
+        inline = _inline(payload, audience, resolve_link, warn)
+        return [lk.para(*inline)] if inline else []
+
+    if kind == 'blockquote':
+        paras = [lk.para(*_inline(l, audience, resolve_link, warn))
+                 for l in payload if l.strip()]
+        return [lk.blockquote(*paras)] if paras else []
+
+    if kind == 'callout':
+        ctype, cid, body_lines = payload
+        inner = _lines_to_blocks(body_lines, audience, resolve_link, warn)
+        if ctype == 'gm-only':
+            if not gm:
+                return []                                   # player: stripped
+            title = f"GM id={cid}" if cid else "GM"
+            return [lk.secret_block(inner or [lk.para()], title)]
+        panel_type = {'info': 'info', 'note': 'note', 'tip': 'success',
+                      'success': 'success', 'important': 'warning',
+                      'warning': 'warning', 'danger': 'warning',
+                      'caution': 'warning'}.get(ctype, 'note')
+        return [lk.panel(panel_type, *(inner or [lk.para()]))]
+
+    if kind == 'pct':
+        if not gm:
+            return []                                       # player: stripped
+        inner = _lines_to_blocks(payload.split('\n'), audience, resolve_link, warn)
+        return [lk.secret_block(inner or [lk.para()], "GM comment")]
+
+    if kind == 'tasklist':
+        items = [(done, _inline(t, audience, resolve_link, warn))
+                 for done, t in payload]
+        return [lk.task_list(items)]
+
+    if kind == 'bullets':
+        return [lk.bullet_list([lk.para(*_inline(t, audience, resolve_link, warn))
+                                for t in payload])]
+
+    if kind == 'ordered':
+        return [lk.ordered_list([lk.para(*_inline(t, audience, resolve_link, warn))
+                                 for t in payload])]
+
+    if kind == 'table':
+        rows = []
+        for li, line in enumerate(payload):
+            if li == 1:
+                continue                                    # separator row
+            cells = [c.strip() for c in line.strip('|').split('|')]
+            rows.append([[lk.para(*_inline(c, audience, resolve_link, warn))]
+                         if c else [lk.para()] for c in cells])
+        return [lk.table(rows)] if rows else []
+
+    if kind == 'fence':
+        lang, code = payload
+        lang = lang or '(none)'
+        if lang in SKIP_FENCE_LANGS:
+            warn(f"```{lang} block skipped (no LK equivalent this round)")
+            return []
+        # daggerheart stat blocks + generic fences → code-marked paragraphs
+        # (LK block-code node unverified — see manual checklist, GH #213)
+        code_paras = [lk.para(lk.text(l, [lk.mark('code')]))
+                      for l in code.rstrip('\n').split('\n')]
+        if lang == 'daggerheart':
+            warn("```daggerheart stat block rendered as code-marked paragraphs")
+        return code_paras
+
+    if kind == 'embed':
+        return _render_embed(payload, audience, resolve_link, warn)
+
+    return []
+
+
+def _render_embed(inner: str, audience: str, resolve_link, warn) -> list:
+    gm = audience == 'gm'
+    target = inner.split('|')[0].strip()
+    label = inner.split('|')[1].strip() if '|' in inner else Path(target).stem
+    ext = Path(target).suffix.lower()
+
+    if target.startswith('gm_secrets/') or '/gm_secrets/' in target:
+        if not gm:
+            return []                                       # player: stripped
+        # Tier 3: marker only — vault file remains the single source of truth
+        path = target if target.endswith('.md') else target + '.md'
+        marker = [lk.para(f"[GM content lives in vault file {path} — not inlined]")]
+        resolved = resolve_link(target)
+        if resolved:
+            res_id, name = resolved
+            marker.append(lk.para("See hidden page: ", lk.mention(res_id, name)))
+        return [lk.secret_block(marker, f"GM embed: {path}")]
+
+    if ext in IMG_EXTS:
+        warn(f"image embed ![[{inner}]] skipped (vault→CDN upload is API-gated)")
+        return []
+    if ext in AUDIO_EXTS:
+        warn(f"audio embed ![[{inner}]] rendered as label (CDN upload API-gated)")
+        return [lk.para(lk.text(f"♪ {label}", [lk.mark('em')]))]
+    if '#' in inner:
+        base = target.split('#')[0]
+        resolved = resolve_link(base)
+        warn(f"section transclusion ![[{inner}]] rendered as link (not inlined)")
+        if resolved:
+            res_id, name = resolved
+            return [lk.para("→ ", lk.mention(res_id, name, alias=label))]
+        return [lk.para(lk.text(f"→ {label}", [lk.mark('em')]))]
+    # whole-note transclusion of a public note → mention link
+    resolved = resolve_link(target)
+    warn(f"note transclusion ![[{inner}]] rendered as link (not inlined)")
+    if resolved:
+        res_id, name = resolved
+        return [lk.para("→ ", lk.mention(res_id, name, alias=label))]
+    return [lk.para(lk.text(f"→ {label}", [lk.mark('em')]))]
+
+
+def _lines_to_blocks(lines: list, audience: str, resolve_link, warn) -> list:
+    """Render a run of plain lines (callout / %% body) grouping list items."""
+    blocks: list[dict] = []
+    bullets: list[str] = []
+
+    def flush():
+        nonlocal bullets
+        if bullets:
+            blocks.append(lk.bullet_list(
+                [lk.para(*_inline(b, audience, resolve_link, warn)) for b in bullets]))
+            bullets = []
+
+    for line in lines:
+        s = line.strip()
+        if not s:
+            continue
+        m = re.match(r'^[-*+] (.*)$', s)
+        if m:
+            bullets.append(m.group(1))
+        else:
+            flush()
+            blocks.append(lk.para(*_inline(s, audience, resolve_link, warn)))
+    flush()
+    return blocks
+
+
+# ── inline rendering ─────────────────────────────────────────────────────────
+
+_TOKEN_RE = re.compile(
+    r'(?P<embed>!\[\[[^\]]+\]\])'
+    r'|(?P<wikilink>\[\[[^\]]+\]\])'
+    r'|(?P<mdlink>\[[^\]]*\]\([^)]+\))'
+    r'|(?P<bolditalic>\*\*\*[^*]+\*\*\*)'
+    r'|(?P<bold>\*\*[^*]+\*\*)'
+    r'|(?P<italic_star>\*[^*\s][^*]*\*)'
+    r'|(?P<italic_us>(?<![\w])_[^_]+_(?![\w]))'
+    r'|(?P<code>`[^`]+`)'
+    r'|(?P<strike>~~[^~]+~~)'
+    r'|(?P<highlight>==[^=]+==)'
+    r'|(?P<gm>\{gm:[^}]*\})'
+    r'|(?P<br><br\s*/?>)'
+)
+
+
+def _inline(txt: str, audience: str, resolve_link, warn, marks=None) -> list:
+    """Convert inline markdown to a list of inline nodes."""
+    marks = marks or []
+    nodes: list[dict] = []
+    pos = 0
+    for m in _TOKEN_RE.finditer(txt):
+        if m.start() > pos:
+            _push_text(nodes, txt[pos:m.start()], marks)
+        g = m.lastgroup
+        s = m.group(0)
+        if g == 'gm':
+            content = s[4:-1]
+            if audience == 'gm':
+                _push_text(nodes, s, marks)           # literal passthrough
+            else:
+                _push_text(nodes, '██████', marks)    # public-HTML parity
+        elif g == 'wikilink':
+            inner = s[2:-2]
+            anchor = ''
+            target = inner.split('|')[0].strip()
+            alias = inner.split('|')[1].strip() if '|' in inner else ''
+            if '#' in target:
+                target, anchor = target.split('#', 1)
+                target = target.strip()
+            resolved = resolve_link(target) if target else None
+            if resolved:
+                res_id, name = resolved
+                if anchor:
+                    warn(f"[[{inner}]] heading anchor dropped (mention links whole page)")
+                nodes.append(lk.mention(res_id, name, alias=alias))
+            else:
+                nodes.append(lk.text(alias or target or inner))
+        elif g == 'embed':
+            # inline embeds inside a paragraph: same policy as block embeds,
+            # but flatten to inline (images/audio → label text)
+            sub = _render_embed(s[3:-2], audience, resolve_link, warn)
+            for blk in sub:
+                nodes.extend(blk.get('content', []))
+        elif g == 'mdlink':
+            mm = re.match(r'\[([^\]]*)\]\(([^)]+)\)', s)
+            label, href = mm.group(1), mm.group(2)
+            if href.startswith(('http://', 'https://', 'mailto:')):
+                nodes.append(lk.text(label or href, marks + [lk.link_mark(href)]))
+            else:
+                nodes.append(lk.text(label or href, marks))  # internal md link → text
+        elif g == 'bolditalic':
+            _push_text(nodes, s[3:-3], marks + [lk.mark('strong'), lk.mark('em')])
+        elif g == 'bold':
+            nodes.extend(_inline(s[2:-2], audience, resolve_link, warn,
+                                 marks + [lk.mark('strong')]))
+        elif g in ('italic_star', 'italic_us'):
+            nodes.extend(_inline(s[1:-1], audience, resolve_link, warn,
+                                 marks + [lk.mark('em')]))
+        elif g == 'code':
+            _push_text(nodes, s[1:-1], marks + [lk.mark('code')])
+        elif g == 'strike':
+            warn("~~strikethrough~~ degraded to plain text (no LK mark)")
+            _push_text(nodes, s[2:-2], marks)
+        elif g == 'highlight':
+            warn("==highlight== degraded to emphasis (no LK mark)")
+            _push_text(nodes, s[2:-2], marks + [lk.mark('em')])
+        elif g == 'br':
+            nodes.append(lk.hard_break())
+        pos = m.end()
+    if pos < len(txt):
+        _push_text(nodes, txt[pos:], marks)
+    return nodes
+
+
+def _push_text(nodes: list, t: str, marks: list) -> None:
+    if t:
+        nodes.append(lk.text(t, list(marks) if marks else None))

--- a/utilities/lk-bridge/pm_to_md.py
+++ b/utilities/lk-bridge/pm_to_md.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""
+LK ProseMirror (ADF-dialect) → Obsidian Markdown converter.
+
+Inverse of md_to_pm.py — reconstructs the exact vault syntax the HTML pipeline
+parses (Tier 2 callout regex html_render.py:261, Tier 1 {gm:} md_utils.py:35,
+Tier 3 embed html_render.py:46, %% comments):
+
+  block-secret "GM" / "GM id=x"      → > [!gm-only] / > [!gm-only id=x]
+  block-secret "GM comment"          → %% ... %%
+  block-secret "GM embed: <path>"    → ![[<path minus .md>]]  (content discarded
+                                        — marker-only by construction)
+  block-secret other titles          → > [!gm-only]  (LK-authored secrets)
+  panel                              → > [!info/note/tip/important]
+  mention                            → [[name]] / [[name|alias]]
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+PANEL_TO_CALLOUT = {'info': 'info', 'note': 'note', 'success': 'tip',
+                    'warning': 'important', 'error': 'warning'}
+
+
+def doc_to_markdown(content: dict, id_to_name: dict) -> str:
+    """Convert a ProseMirror doc node to Markdown text."""
+    if not content or content.get('type') != 'doc':
+        return ''
+    lines: list[str] = []
+    for node in content.get('content', []):
+        block = _block(node, id_to_name)
+        if block is not None:
+            lines.append(block)
+    return '\n\n'.join(l for l in lines if l is not None).strip() + '\n'
+
+
+def _block(node: dict, ids: dict, depth: int = 0) -> str | None:
+    t = node.get('type')
+    if t == 'heading':
+        level = (node.get('attrs') or {}).get('level', 1)
+        return '#' * level + ' ' + _inline(node.get('content', []), ids)
+    if t == 'paragraph':
+        return _inline(node.get('content', []), ids)
+    if t == 'rule':
+        return '---'
+    if t == 'blockquote':
+        inner = [_block(c, ids) for c in node.get('content', [])]
+        return '\n'.join('> ' + l for blk in inner if blk
+                         for l in blk.split('\n'))
+    if t == 'bulletList':
+        out = []
+        for item in node.get('content', []):
+            body = [_block(c, ids) for c in item.get('content', [])]
+            first, *rest = [b for b in body if b] or ['']
+            out.append('- ' + first)
+            out.extend('  ' + r for r in rest)
+        return '\n'.join(out)
+    if t == 'orderedList':
+        out = []
+        for i, item in enumerate(node.get('content', []), 1):
+            body = [_block(c, ids) for c in item.get('content', [])]
+            first, *rest = [b for b in body if b] or ['']
+            out.append(f'{i}. ' + first)
+            out.extend('   ' + r for r in rest)
+        return '\n'.join(out)
+    if t == 'taskList':
+        out = []
+        for item in node.get('content', []):
+            state = (item.get('attrs') or {}).get('state') == 'DONE'
+            txt = _inline_deep(item.get('content', []), ids)
+            out.append(f"- [{'x' if state else ' '}] {txt}")
+        return '\n'.join(out)
+    if t == 'panel':
+        ptype = (node.get('attrs') or {}).get('panelType', 'note')
+        callout = PANEL_TO_CALLOUT.get(ptype, 'note')
+        inner = [_block(c, ids) for c in node.get('content', [])]
+        body = '\n'.join(l for blk in inner if blk for l in blk.split('\n'))
+        return f'> [!{callout}]\n' + '\n'.join('> ' + l for l in body.split('\n'))
+    if t == 'table':
+        return _table(node, ids)
+    if t == 'bodiedExtension':
+        return _secret(node, ids)
+    if t == 'mediaSingle':
+        for media in node.get('content', []):
+            url = (media.get('attrs') or {}).get('url', '')
+            if url:
+                return f'![embedded image]({url})'
+        return None
+    if t in ('layoutSection',):
+        inner = []
+        for col in node.get('content', []):
+            for c in col.get('content', []):
+                blk = _block(c, ids)
+                if blk:
+                    inner.append(blk)
+        return '\n\n'.join(inner)
+    if t in ('extension', 'inlineExtension', 'event', 'arrow', 'bookmark', 'draw',
+             'element', 'external', 'frame', 'free', 'geo', 'group', 'image', 'note'):
+        return None                       # board/map/timeline internals — out of scope
+    # unknown block: flatten any inline content
+    if node.get('content'):
+        return _inline_deep(node.get('content', []), ids)
+    return None
+
+
+def _secret(node: dict, ids: dict) -> str | None:
+    attrs = node.get('attrs') or {}
+    if attrs.get('extensionKey') not in ('block-secret', ''):
+        return None
+    title = str((attrs.get('parameters') or {}).get('extensionTitle', '') or '')
+    inner_blocks = [_block(c, ids) for c in node.get('content', [])]
+    body = '\n'.join(b for b in inner_blocks if b)
+
+    if title.startswith('GM embed: '):
+        path = title[len('GM embed: '):].strip()
+        if path.endswith('.md'):
+            path = path[:-3]
+        return f'![[{path}]]'             # content discarded — marker-only
+    if title == 'GM comment':
+        return f'%%\n{body}\n%%'
+    # "GM", "GM id=x", LK default "Secret", or anything else → Tier 2 callout
+    cid = ''
+    if title.startswith('GM id='):
+        cid = title[len('GM id='):].strip()
+    header = f'> [!gm-only id={cid}]' if cid else '> [!gm-only]'
+    quoted = '\n'.join('> ' + l for l in body.split('\n')) if body else '>'
+    return f'{header}\n{quoted}'
+
+
+def _table(node: dict, ids: dict) -> str:
+    rows = []
+    header = False
+    for row in node.get('content', []):
+        cells = []
+        for cell in row.get('content', []):
+            if cell.get('type') == 'tableHeader':
+                header = True
+            cells.append(_inline_deep(cell.get('content', []), ids).replace('|', '\\|'))
+        rows.append(cells)
+    if not rows:
+        return ''
+    width = max(len(r) for r in rows)
+    for r in rows:
+        r.extend([''] * (width - len(r)))
+    lines = ['| ' + ' | '.join(rows[0]) + ' |',
+             '|' + '---|' * width]
+    for r in rows[1:]:
+        lines.append('| ' + ' | '.join(r) + ' |')
+    if not header and len(rows) == 1:
+        lines = ['| ' + ' | '.join(rows[0]) + ' |', '|' + '---|' * width]
+    return '\n'.join(lines)
+
+
+def _inline_deep(nodes: list, ids: dict) -> str:
+    """Flatten nested block content (e.g. a table cell's paragraphs) to one line."""
+    parts = []
+    for n in nodes:
+        t = n.get('type')
+        if t == 'paragraph':
+            parts.append(_inline(n.get('content', []), ids))
+        elif t in ('text', 'mention', 'hardBreak', 'emoji', 'date', 'status'):
+            parts.append(_inline([n], ids))
+        else:
+            blk = _block(n, ids)
+            if blk:
+                parts.append(blk.replace('\n', ' '))
+    return ' '.join(p for p in parts if p)
+
+
+def _inline(nodes: list, ids: dict) -> str:
+    out = []
+    for n in nodes:
+        t = n.get('type')
+        if t == 'text':
+            out.append(_marked(n))
+        elif t == 'mention':
+            attrs = n.get('attrs') or {}
+            name = ids.get(attrs.get('id', ''), attrs.get('text', ''))
+            alias = attrs.get('alias', '')
+            out.append(f'[[{name}|{alias}]]' if alias and alias != name else f'[[{name}]]')
+        elif t == 'hardBreak':
+            out.append('<br>')
+        elif t in ('emoji', 'date', 'status', 'inlineExtension'):
+            txt = (n.get('attrs') or {}).get('text', '')
+            if txt:
+                out.append(txt)
+        elif n.get('content'):
+            out.append(_inline(n['content'], ids))
+    return ''.join(out)
+
+
+def _marked(n: dict) -> str:
+    txt = n.get('text', '')
+    kinds = {m.get('type') for m in n.get('marks', [])}
+    href = next((m.get('attrs', {}).get('href') for m in n.get('marks', [])
+                 if m.get('type') == 'link'), None)
+    if 'code' in kinds:
+        txt = f'`{txt}`'
+    if 'strong' in kinds and 'em' in kinds:
+        txt = f'***{txt}***'
+    elif 'strong' in kinds:
+        txt = f'**{txt}**'
+    elif 'em' in kinds:
+        txt = f'*{txt}*'
+    if href:
+        txt = f'[{txt}]({href})'
+    return txt

--- a/utilities/lk-bridge/pm_to_md.py
+++ b/utilities/lk-bridge/pm_to_md.py
@@ -108,7 +108,12 @@ def _block(node: dict, ids: dict, depth: int = 0) -> str | None:
 def _secret(node: dict, ids: dict) -> str | None:
     attrs = node.get('attrs') or {}
     if attrs.get('extensionKey') not in ('block-secret', ''):
-        return None
+        # LK-authored container blocks (e.g. block-text-field, observed
+        # 2026-07-04) — unwrap: render inner content as plain blocks so
+        # nothing is silently dropped on LK → vault conversion
+        inner = [_block(c, ids) for c in node.get('content', [])]
+        body = '\n\n'.join(b for b in inner if b)
+        return body or None
     title = str((attrs.get('parameters') or {}).get('extensionTitle', '') or '')
     inner_blocks = [_block(c, ids) for c in node.get('content', [])]
     body = '\n'.join(b for b in inner_blocks if b)

--- a/utilities/lk-bridge/schemas/SOURCE.md
+++ b/utilities/lk-bridge/schemas/SOURCE.md
@@ -1,0 +1,44 @@
+# Schema provenance
+
+## `lk-envelope.schema.json` (hand-written)
+
+Derived from real LK exports:
+- `Welcome to Tarim Shaiel.json` (May 2026, 15 resources) — original baseline
+- `Tarim-Shaiel Library.json` (2026-07-03, 50 resources, **post-rewrite**) — current reference
+
+2026-07-03 baseline diff verdict: envelope schema identical across the rewrite;
+additive changes only (`board`/`map` document types, optional `map` document
+field). The `hash` field uses an unknown LK-internal algorithm — twelve
+serialization variants failed to reproduce it — and LK does **not** verify it
+on import (proven: an import with a "wrong" hash was accepted, May 2026,
+re-confirmed against the rewrite's exports). Our exports carry a
+self-consistency SHA-256 instead.
+
+## `lk-dialect.schema.json` (hand-written — NOT vanilla ADF)
+
+LegendKeeper's editor is the open-source Atlaskit editor (Atlassian's
+ProseMirror distribution); its document model descends from ADF (Atlassian
+Document Format). Evidence: 24/26 node types match ADF definitions, and link
+marks carry `__confluenceMetadata` — an implementation-private field defined
+in `@atlaskit/adf-schema`'s `link.js` (`OPTIONAL_ATTRS`). LK has never
+documented this; it is artifact-proven.
+
+**Why we don't validate against Atlassian's published ADF schema:** it rejects
+14/14 real LK documents. Measured divergences (2026-07-03):
+
+1. `strong`/`em` marks carry `"attrs": {}` (ADF forbids attrs on those marks)
+2. GM sections use `bodiedExtension` with **empty** `extensionKey`/`extensionType`
+   (ADF requires non-empty); real LK data contains `layout: "default "` with a
+   trailing space (fails ADF's enum)
+3. `mention.attrs.documentId` — LK addition, ADF forbids unknown attrs
+4. `media` with empty `id`/`collection` plus `__external`/`url`/`__fileMimeType`
+5. `blockquote` may contain `heading`; `panel` may contain `heading`
+   (both disallowed by published ADF)
+
+The dialect schema encodes the vocabulary LK actually emits, measured from the
+reference exports above. Marks observed in real content: `strong`, `em`,
+`code`, `link` only. Block-level code node: **unverified** (LK tutorial content
+shows only the inline `code` mark) — manual checklist item, GH #213.
+
+Vanilla ADF schema reference (not vendored — 74 KB, draft-04, rejected as
+validator): `https://unpkg.com/@atlaskit/adf-schema@latest/dist/json-schema/v1/full.json`

--- a/utilities/lk-bridge/schemas/lk-dialect.schema.json
+++ b/utilities/lk-bridge/schemas/lk-dialect.schema.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "LK ProseMirror content dialect (measured, not vanilla ADF)",
+  "description": "Node vocabulary measured from real LK exports (May 2026 + 2026-07-03 post-rewrite). LK is built on the Atlaskit editor (ADF lineage — see schemas/SOURCE.md) but diverges from published ADF in enumerated ways; this schema encodes the dialect LK actually emits and accepts. Applied to each document's 'content' field.",
+  "$ref": "#/definitions/doc",
+  "definitions": {
+    "doc": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {"const": "doc"},
+        "content": {"type": "array", "items": {"$ref": "#/definitions/blockNode"}}
+      }
+    },
+    "blockNode": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "enum": ["paragraph", "heading", "bulletList", "orderedList", "listItem",
+                   "blockquote", "rule", "panel", "table", "tableRow", "tableCell",
+                   "tableHeader", "mediaSingle", "layoutSection", "layoutColumn",
+                   "bodiedExtension", "extension", "taskList", "taskItem",
+                   "event", "codeBlock",
+                   "arrow", "bookmark", "draw", "element", "external", "frame",
+                   "free", "geo", "group", "image", "note"]
+        },
+        "attrs": {"type": "object"},
+        "content": {"type": "array", "items": {"$ref": "#/definitions/anyNode"}},
+        "marks": {"type": "array", "items": {"$ref": "#/definitions/mark"}}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"type": {"const": "heading"}}},
+          "then": {
+            "properties": {
+              "attrs": {
+                "type": "object",
+                "required": ["level"],
+                "properties": {"level": {"type": "integer", "minimum": 1, "maximum": 6},
+                               "id": {"type": "string"}}
+              }
+            },
+            "required": ["attrs"]
+          }
+        },
+        {
+          "if": {"properties": {"type": {"const": "panel"}}},
+          "then": {
+            "properties": {
+              "attrs": {
+                "type": "object",
+                "required": ["panelType"],
+                "properties": {"panelType": {"enum": ["info", "note", "warning", "success", "error"]}}
+              }
+            },
+            "required": ["attrs"]
+          }
+        },
+        {
+          "if": {"properties": {"type": {"const": "bodiedExtension"}}},
+          "then": {
+            "properties": {
+              "attrs": {
+                "type": "object",
+                "required": ["extensionType", "extensionKey"],
+                "properties": {
+                  "extensionType": {"type": "string"},
+                  "extensionKey": {"type": "string"},
+                  "parameters": {"type": "object"},
+                  "layout": {"type": "string"}
+                }
+              }
+            },
+            "required": ["attrs"]
+          }
+        }
+      ]
+    },
+    "inlineNode": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {"enum": ["text", "mention", "hardBreak", "inlineExtension", "media", "file", "emoji", "date", "status"]},
+        "text": {"type": "string"},
+        "attrs": {"type": "object"},
+        "marks": {"type": "array", "items": {"$ref": "#/definitions/mark"}}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"type": {"const": "text"}}},
+          "then": {"required": ["text"]}
+        },
+        {
+          "if": {"properties": {"type": {"const": "mention"}}},
+          "then": {
+            "properties": {
+              "attrs": {
+                "type": "object",
+                "required": ["id", "text"],
+                "properties": {
+                  "id": {"type": "string"},
+                  "text": {"type": "string"},
+                  "alias": {"type": "string"},
+                  "accessLevel": {"type": "string"},
+                  "userType": {"type": "string"},
+                  "documentId": {"type": "string"}
+                }
+              }
+            },
+            "required": ["attrs"]
+          }
+        }
+      ]
+    },
+    "anyNode": {
+      "anyOf": [
+        {"$ref": "#/definitions/blockNode"},
+        {"$ref": "#/definitions/inlineNode"}
+      ]
+    },
+    "mark": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {"enum": ["strong", "em", "code", "link", "strike", "underline",
+                          "textColor", "subsup", "alignment", "indentation"]},
+        "attrs": {"type": "object"}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"type": {"const": "link"}}},
+          "then": {
+            "properties": {
+              "attrs": {
+                "type": "object",
+                "required": ["href"],
+                "properties": {"href": {"type": "string"},
+                               "__confluenceMetadata": {"type": ["object", "null"]}}
+              }
+            },
+            "required": ["attrs"]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/utilities/lk-bridge/schemas/lk-envelope.schema.json
+++ b/utilities/lk-bridge/schemas/lk-envelope.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "LegendKeeper export envelope (reverse-engineered)",
+  "description": "Derived from real LK exports: May 2026 baseline + 2026-07-03 post-rewrite export (verdict: identical envelope schema). The 'hash' field uses an unknown LK algorithm and is NOT verified by LK on import.",
+  "type": "object",
+  "required": ["version", "exportId", "exportedAt", "resources", "calendars", "resourceCount", "hash"],
+  "properties": {
+    "version": {"const": 1},
+    "exportId": {"type": "string", "minLength": 1},
+    "exportedAt": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}T"},
+    "resourceCount": {"type": "integer", "minimum": 0},
+    "hash": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "calendars": {"type": "array"},
+    "resources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "pos", "documents"],
+        "$comment": "parentId omitted entirely on some root resources in post-rewrite exports",
+        "properties": {
+          "schemaVersion": {"const": 1},
+          "id": {"type": "string", "pattern": "^[a-z0-9]{8}$"},
+          "name": {"type": "string"},
+          "parentId": {"type": "string"},
+          "pos": {"type": "string", "minLength": 1},
+          "aliases": {"type": "array"},
+          "banner": {"type": "object"},
+          "createdBy": {"type": "string"},
+          "iconColor": {"type": "string"},
+          "iconGlyph": {"type": "string"},
+          "iconShape": {"type": "string"},
+          "isHidden": {"type": "boolean"},
+          "isLocked": {"type": "boolean"},
+          "properties": {"type": "array"},
+          "showPropertyBar": {"type": "boolean"},
+          "tags": {"type": "array", "items": {"type": "string"}},
+          "documents": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["id", "type", "content"],
+              "properties": {
+                "id": {"type": "string", "minLength": 1},
+                "type": {"enum": ["page", "time", "blank", "board", "map"]},
+                "presentation": {
+                  "type": "object",
+                  "description": "Optional in post-rewrite LK exports, but null HANGS the importer (proven 2026-05) — bridge exports always emit it; validated as an error when null, a warning when absent"
+                },
+                "content": {
+                  "type": "object",
+                  "$comment": "empty {} on blank documents in post-rewrite exports"
+                },
+                "map": {"type": "object"}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/utilities/lk-bridge/to_lk.py
+++ b/utilities/lk-bridge/to_lk.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""
+Vault Markdown → LegendKeeper import file.
+
+Usage:
+    # arbitrary files
+    python utilities/lk-bridge/to_lk.py narrative/lore/liberation_aftermath.md \
+        world/regions/tarim-basin.md --audience gm --lk -o roundtrip/test.json
+
+    # directory scope (recursive; scope guards applied)
+    python utilities/lk-bridge/to_lk.py narrative world --audience gm \
+        -o roundtrip/full-export.json --lk
+
+Audience modes (see README.md secrets mapping):
+    gm     — full mirror: GM constructs become LK block-secret sections;
+             page-level gm_secrets files become hidden resources (default)
+    player — public-HTML parity: all GM content stripped; gm_secrets files
+             excluded entirely
+
+Scope guards (directory mode): Index.md / _category.md skipped; default-excluded
+subtrees (world/abilities, world/classes — SRD reference data) need --include-all.
+Never writes to any vault file. Warnings go to stderr and the manifest.
+"""
+
+import sys
+import json
+import argparse
+from pathlib import Path
+
+BRIDGE_DIR = Path(__file__).parent
+VAULT = BRIDGE_DIR.parent.parent
+sys.path.insert(0, str(BRIDGE_DIR))
+sys.path.insert(0, str(BRIDGE_DIR.parent))
+
+import lk_schema as lk
+import md_to_pm
+from shared.frontmatter import parse_frontmatter
+
+SKIP_NAMES = {'Index.md', '_category.md'}
+DEFAULT_EXCLUDE_SUBTREES = ('world/abilities', 'world/classes')
+POS_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+
+def collect_files(paths: list[str], include_all: bool) -> list[Path]:
+    files: list[Path] = []
+    for p in paths:
+        path = (VAULT / p) if not Path(p).is_absolute() else Path(p)
+        if path.is_file():
+            files.append(path)
+            continue
+        if not path.is_dir():
+            print(f"WARNING: {p} not found — skipped", file=sys.stderr)
+            continue
+        for md in sorted(path.rglob('*.md')):
+            rel = md.relative_to(VAULT).as_posix()
+            if md.name in SKIP_NAMES:
+                continue
+            if not include_all and rel.startswith(DEFAULT_EXCLUDE_SUBTREES):
+                continue
+            files.append(md)
+    # dedupe, keep order
+    seen, out = set(), []
+    for f in files:
+        if f not in seen:
+            seen.add(f)
+            out.append(f)
+    return out
+
+
+def is_gm_page(fm: dict, rel: str) -> bool:
+    """Fails-closed, mirroring the HTML pipeline's narrow allowlist: only an
+    explicit ``visibility: public`` is player-visible. Any other value —
+    gm_secrets, internal, a typo like gm_only, or a missing field — is
+    GM-side (hidden in gm mode, excluded in player mode)."""
+    return fm.get('visibility') != 'public' or '/gm_secrets/' in f'/{rel}'
+
+
+def pos_for(index: int) -> str:
+    """Fractional-index style position: A, B, ..., Z, ZA, ZB, ..."""
+    out = ''
+    while True:
+        out = POS_ALPHABET[index % 26] + out if not out else out
+        prefix = index // 26
+        if prefix == 0:
+            return ('Z' * (len(out) - 1)) + out if len(out) > 1 else out
+        index = index % 26
+        return 'Z' * prefix + POS_ALPHABET[index]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Vault Markdown → LK import file")
+    ap.add_argument('paths', nargs='+', help="Vault files and/or directories")
+    ap.add_argument('--audience', choices=['gm', 'player'], default='gm')
+    ap.add_argument('-o', '--output', required=True, help="Output .json path")
+    ap.add_argument('--lk', action='store_true', help="Also write gzip .lk beside the .json")
+    ap.add_argument('--include-all', action='store_true',
+                    help="Include default-excluded subtrees (world/abilities, world/classes)")
+    ap.add_argument('--hub-name', default=None,
+                    help="Name for the auto-generated hub parent page")
+    ap.add_argument('--manifest', default=str(BRIDGE_DIR / 'lk_manifest.json'),
+                    help="Provisional-ID manifest output path")
+    args = ap.parse_args()
+
+    out_path = Path(args.output)
+    if out_path.resolve().is_relative_to(VAULT) and not \
+            out_path.resolve().is_relative_to(BRIDGE_DIR):
+        # allow only bridge-internal output dirs inside the vault
+        for content_root in ('world', 'narrative', 'mechanics', 'characters'):
+            if out_path.resolve().is_relative_to(VAULT / content_root):
+                sys.exit(f"REFUSED: output path {out_path} is inside vault content")
+
+    files = collect_files(args.paths, args.include_all)
+    if not files:
+        sys.exit("No files collected.")
+
+    gm_mode = args.audience == 'gm'
+
+    # ── pass 1: read all files, build the link-resolution index ────────────
+    entries = []          # (rel, fm, body, res_id, is_gm)
+    by_stem = {}          # lowercase stem → (res_id, title)
+    by_rel = {}           # vault-relative path (no ext) → (res_id, title)
+    for f in files:
+        try:
+            rel = f.relative_to(VAULT).as_posix()
+        except ValueError:
+            rel = f.name          # file outside the vault (tests, ad-hoc input)
+        raw = f.read_text(errors='ignore')
+        fm, body = parse_frontmatter(raw)
+        gm_page = is_gm_page(fm, rel)
+        if gm_page and not gm_mode:
+            continue                      # player export: excluded entirely
+        title = str(fm.get('title') or f.stem)
+        res_id = lk.short_id(rel)
+        entries.append((rel, fm, body, res_id, gm_page))
+        by_stem[f.stem.lower()] = (res_id, title)
+        by_rel[rel[:-3].lower()] = (res_id, title)
+
+    def resolve_link(target: str):
+        t = target.strip().strip('/')
+        if t.lower().endswith('.md'):
+            t = t[:-3]
+        return by_rel.get(t.lower()) or by_stem.get(t.rsplit('/', 1)[-1].lower())
+
+    # ── pass 2: build directory-hierarchy resources ────────────────────────
+    hub_name = args.hub_name or f"LK Bridge Import {lk.now_iso()[:10]}"
+    hub_id = lk.short_id(f"hub:{hub_name}")
+    resources = []
+    dir_ids: dict[str, str] = {}
+    warnings: list[str] = []
+    old_schema: list[str] = []
+
+    def dir_resource(rel_dir: str) -> str:
+        """Get/create a folder resource chain for rel_dir; return its ID."""
+        if not rel_dir or rel_dir == '.':
+            return hub_id
+        if rel_dir in dir_ids:
+            return dir_ids[rel_dir]
+        parent = dir_resource(str(Path(rel_dir).parent))
+        rid = lk.short_id(f"dir:{rel_dir}")
+        name = Path(rel_dir).name.replace('_', ' ').replace('-', ' ').title()
+        hidden = 'gm_secrets' in Path(rel_dir).parts
+        resources.append(lk.resource(
+            rid, name, parent, [lk.doc(lk.short_id(f"dirdoc:{rel_dir}"),
+                                       [lk.para(f"Section: {rel_dir}")])],
+            tags=['section'], pos=pos_for(len(resources)),
+            is_hidden=hidden, icon_glyph="fas fa-folder"))
+        dir_ids[rel_dir] = rid
+        return rid
+
+    # ── pass 3: convert every file ──────────────────────────────────────────
+    manifest_resources = {}
+    for idx, (rel, fm, body, res_id, gm_page) in enumerate(entries):
+        title = str(fm.get('title') or Path(rel).stem)
+        if not fm.get('doc_type') and fm.get('type'):
+            old_schema.append(rel)
+        result = md_to_pm.convert(body, audience=args.audience,
+                                  resolve_link=resolve_link, source=rel)
+        warnings.extend(result.warnings)
+        tags = []
+        for key in ('domain', 'content_type'):
+            v = fm.get(key)
+            if isinstance(v, str) and v:
+                tags.append(v)
+        fmtags = fm.get('tags')
+        if isinstance(fmtags, list):
+            tags.extend(str(t) for t in fmtags[:6])
+        if gm_page and 'gm-secret' not in tags:
+            tags.append('gm-secret')
+        parent = dir_resource(str(Path(rel).parent))
+        resources.append(lk.resource(
+            res_id, title, parent,
+            [lk.doc(lk.short_id(f"doc:{rel}"), result.nodes or [lk.para()])],
+            tags=tags, pos=pos_for(idx), is_hidden=gm_page))
+        manifest_resources[rel] = {
+            "provisionalId": res_id, "lkId": None, "lkName": title,
+            "gm": gm_page,
+        }
+
+    # hub page with mentions to top-level sections
+    top_mentions = []
+    for rel_dir, rid in sorted(dir_ids.items()):
+        if str(Path(rel_dir).parent) in ('.', ''):
+            name = Path(rel_dir).name.title()
+            top_mentions.append(lk.para("• ", lk.mention(rid, name)))
+    hub_doc_nodes = [
+        lk.heading(hub_name, 1),
+        lk.para(f"Generated from vault by lk-bridge to_lk.py — audience: {args.audience}. "
+                f"{len(entries)} pages."),
+    ] + top_mentions
+    resources.insert(0, lk.resource(
+        hub_id, hub_name, "", [lk.doc(lk.short_id(f"hubdoc:{hub_name}"), hub_doc_nodes)],
+        tags=['lk-bridge'], pos="A", icon_glyph="fas fa-compass"))
+
+    export = lk.envelope(resources, export_id=lk.short_id(f"exp:{hub_name}"))
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    lk.write_export(export, out_path)
+    if args.lk:
+        lk.write_export(export, out_path.with_suffix('.lk'), as_lk=True)
+
+    manifest = {
+        "generation": {"exportId": export["exportId"], "capturedAt": export["exportedAt"],
+                       "note": "lkId fields are filled by manifest.py from an LK re-export; "
+                               "LK reassigns IDs on import."},
+        "resources": manifest_resources,
+    }
+    Path(args.manifest).write_text(json.dumps(manifest, indent=1))
+
+    print(f"Export written: {out_path}" + (f" (+ .lk)" if args.lk else ""))
+    print(f"  resources: {len(resources)} ({len(entries)} pages, "
+          f"{len(dir_ids)} sections, 1 hub)")
+    print(f"  audience:  {args.audience}")
+    if old_schema:
+        print(f"  old-schema files tolerated: {len(old_schema)}")
+    if warnings:
+        print(f"  conversion warnings: {len(warnings)} (first 20 below)", file=sys.stderr)
+        for w in warnings[:20]:
+            print(f"    ⚠ {w}", file=sys.stderr)
+    print(f"  manifest:  {args.manifest}")
+
+
+if __name__ == '__main__':
+    main()

--- a/utilities/lk-bridge/validate_lk.py
+++ b/utilities/lk-bridge/validate_lk.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+Offline validator for generated LK export files.
+
+Three layers (see schemas/SOURCE.md for provenance):
+  1. Envelope — hand-written schema from real LK exports
+  2. Content dialect — hand-written LK-dialect schema (NOT vanilla ADF,
+     which rejects real LK output)
+  3. Semantic checks — self-consistency hash, non-null presentation,
+     player-mode purity (no GM strings)
+
+Usage:
+    python utilities/lk-bridge/validate_lk.py roundtrip/gm-export.json
+    python utilities/lk-bridge/validate_lk.py roundtrip/player.json --player
+"""
+
+import sys
+import json
+import gzip
+import hashlib
+import argparse
+from pathlib import Path
+
+try:
+    import jsonschema
+except ImportError:
+    sys.exit("jsonschema not installed — pip install jsonschema (see requirements.txt)")
+
+SCHEMA_DIR = Path(__file__).parent / 'schemas'
+
+
+def load_export(path: Path) -> dict:
+    raw = path.read_bytes()
+    if raw[:2] == b'\x1f\x8b':
+        raw = gzip.decompress(raw)
+    return json.loads(raw)
+
+
+def validate(path: Path, player_mode: bool = False) -> int:
+    export = load_export(path)
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    # ── 1. envelope ──
+    env_schema = json.loads((SCHEMA_DIR / 'lk-envelope.schema.json').read_text())
+    v = jsonschema.Draft7Validator(env_schema)
+    for e in sorted(v.iter_errors(export), key=lambda e: list(e.path)):
+        errors.append(f"envelope: {'/'.join(str(p) for p in e.path)}: {e.message[:140]}")
+
+    # ── 2. content dialect ──
+    dia_schema = json.loads((SCHEMA_DIR / 'lk-dialect.schema.json').read_text())
+    dv = jsonschema.Draft7Validator(dia_schema)
+    for r in export.get('resources', []):
+        for d in r.get('documents', []):
+            content = d.get('content')
+            if not content or not content.get('type'):
+                continue      # blank docs export as content: {} post-rewrite
+            errs = list(dv.iter_errors(content))
+            if errs:
+                best = jsonschema.exceptions.best_match(errs)
+                errors.append(f"dialect: resource {r.get('name', '?')!r}: "
+                              f"{'/'.join(str(p) for p in best.path)}: {best.message[:140]}")
+
+    # ── 3. semantic ──
+    payload = {k: v for k, v in export.items() if k != 'hash'}
+    computed = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+    if computed != export.get('hash'):
+        warnings.append("hash: not our self-consistency hash "
+                        "(expected for LK-produced exports; LK ignores it on import)")
+
+    if export.get('resourceCount') != len(export.get('resources', [])):
+        errors.append(f"semantic: resourceCount {export.get('resourceCount')} != "
+                      f"{len(export.get('resources', []))} actual resources")
+
+    absent_presentation = 0
+    for r in export.get('resources', []):
+        for d in r.get('documents', []):
+            if 'presentation' not in d:
+                absent_presentation += 1   # post-rewrite LK omits it on some docs
+            elif not isinstance(d['presentation'], dict):
+                errors.append(f"semantic: resource {r.get('name', '?')!r} document "
+                              f"{d.get('id', '?')} has null presentation "
+                              f"(HANGS the LK importer)")
+    if absent_presentation:
+        warnings.append(f"presentation absent on {absent_presentation} document(s) "
+                        f"(normal for LK-produced exports; bridge exports always emit it)")
+
+    # mention integrity: every mention id resolves within the export
+    ids = {r['id'] for r in export.get('resources', [])}
+    def check_mentions(n, res_name):
+        if isinstance(n, dict):
+            if n.get('type') == 'mention':
+                mid = (n.get('attrs') or {}).get('id', '')
+                if mid and mid not in ids:
+                    warnings.append(f"mention: {res_name!r} → id {mid} not in export "
+                                    f"(OK only if targeting an existing LK resource)")
+            for v in n.values():
+                check_mentions(v, res_name)
+        elif isinstance(n, list):
+            for v in n:
+                check_mentions(v, res_name)
+    for r in export.get('resources', []):
+        check_mentions(r.get('documents'), r.get('name', '?'))
+
+    if player_mode:
+        text = json.dumps(export, ensure_ascii=False)
+        for marker, what in [('block-secret', 'block-secret extension'),
+                             ('{gm:', 'Tier 1 GM inline'),
+                             ('gm_secrets', 'gm_secrets path')]:
+            if marker in text:
+                errors.append(f"purity: player export contains {what} ({marker!r})")
+        for r in export.get('resources', []):
+            if r.get('isHidden'):
+                errors.append(f"purity: player export contains hidden resource "
+                              f"{r.get('name', '?')!r}")
+
+    # ── report ──
+    label = 'PLAYER' if player_mode else 'GM'
+    print(f"{path.name} [{label} mode] — resources: {len(export.get('resources', []))}")
+    for w in warnings:
+        print(f"  ⚠ {w}")
+    if errors:
+        for e in errors[:40]:
+            print(f"  ✗ {e}")
+        print(f"FAIL: {len(errors)} error(s)")
+        return 1
+    print("PASS")
+    return 0
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Validate a generated LK export file")
+    ap.add_argument('files', nargs='+')
+    ap.add_argument('--player', action='store_true',
+                    help="Also enforce player-mode purity (no GM content)")
+    args = ap.parse_args()
+    rc = 0
+    for f in args.files:
+        rc |= validate(Path(f), player_mode=args.player)
+    sys.exit(rc)
+
+
+if __name__ == '__main__':
+    main()

--- a/utilities/shared/frontmatter.py
+++ b/utilities/shared/frontmatter.py
@@ -14,6 +14,22 @@ except ImportError:
     _YAML_AVAILABLE = False
 
 
+def doc_type_of(fm: dict) -> str:
+    """Resolve a document's legacy type label across schema generations.
+
+    Schema C (Decision 17, 2026-05-02) replaced the single ``type:`` field with
+    ``domain:`` / ``doc_type:`` / ``content_type:``. Consumers that still route
+    on the old label (LK pipeline: myth/lore/timeline) should call this instead
+    of ``fm.get('type')``: it prefers ``content_type:``, then ``doc_type:``,
+    then falls back to legacy ``type:``. Always returns a lowercase string.
+    """
+    for key in ('content_type', 'doc_type', 'type'):
+        value = fm.get(key)
+        if value:
+            return str(value).strip().lower()
+    return ''
+
+
 def parse_frontmatter(text: str) -> tuple[dict, str]:
     """Return (frontmatter_dict, body_text).
 


### PR DESCRIPTION
## Summary

Implements the interim (no-API) LK bridge per the plan and findings in #213: a bidirectional vault↔LegendKeeper converter with offline validation, superseding `utilities/legendkeeper-pipeline/` for prose pages.

- **`utilities/lk-bridge/`** — `lk_schema.py` (LK JSON builders), `md_to_pm.py`/`pm_to_md.py` (Markdown ↔ ADF-dialect ProseMirror), `to_lk.py` (export CLI: file or directory scope, `--audience gm|player`), `from_lk.py` (LK export → Schema C Markdown; refuses vault content roots), `validate_lk.py` + `schemas/` (envelope + LK-dialect schemas, semantic checks), `manifest.py` (real-ID capture)
- **Secrets:** full-mirror mapping — vault GM tiers → LK `block-secret` with `extensionTitle` discriminator; player mode enforces public-HTML parity with **fails-closed** visibility gating (only explicit `visibility: public` exports — the validator caught and killed an allowlist-polarity bug during development, excluding 70 not-explicitly-public pages)
- **Legacy shims:** additive `doc_type_of()` in `shared/frontmatter.py`; Schema C call-site patches in the two legacy LK generators; legacy notice in `from_lk_json.py`
- **Tests:** 24 new in `tests/test_lk_bridge.py` incl. offline round-trip on real content and a GM-constructs fixture

## Verification

- `validate_lk.py` PASSES on all generated exports AND on the real post-rewrite LK export (dialect-schema sanity gate)
- Player export purity: zero `block-secret`/`{gm:`/hidden resources; Tier 1 renders as `██████`
- Offline round-trip: Tier 2 count survives vault→LK→vault on `liberation_aftermath.md`
- HTML regression gate: `docs/` **byte-identical** after `build.py all`
- Full generated artifacts: GM mirror 461 resources / player 77 (gitignored under `roundtrip/`)

## Pre-existing issues surfaced (NOT addressed here)

- `tests/test_lore_generator.py` fails collection on `main` (imports removed `build_html`); 5 `test_shared_assets.py` failures also pre-exist on `main`
- `build.py all` empties `world/data/tarim-shaiel-locations.geojson` (restored via checkout; needs its own investigation)

## Next (manual round, tracked in #213)

Import fixture + full GM export into a scratch LK project; re-export; verify the 4 open questions (custom `extensionTitle` survival, `isHidden` preservation, cross-import mention retarget, block-code node shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)