### PR TITLE
infra: read MapTiler API key from env var instead of hardcoding it

### DIFF
--- a/utilities/locations/generate_locations_html.py
+++ b/utilities/locations/generate_locations_html.py
@@ -45,6 +45,7 @@ from locations.location_components import (
     render_xref_stub,
     _TYPE_LABELS,
     MAP_ATTRIBUTION_HTML,
+    MAPTILER_STYLE_URL,
 )
 from locations.map_icons import icon_registration_js
 from shared.renderer import render_page
@@ -403,7 +404,7 @@ def _build_world_map_html(
   {data_js}
   var map = window._tsMap = new maplibregl.Map({{
     container: 'world-map',
-    style: 'https://api.maptiler.com/maps/019e13d9-26c8-7cd9-bf8d-64d83f66624e/style.json?key=uZtsACZHTZGwWfZ3HGai',
+    style: '{MAPTILER_STYLE_URL}',
     center: [75.0, 40.0],
     zoom: 5,
     minZoom: 5,

--- a/utilities/locations/location_components.py
+++ b/utilities/locations/location_components.py
@@ -6,6 +6,8 @@ Used by the main generator to assemble location detail pages.
 """
 
 import json
+import os
+import sys
 from html import escape
 from typing import Optional
 
@@ -127,9 +129,24 @@ def render_resources(resources: list[str]) -> str:
 
 # ---------------------------------------------------------------------------
 # MapLibre GL JS map configuration
-# Style JSON lives at /assets/map-style.json (copied from utilities/assets/
-# to docs/assets/ at build time). MapTiler API key is baked into the style.
+# The style id itself isn't sensitive, but the MapTiler key is -- it must
+# come from the environment (Netlify env var in production, exported locally
+# for dev builds) rather than being committed to source. See
+# https://github.com/mofro/tarim-shaiel-campaign-frame/issues/275
 # ---------------------------------------------------------------------------
+
+MAPTILER_STYLE_ID = '019e13d9-26c8-7cd9-bf8d-64d83f66624e'
+MAPTILER_KEY = os.environ.get('MAPTILER_KEY', '')
+if not MAPTILER_KEY:
+    print(
+        "WARNING: MAPTILER_KEY environment variable is not set -- "
+        "maps will fail to load tiles. Set it in your shell for local "
+        "builds, or in Netlify's Environment Variables for production.",
+        file=sys.stderr,
+    )
+MAPTILER_STYLE_URL = (
+    f'https://api.maptiler.com/maps/{MAPTILER_STYLE_ID}/style.json?key={MAPTILER_KEY}'
+)
 
 # Attribution shown below non-interactive mini-maps (world map uses built-in
 # MapLibre attribution control which reads from the style JSON).
@@ -283,7 +300,7 @@ def render_mini_map(
 (function() {{
   var map = new maplibregl.Map({{
     container: '{map_id}',
-    style: 'https://api.maptiler.com/maps/019e13d9-26c8-7cd9-bf8d-64d83f66624e/style.json?key=uZtsACZHTZGwWfZ3HGai',
+    style: '{MAPTILER_STYLE_URL}',
     center: [{lon}, {lat}],
     zoom: {effective_zoom},
     minZoom: {effective_min_zoom},


### PR DESCRIPTION
## Summary
- Removes the hardcoded MapTiler API key from `utilities/locations/location_components.py` and `utilities/locations/generate_locations_html.py`.
- Key is now read via `MAPTILER_KEY` from the environment at build time; the style id (not sensitive) stays inline.
- Prints a stderr warning if `MAPTILER_KEY` is unset, so a missing key is visible during generation instead of silently baking `key=` into the output.
- `MAPTILER_STYLE_URL` is defined once in `location_components.py` and imported by `generate_locations_html.py`, replacing two independent hardcoded copies of the same URL.

## Follow-up required (outside this PR, needs account access)
- Rotate the MapTiler key (the old one is already exposed in git history).
- Restrict the new key by HTTP referrer/domain in the MapTiler dashboard.
- Set `MAPTILER_KEY` as a Netlify environment variable (Site settings → Environment variables) for production builds.

Part of #275.

## Test plan
- [x] `MAPTILER_KEY` unset → generator prints the expected warning, exits 0 (verified via dry-run)
- [x] `MAPTILER_KEY` set → generator runs clean, no warning (verified via dry-run)
- [x] Full dry-run build (`generate_locations_html.py --dry-run`) completes with no errors in either case
- [ ] Netlify build succeeds once `MAPTILER_KEY` is set as an env var there (needs to happen after merge)