### PR TITLE
infra: fix coordinate picker — mouseup instead of click

### DIFF
--- a/utilities/locations/generate_locations_html.py
+++ b/utilities/locations/generate_locations_html.py
@@ -414,9 +414,14 @@ def _build_world_map_html(
             'title="Click the map to read coordinates. Click this readout to copy.">'
             'Click map for coordinates</div>'
         )
+        # mouseup, not click -- MapLibre only fires "click" when there is
+        # near-zero pointer movement between down/up, so any trackpad
+        # micro-drag (very common) gets classified as a pan instead and
+        # "click" never fires at all. mouseup always fires with the final
+        # cursor position, drag or not.
         coord_picker_js = (
             'var coordEl = document.getElementById("coord-picker");\n'
-            'map.on("click", function(e) {\n'
+            'map.on("mouseup", function(e) {\n'
             '  var lat = e.lngLat.lat.toFixed(6), lng = e.lngLat.lng.toFixed(6);\n'
             '  coordEl.dataset.coords = "  - " + lat + "\\n  - " + lng;\n'
             '  coordEl.textContent = "lat " + lat + ", lng " + lng + "  (click to copy)";\n'


### PR DESCRIPTION
## Summary
- The GM-only coordinate picker (added in 86126f5) used MapLibre's `click` event, which only fires when pointer movement between mousedown/mouseup is near-zero — any trackpad micro-drag (common) gets classified as a pan instead, so `click` silently never fires.
- Switched to `mouseup`, which always fires with the final cursor position regardless of movement.

## Context
Small follow-up on the HeroHeaven-1yu map-georeferencing work — not a full fix for that epic, just this one interaction bug in the picker tool.

## Test plan
- [ ] Open the GM map build, drag-select a point on a trackpad, confirm the coordinate readout updates
- [ ] Confirm a plain click (no drag) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)