### PR TITLE
Infra: OSM route snapping and Overpass waystation generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ __pycache__/
 *.tar.bz2
 *.tar.xz
 archive/
+Downloads/
 
 # Binary / large assets
 images/*
@@ -55,6 +56,10 @@ utilities/world/natural_earth/ne_10m_rivers_lake_centerlines/
 *.pdf
 *.zip
 *.webarchive
+
+# OSM / Overpass API response caches (local-only, not committed)
+world/data/.routes_cache.json
+world/data/.waystations_cache.json
 
 # Workflow and build artifacts
 docs/*.html

--- a/utilities/locations/generate_locations_html.py
+++ b/utilities/locations/generate_locations_html.py
@@ -55,9 +55,10 @@ _LOCATIONS_DIR = VAULT_ROOT / "world" / "locations"
 _REGIONS_DIR   = VAULT_ROOT / "world" / "regions"
 _DATA_DIR      = VAULT_ROOT / "world" / "data"
 
-_LOCATIONS_GEOJSON = _DATA_DIR / "tarim-shaiel-locations.geojson"
-_ROUTES_GEOJSON    = _DATA_DIR / "tarim-shaiel-routes.geojson"
-_REGIONS_GEOJSON   = _DATA_DIR / "tarim-shaiel-regions.geojson"
+_LOCATIONS_GEOJSON  = _DATA_DIR / "tarim-shaiel-locations.geojson"
+_ROUTES_GEOJSON     = _DATA_DIR / "tarim-shaiel-routes.geojson"
+_REGIONS_GEOJSON    = _DATA_DIR / "tarim-shaiel-regions.geojson"
+_WAYSTATIONS_GEOJSON = _DATA_DIR / "tarim-shaiel-waystations.geojson"
 
 _GM_PAGE_BANNER = (
     '<div class="gm-page-banner">'
@@ -340,6 +341,7 @@ def _build_world_map_html(
     locations_geojson: dict | None,
     routes_geojson: dict | None,
     regions_geojson: dict | None,
+    waystations_geojson: dict | None = None,
     gm_mode: bool = False,
     show_locations: bool = False,
 ) -> str:
@@ -377,6 +379,17 @@ def _build_world_map_html(
             'map.addLayer({id:"routes",type:"line",minzoom:4,source:"routes",'
             'layout:{"line-cap":"butt"},'
             'paint:{"line-color":"#b8892a","line-width":1.5,"line-opacity":0.5,"line-dasharray":[4,4]}});\n'
+        )
+    if waystations_geojson:
+        data_js += f'var _waystationGJ = {json.dumps(waystations_geojson)};\n'
+        sources_js += 'map.addSource("waystations", {type:"geojson", data:_waystationGJ});\n'
+        layers_js += (
+            'map.addLayer({id:"waystations",type:"symbol",source:"waystations",minzoom:5,'
+            'layout:{"icon-image":"cat-route-node","icon-size":0.7,'
+            '"text-field":["case",["!=",["get","osm_name"],null],["get","osm_name"],""],'
+            '"text-size":9,"text-offset":[0,0.8],"text-anchor":"top","text-optional":true},'
+            'paint:{"icon-opacity":0.5,"text-color":"#cccccc",'
+            '"text-halo-color":"rgba(10,8,5,0.95)","text-halo-width":1}});\n'
         )
     if locations_geojson and show_locations:
         # Inject _slug into each feature's properties so the click handler
@@ -477,6 +490,7 @@ def _build_location_page(
     regions: dict[str, RegionData],
     locations_geojson: dict | None,
     routes_geojson: dict | None,
+    waystations_geojson: dict | None,
     gm_mode: bool,
 ) -> str:
     region = regions.get(loc['parent_region']) if loc['parent_region'] else None
@@ -490,7 +504,7 @@ def _build_location_page(
         revealed_ids=revealed,
     )
 
-    mini_map_html = render_mini_map(loc, locations_geojson, routes_geojson, zoom=7)
+    mini_map_html = render_mini_map(loc, locations_geojson, routes_geojson, waystations_geojson, zoom=7)
     stats_row_html = render_stats_row(loc, region)
     danger_html = render_danger_pips(loc['location_type'])
     faction_html = render_faction_table(loc['factions_visible'])
@@ -532,6 +546,7 @@ def _build_region_page(
     region_locations: list[LocationData],
     locations_geojson: dict | None,
     routes_geojson: dict | None,
+    waystations_geojson: dict | None,
     gm_mode: bool,
 ) -> str:
     from shared.html_render import render_body as _rb
@@ -542,7 +557,7 @@ def _build_region_page(
     anchor = next((l for l in region_locations if l['lat'] is not None), None)
     if anchor:
         from locations.location_components import render_mini_map
-        region_map_html = render_mini_map(anchor, locations_geojson, routes_geojson, zoom=5)
+        region_map_html = render_mini_map(anchor, locations_geojson, routes_geojson, waystations_geojson, zoom=5)
 
     # Location cards
     loc_cards = []
@@ -581,12 +596,13 @@ def _build_world_home(
     locations_geojson: dict | None,
     routes_geojson: dict | None,
     regions_geojson: dict | None,
+    waystations_geojson: dict | None,
     gm_mode: bool,
 ) -> str:
     world_map_html = _build_world_map_html(
         # Region boundary boxes disabled -- not ready for display yet.
         # Pass regions_geojson through again once they are.
-        locations, locations_geojson, routes_geojson, None,
+        locations, locations_geojson, routes_geojson, None, waystations_geojson,
         gm_mode=gm_mode, show_locations=True,
     )
 
@@ -642,8 +658,9 @@ def generate(
     # geojson generator (utilities/geojson/generate_geojson.py) — do not write it here.
     locs_gj = _build_locations_geojson(locations)
 
-    routes_gj  = _load_geojson(_ROUTES_GEOJSON)
-    regions_gj = _load_geojson(_REGIONS_GEOJSON)
+    routes_gj      = _load_geojson(_ROUTES_GEOJSON)
+    regions_gj     = _load_geojson(_REGIONS_GEOJSON)
+    waystations_gj = _load_geojson(_WAYSTATIONS_GEOJSON)
 
     # Filter to public-only locations for public builds
     if public_only:
@@ -661,7 +678,7 @@ def generate(
 
     for loc in locations:
         try:
-            html = _build_location_page(loc, regions, locs_gj, routes_gj, gm_mode)
+            html = _build_location_page(loc, regions, locs_gj, routes_gj, waystations_gj, gm_mode)
         except Exception as e:
             msg = f"  ERROR building {loc['slug']}: {e}"
             print(msg, file=sys.stderr)
@@ -684,7 +701,7 @@ def generate(
     for slug, region in regions.items():
         region_locs = [l for l in locations if l['parent_region'] == slug]
         try:
-            html = _build_region_page(region, region_locs, locs_gj, routes_gj, gm_mode)
+            html = _build_region_page(region, region_locs, locs_gj, routes_gj, waystations_gj, gm_mode)
         except Exception as e:
             msg = f"  ERROR building region {slug}: {e}"
             print(msg, file=sys.stderr)
@@ -702,7 +719,7 @@ def generate(
     # --- World home ---
     try:
         world_html = _build_world_home(
-            locations, regions, locs_gj, routes_gj, regions_gj, gm_mode
+            locations, regions, locs_gj, routes_gj, regions_gj, waystations_gj, gm_mode
         )
     except Exception as e:
         msg = f"  ERROR building world.html: {e}"

--- a/utilities/locations/location_components.py
+++ b/utilities/locations/location_components.py
@@ -269,6 +269,7 @@ def render_mini_map(
     loc: LocationData,
     locations_geojson: Optional[dict] = None,
     routes_geojson: Optional[dict] = None,
+    waystations_geojson: Optional[dict] = None,
     zoom: float = 6,
 ) -> str:
     """Render a MapLibre mini-map div for a single location.
@@ -308,9 +309,24 @@ def render_mini_map(
             'paint:{"line-color":"#b8892a","line-width":2,"line-opacity":0.6}});\n'
         )
 
+    if waystations_geojson or locations_geojson:
+        # Register the sprite atlas once; both waystations and location layers use it.
+        layers_js += icon_registration_js()
+
+    if waystations_geojson:
+        sources_js += f'map.addSource("waystations-overlay",{{type:"geojson",data:{json.dumps(waystations_geojson)}}});\n'
+        layers_js += (
+            'map.addLayer({id:"waystations-overlay",type:"symbol",'
+            'source:"waystations-overlay",minzoom:5,'
+            'layout:{"icon-image":"cat-route-node","icon-size":0.7,'
+            '"text-field":["case",["!=",["get","osm_name"],null],["get","osm_name"],""],'
+            '"text-size":9,"text-offset":[0,0.8],"text-anchor":"top","text-optional":true},'
+            'paint:{"icon-opacity":0.5,"text-color":"#cccccc",'
+            '"text-halo-color":"rgba(10,8,5,0.95)","text-halo-width":1}});\n'
+        )
+
     if locations_geojson:
         sources_js += f'map.addSource("loc-overlay",{{type:"geojson",data:{json.dumps(locations_geojson)}}});\n'
-        layers_js += icon_registration_js()
         layers_js += _mini_map_tiered_layers_js(own_slug=loc['slug'])
 
     return f"""<div class="mini-map" id="{map_id}"></div>

--- a/utilities/routes/generate_routes.py
+++ b/utilities/routes/generate_routes.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""
+Re-route Silk Road segments via OSRM (foot profile).
+
+Reads world/data/tarim-shaiel-routes.geojson, calls the free public OSRM
+API for each LineString feature using its current first and last coordinates
+as endpoints, and replaces the intermediate vertices with a road-following
+path. All segment properties (kind, label, stroke, etc.) are preserved.
+
+Fallback: if OSRM returns no route, errors, or a path longer than 3× the
+straight-line haversine distance, the original geometry is kept unchanged.
+
+Results are cached in world/data/.routes_cache.json so subsequent runs do
+not re-query the API unless the cache is cleared.
+
+Usage:
+    python utilities/routes/generate_routes.py
+    python utilities/routes/generate_routes.py --segment route_seg_karmana_rabati-malik
+    python utilities/routes/generate_routes.py --dry-run
+    python utilities/routes/generate_routes.py --clear-cache
+"""
+
+import argparse
+import json
+import math
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+import urllib.request
+import urllib.error
+
+SCRIPT_DIR = Path(__file__).parent
+VAULT_ROOT = SCRIPT_DIR.parent.parent
+
+ROUTES_PATH = VAULT_ROOT / "world" / "data" / "tarim-shaiel-routes.geojson"
+CACHE_PATH  = VAULT_ROOT / "world" / "data" / ".routes_cache.json"
+
+OSRM_BASE   = "http://router.project-osrm.org/route/v1/foot"
+FALLBACK_RATIO = 3.0   # keep original if OSRM route > 3× straight-line distance
+REQUEST_TIMEOUT = 30   # seconds
+
+
+# ---------------------------------------------------------------------------
+# Geometry helpers
+# ---------------------------------------------------------------------------
+
+def haversine_km(lon1: float, lat1: float, lon2: float, lat2: float) -> float:
+    R = 6371.0
+    dlat = math.radians(lat2 - lat1)
+    dlon = math.radians(lon2 - lon1)
+    a = (math.sin(dlat / 2) ** 2
+         + math.cos(math.radians(lat1)) * math.cos(math.radians(lat2))
+         * math.sin(dlon / 2) ** 2)
+    return R * 2 * math.asin(math.sqrt(a))
+
+
+def path_length_km(coords: list[list[float]]) -> float:
+    total = 0.0
+    for i in range(len(coords) - 1):
+        total += haversine_km(coords[i][0], coords[i][1], coords[i+1][0], coords[i+1][1])
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Cache
+# ---------------------------------------------------------------------------
+
+def _load_cache() -> dict:
+    if CACHE_PATH.exists():
+        try:
+            return json.loads(CACHE_PATH.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+    return {}
+
+
+def _save_cache(cache: dict) -> None:
+    CACHE_PATH.write_text(json.dumps(cache, indent=2), encoding="utf-8")
+
+
+def _cache_key(lon1: float, lat1: float, lon2: float, lat2: float) -> str:
+    return f"{lon1:.4f},{lat1:.4f};{lon2:.4f},{lat2:.4f}"
+
+
+# ---------------------------------------------------------------------------
+# OSRM
+# ---------------------------------------------------------------------------
+
+def osrm_route(lon1: float, lat1: float, lon2: float, lat2: float,
+               cache: dict) -> Optional[list[list[float]]]:
+    """Return road-following coordinate list from OSRM, or None on failure."""
+    key = _cache_key(lon1, lat1, lon2, lat2)
+    if key in cache:
+        return cache[key]
+
+    url = f"{OSRM_BASE}/{lon1},{lat1};{lon2},{lat2}?geometries=geojson&overview=full"
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "tarim-shaiel-route-generator/1.0"})
+        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.URLError as e:
+        print(f"    OSRM network error: {e}", file=sys.stderr)
+        cache[key] = None
+        return None
+    except Exception as e:
+        print(f"    OSRM unexpected error: {e}", file=sys.stderr)
+        cache[key] = None
+        return None
+
+    if data.get("code") != "Ok" or not data.get("routes"):
+        cache[key] = None
+        return None
+
+    coords = data["routes"][0]["geometry"]["coordinates"]
+    cache[key] = coords
+    return coords
+
+
+# ---------------------------------------------------------------------------
+# Route a single feature
+# ---------------------------------------------------------------------------
+
+def route_feature(feat: dict, cache: dict, dry_run: bool = False) -> tuple[dict, str]:
+    """
+    Attempt to replace the feature's geometry with an OSRM-routed path.
+    Returns (updated_feature, status) where status is one of:
+      "routed"   — OSRM path used
+      "fallback" — kept original (OSRM failed or implausible)
+      "dry_run"  — would have called OSRM but skipped
+    """
+    coords = feat["geometry"]["coordinates"]
+    if len(coords) < 2:
+        return feat, "fallback"
+
+    start = coords[0]
+    end   = coords[-1]
+    straight_km = haversine_km(start[0], start[1], end[0], end[1])
+
+    if dry_run:
+        return feat, "dry_run"
+
+    routed = osrm_route(start[0], start[1], end[0], end[1], cache)
+
+    if routed is None or len(routed) < 2:
+        return feat, "fallback"
+
+    routed_km = path_length_km(routed)
+    if straight_km > 0 and routed_km > FALLBACK_RATIO * straight_km:
+        print(
+            f"    fallback: routed={routed_km:.0f}km > {FALLBACK_RATIO}× "
+            f"straight={straight_km:.0f}km",
+            file=sys.stderr,
+        )
+        return feat, "fallback"
+
+    updated = {**feat, "geometry": {**feat["geometry"], "coordinates": routed}}
+    return updated, "routed"
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Re-route Tarim-Shaiel route segments via OSRM foot routing."
+    )
+    parser.add_argument(
+        "--segment",
+        help="Process only this segment ID (e.g. route_seg_karmana_rabati-malik)",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print what would happen without calling OSRM or writing files.",
+    )
+    parser.add_argument(
+        "--clear-cache", action="store_true",
+        help="Delete the OSRM cache before running.",
+    )
+    parser.add_argument(
+        "--out", default=str(ROUTES_PATH),
+        help=f"Output path (default: {ROUTES_PATH.name})",
+    )
+    args = parser.parse_args()
+
+    if args.clear_cache and CACHE_PATH.exists():
+        CACHE_PATH.unlink()
+        print("  Cache cleared.")
+
+    if not ROUTES_PATH.exists():
+        print(f"ERROR: {ROUTES_PATH} not found", file=sys.stderr)
+        return 1
+
+    geojson = json.loads(ROUTES_PATH.read_text(encoding="utf-8"))
+    features = geojson.get("features", [])
+    cache = _load_cache()
+
+    out_features = []
+    counts = {"routed": 0, "fallback": 0, "dry_run": 0, "skipped": 0}
+
+    for feat in features:
+        fid = feat.get("id", "")
+
+        if args.segment and fid != args.segment:
+            out_features.append(feat)
+            counts["skipped"] += 1
+            continue
+
+        coords = feat.get("geometry", {}).get("coordinates", [])
+        if len(coords) < 2:
+            out_features.append(feat)
+            counts["skipped"] += 1
+            continue
+
+        start = coords[0]
+        end   = coords[-1]
+        straight_km = haversine_km(start[0], start[1], end[0], end[1])
+
+        print(f"  {fid}  ({straight_km:.0f} km straight-line)")
+
+        updated, status = route_feature(feat, cache, dry_run=args.dry_run)
+        out_features.append(updated)
+        counts[status] += 1
+
+        if status == "routed":
+            new_pts = len(updated["geometry"]["coordinates"])
+            print(f"    → routed: {new_pts} points")
+        elif status == "fallback":
+            print(f"    → kept original ({len(coords)} points)")
+        else:
+            print(f"    → {status}")
+
+        # Polite pause between real API calls
+        if not args.dry_run and status in ("routed", "fallback"):
+            time.sleep(0.5)
+
+    if not args.dry_run:
+        _save_cache(cache)
+
+        out_path = Path(args.out)
+        out_path.write_text(
+            json.dumps({**geojson, "features": out_features}, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        print(f"\n  Written: {out_path.name}")
+
+    print(
+        f"\n  Results: routed={counts['routed']}  fallback={counts['fallback']}  "
+        f"dry_run={counts['dry_run']}  skipped={counts['skipped']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utilities/routes/place_waystations.py
+++ b/utilities/routes/place_waystations.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""
+Place waystation candidates along routed Silk Road segments.
+
+Reads world/data/tarim-shaiel-routes.geojson, walks each LineString at
+INTERVAL_KM intervals (default 30 km), and queries the Overpass API for
+historically attested settlements or caravanserais within RADIUS_KM (15 km).
+
+Output is world/data/tarim-shaiel-waystations.geojson — committed to git,
+reviewed by the author, and rendered as a dim togglable MapLibre layer.
+
+Incremental rebuild: on re-run, features already marked
+  approval_status != "candidate"  (i.e. "promoted" / "rejected")
+are preserved unchanged. Only the "candidate" pool is regenerated.
+
+Overpass responses are cached in world/data/.waystations_cache.json.
+
+Usage:
+    python utilities/routes/place_waystations.py
+    python utilities/routes/place_waystations.py --segment route_seg_kashgar_aksu
+    python utilities/routes/place_waystations.py --interval 25
+    python utilities/routes/place_waystations.py --dry-run
+    python utilities/routes/place_waystations.py --clear-cache
+"""
+
+import argparse
+import json
+import math
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+import urllib.request
+import urllib.error
+import urllib.parse
+
+SCRIPT_DIR = Path(__file__).parent
+VAULT_ROOT = SCRIPT_DIR.parent.parent
+
+ROUTES_PATH      = VAULT_ROOT / "world" / "data" / "tarim-shaiel-routes.geojson"
+WAYSTATIONS_PATH = VAULT_ROOT / "world" / "data" / "tarim-shaiel-waystations.geojson"
+CACHE_PATH       = VAULT_ROOT / "world" / "data" / ".waystations_cache.json"
+
+OVERPASS_URL = "https://overpass-api.de/api/interpreter"
+REQUEST_TIMEOUT = 30
+SLEEP_BETWEEN_QUERIES = 1.2  # seconds — polite rate-limiting
+
+
+# ---------------------------------------------------------------------------
+# Geometry helpers
+# ---------------------------------------------------------------------------
+
+def haversine_km(lon1: float, lat1: float, lon2: float, lat2: float) -> float:
+    R = 6371.0
+    dlat = math.radians(lat2 - lat1)
+    dlon = math.radians(lon2 - lon1)
+    a = (math.sin(dlat / 2) ** 2
+         + math.cos(math.radians(lat1)) * math.cos(math.radians(lat2))
+         * math.sin(dlon / 2) ** 2)
+    return R * 2 * math.asin(math.sqrt(a))
+
+
+def interpolate(p1: list[float], p2: list[float], t: float) -> list[float]:
+    """Linear interpolation between two [lon, lat] points, t in [0, 1]."""
+    return [p1[0] + t * (p2[0] - p1[0]), p1[1] + t * (p2[1] - p1[1])]
+
+
+def sample_points_along_path(
+    coords: list[list[float]], interval_km: float
+) -> list[tuple[float, float, float]]:
+    """
+    Walk the LineString and return (lon, lat, dist_from_start) for each
+    candidate point spaced approximately interval_km apart.
+    Skips the exact start and end (those are already known city nodes).
+    """
+    if len(coords) < 2:
+        return []
+
+    points = []
+    cumulative = 0.0
+    next_target = interval_km
+
+    for i in range(len(coords) - 1):
+        seg_len = haversine_km(
+            coords[i][0], coords[i][1], coords[i+1][0], coords[i+1][1]
+        )
+        while next_target <= cumulative + seg_len:
+            t = (next_target - cumulative) / seg_len if seg_len > 0 else 0
+            pt = interpolate(coords[i], coords[i + 1], t)
+            points.append((pt[0], pt[1], next_target))
+            next_target += interval_km
+        cumulative += seg_len
+
+    return points
+
+
+# ---------------------------------------------------------------------------
+# Overpass query
+# ---------------------------------------------------------------------------
+
+OVERPASS_QUERY_TEMPLATE = """
+[out:json][timeout:25];
+(
+  node["historic"="caravanserai"](around:{radius},{lat},{lon});
+  node["place"~"^(town|village|hamlet)$"](around:{radius},{lat},{lon});
+  way["historic"="caravanserai"](around:{radius},{lat},{lon});
+  node["amenity"="place_of_worship"]["historic"](around:{radius},{lat},{lon});
+);
+out center;
+""".strip()
+
+
+def _load_cache() -> dict:
+    if CACHE_PATH.exists():
+        try:
+            return json.loads(CACHE_PATH.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+    return {}
+
+
+def _save_cache(cache: dict) -> None:
+    CACHE_PATH.write_text(json.dumps(cache, indent=2), encoding="utf-8")
+
+
+def _cache_key(lon: float, lat: float, radius_km: float) -> str:
+    return f"{lon:.4f},{lat:.4f},{radius_km:.0f}km"
+
+
+def overpass_query(
+    lon: float, lat: float, radius_km: float, cache: dict
+) -> Optional[list[dict]]:
+    """Return list of OSM elements near (lon, lat), or None on failure."""
+    key = _cache_key(lon, lat, radius_km)
+    if key in cache:
+        return cache[key]
+
+    query = OVERPASS_QUERY_TEMPLATE.format(
+        radius=int(radius_km * 1000), lat=f"{lat:.6f}", lon=f"{lon:.6f}"
+    )
+    try:
+        # Overpass expects form-encoded body: data=<query>
+        encoded = urllib.parse.urlencode({"data": query}).encode("utf-8")
+        req = urllib.request.Request(
+            OVERPASS_URL,
+            data=encoded,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "User-Agent": "tarim-shaiel-waystation-generator/1.0",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
+            result = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.URLError as e:
+        print(f"    Overpass network error: {e}", file=sys.stderr)
+        cache[key] = []
+        return []
+    except Exception as e:
+        print(f"    Overpass unexpected error: {e}", file=sys.stderr)
+        cache[key] = []
+        return []
+
+    elements = result.get("elements", [])
+    cache[key] = elements
+    return elements
+
+
+def _best_element(elements: list[dict]) -> Optional[dict]:
+    """Pick the most historically relevant element from an Overpass result set."""
+    # Priority: caravanserai > place_of_worship+historic > town > village > hamlet
+    def priority(el: dict) -> int:
+        tags = el.get("tags", {})
+        if tags.get("historic") == "caravanserai":
+            return 0
+        if tags.get("amenity") == "place_of_worship" and "historic" in tags:
+            return 1
+        place = tags.get("place", "")
+        if place == "town":
+            return 2
+        if place == "village":
+            return 3
+        if place == "hamlet":
+            return 4
+        return 5
+
+    if not elements:
+        return None
+    return min(elements, key=priority)
+
+
+def _slug_from(name: str) -> str:
+    """Turn a name string into a URL-safe slug."""
+    s = name.lower().strip()
+    s = re.sub(r"[^\w\s-]", "", s)
+    s = re.sub(r"[\s_]+", "-", s)
+    return s[:60]
+
+
+# ---------------------------------------------------------------------------
+# Build waystation feature
+# ---------------------------------------------------------------------------
+
+def make_waystation_feature(
+    lon: float,
+    lat: float,
+    dist_km: float,
+    route_segment_id: str,
+    elements: list[dict],
+    candidate_index: int,
+) -> dict:
+    best = _best_element(elements) if elements else None
+
+    if best:
+        tags = best.get("tags", {})
+        osm_name = tags.get("name") or tags.get("name:en") or tags.get("int_name")
+        # For ways, Overpass returns a 'center' node
+        if best["type"] == "way" and "center" in best:
+            lon = best["center"]["lon"]
+            lat = best["center"]["lat"]
+        else:
+            lon = best.get("lon", lon)
+            lat = best.get("lat", lat)
+        osm_id  = str(best.get("id", ""))
+        source  = "historic_osm"
+        slug    = _slug_from(osm_name) if osm_name else f"waystation-{candidate_index}"
+        osm_tags = {k: v for k, v in tags.items() if k in (
+            "historic", "place", "amenity", "name", "name:en"
+        )}
+    else:
+        osm_name = None
+        osm_id   = None
+        source   = "generated"
+        slug     = f"waystation-{candidate_index}"
+        osm_tags = {}
+
+    return {
+        "type": "Feature",
+        "properties": {
+            "kind":                "waystation",
+            "source":              source,
+            "osm_id":              osm_id,
+            "osm_name":            osm_name,
+            "osm_tags":            osm_tags,
+            "suggested_slug":      slug,
+            "route_segment":       route_segment_id,
+            "dist_from_start_km":  round(dist_km, 1),
+            "approval_status":     "candidate",
+        },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [round(lon, 6), round(lat, 6)],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Place waystation candidates along routed Silk Road segments."
+    )
+    parser.add_argument(
+        "--segment",
+        help="Process only this segment ID.",
+    )
+    parser.add_argument(
+        "--interval", type=float, default=30.0,
+        help="Distance between candidates in km (default: 30).",
+    )
+    parser.add_argument(
+        "--radius", type=float, default=15.0,
+        help="Overpass search radius in km (default: 15).",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print candidate positions without calling Overpass.",
+    )
+    parser.add_argument(
+        "--clear-cache", action="store_true",
+        help="Delete the Overpass cache before running.",
+    )
+    parser.add_argument(
+        "--out", default=str(WAYSTATIONS_PATH),
+        help=f"Output path (default: {WAYSTATIONS_PATH.name})",
+    )
+    args = parser.parse_args()
+
+    if args.clear_cache and CACHE_PATH.exists():
+        CACHE_PATH.unlink()
+        print("  Cache cleared.")
+
+    if not ROUTES_PATH.exists():
+        print(f"ERROR: {ROUTES_PATH} not found", file=sys.stderr)
+        return 1
+
+    routes_gj = json.loads(ROUTES_PATH.read_text(encoding="utf-8"))
+    cache = _load_cache()
+
+    # Load existing waystations to preserve promoted/rejected entries
+    out_path = Path(args.out)
+    preserved: list[dict] = []
+    if out_path.exists():
+        try:
+            existing = json.loads(out_path.read_text(encoding="utf-8"))
+            for feat in existing.get("features", []):
+                status = feat.get("properties", {}).get("approval_status", "candidate")
+                if status != "candidate":
+                    preserved.append(feat)
+        except Exception:
+            pass
+    if preserved:
+        print(f"  Preserved {len(preserved)} non-candidate feature(s).")
+
+    new_candidates: list[dict] = []
+    candidate_index = 0
+    total_historic = 0
+    total_generated = 0
+
+    for feat in routes_gj.get("features", []):
+        fid = feat.get("id", "")
+
+        if args.segment and fid != args.segment:
+            continue
+
+        coords = feat.get("geometry", {}).get("coordinates", [])
+        if len(coords) < 2:
+            continue
+
+        sample_pts = sample_points_along_path(coords, args.interval)
+        if not sample_pts:
+            continue
+
+        print(f"  {fid}: {len(sample_pts)} candidate(s)")
+
+        for lon, lat, dist_km in sample_pts:
+            candidate_index += 1
+
+            if args.dry_run:
+                print(f"    [{candidate_index}] {lat:.4f},{lon:.4f} @ {dist_km:.0f}km — (dry run)")
+                new_candidates.append(make_waystation_feature(
+                    lon, lat, dist_km, fid, [], candidate_index
+                ))
+                continue
+
+            elements = overpass_query(lon, lat, args.radius, cache) or []
+            feat_out = make_waystation_feature(lon, lat, dist_km, fid, elements, candidate_index)
+            source = feat_out["properties"]["source"]
+            osm_name = feat_out["properties"].get("osm_name") or "(unnamed)"
+
+            if source == "historic_osm":
+                total_historic += 1
+                print(f"    [{candidate_index}] {dist_km:.0f}km — OSM hit: {osm_name}")
+            else:
+                total_generated += 1
+                print(f"    [{candidate_index}] {dist_km:.0f}km — generated")
+
+            new_candidates.append(feat_out)
+            time.sleep(SLEEP_BETWEEN_QUERIES)
+
+    if not args.dry_run:
+        _save_cache(cache)
+
+    all_features = preserved + new_candidates
+    output_gj = {"type": "FeatureCollection", "features": all_features}
+
+    if not args.dry_run:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            json.dumps(output_gj, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        print(f"\n  Written: {out_path.name}")
+
+    print(
+        f"\n  Results: {len(new_candidates)} new candidates "
+        f"({total_historic} historic OSM, {total_generated} generated)"
+    )
+    if preserved:
+        print(f"           {len(preserved)} existing non-candidate feature(s) preserved")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds `utilities/routes/generate_routes.py` — OSRM foot-profile route snapping for all 34 Silk Road segments, with 3× haversine fallback and disk cache
- Adds `utilities/routes/place_waystations.py` — Overpass-backed waystation candidate generator at 30 km intervals, with incremental rebuild (preserves promoted/rejected features)
- Integrates new `tarim-shaiel-waystations.geojson` layer into `render_mini_map()` and `generate_locations_html.py` as a dimmed (opacity 0.5), togglable MapLibre symbol layer
- Both scripts are **local-only** — not registered in `build.py`; Netlify reads committed GeoJSON

Resolves: #281

## Test plan

- [ ] `python utilities/routes/generate_routes.py --dry-run` — prints 34 segments with no API calls
- [ ] `python utilities/routes/place_waystations.py --dry-run --segment route_seg_kashgar_aksu` — 14 candidates
- [ ] `python utilities/build.py locations` — builds without errors (waystations file absent → None passed through gracefully)
- [ ] After first real `place_waystations.py` run: open `docs/locations/waycross-map.html` at zoom 5+ and confirm candidate layer renders dimly

🤖 Generated with [Claude Code](https://claude.com/claude-code)